### PR TITLE
Problem: broken documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in contributing to Chain! Good places to start are this document and [the official documentation](https://github.com/crypto-com/cro-documentation/). If you have any questions, feel free to ask on [Matrix](https://riot.im/app/#/room/#cro:matrix.org).
+Thank you for your interest in contributing to Chain! Good places to start are this document and [the official documentation](https://github.com/crypto-com/chain-docs). If you have any questions, feel free to ask on [Matrix](https://riot.im/app/#/room/#cro:matrix.org).
 
 
 ## Code of Conduct


### PR DESCRIPTION
Solution: created a new repo and fixed the link in CONTRIBUTING.md