### PR TITLE
Problem: (CRO-53) No easy way to query transaction data from Chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -292,6 +293,7 @@ name = "client-index"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.1.0",
  "client-common 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -10,6 +10,7 @@ rand = "0.6"
 failure = "0.1"
 miscreant = "0.4"
 blake2 = "0.8"
+rlp = "0.3"
 sled = { version = "0.22", optional = true }
 
 [features]

--- a/client-common/src/balance/balance_change.rs
+++ b/client-common/src/balance/balance_change.rs
@@ -8,7 +8,7 @@ use chain_core::init::coin::Coin;
 use crate::{ErrorKind, Result};
 
 /// Incoming or Outgoing balance change
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BalanceChange {
     /// Represents balance addition
     Incoming(Coin),
@@ -69,6 +69,8 @@ impl Add<BalanceChange> for Coin {
 mod tests {
     use super::*;
 
+    use rlp::{decode, encode};
+
     #[test]
     fn add_incoming() {
         let coin = Coin::zero()
@@ -107,5 +109,21 @@ mod tests {
             + BalanceChange::Outgoing(Coin::new(30).expect("Unable to create new coin"));
 
         assert!(coin.is_err(), "Created negative coin")
+    }
+
+    #[test]
+    fn check_incoming_encoding() {
+        let change = BalanceChange::Incoming(Coin::new(30).expect("Unable to create new coin"));
+        let new_change = decode(&encode(&change)).expect("Unable to decode balance change");
+
+        assert_eq!(change, new_change, "Incorrect balance change encoding");
+    }
+
+    #[test]
+    fn check_outgoing_encoding() {
+        let change = BalanceChange::Outgoing(Coin::new(30).expect("Unable to create new coin"));
+        let new_change = decode(&encode(&change)).expect("Unable to decode balance change");
+
+        assert_eq!(change, new_change, "Incorrect balance change encoding");
     }
 }

--- a/client-common/src/error.rs
+++ b/client-common/src/error.rs
@@ -56,6 +56,9 @@ pub enum ErrorKind {
     /// RPC error
     #[fail(display = "RPC error")]
     RpcError,
+    /// Invalid transaction
+    #[fail(display = "Invalid transaction")]
+    InvalidTransaction,
 }
 
 impl Fail for Error {

--- a/client-common/src/storage.rs
+++ b/client-common/src/storage.rs
@@ -1,7 +1,9 @@
 //! Data storage layer
+mod memory_storage;
 #[cfg(feature = "sled")]
 mod sled_storage;
 
+pub use memory_storage::MemoryStorage;
 #[cfg(feature = "sled")]
 pub use sled_storage::SledStorage;
 

--- a/client-common/src/storage/memory_storage.rs
+++ b/client-common/src/storage/memory_storage.rs
@@ -1,11 +1,10 @@
-#![cfg(test)]
-
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use client_common::{Error, ErrorKind, Result, Storage};
+use crate::{Error, ErrorKind, Result, Storage};
 
 /// Storage backed by `HashMap`
+#[allow(clippy::type_complexity)]
 #[derive(Default)]
 pub struct MemoryStorage(Arc<RwLock<HashMap<Vec<u8>, HashMap<Vec<u8>, Vec<u8>>>>>);
 

--- a/client-core/src/service/key_service.rs
+++ b/client-core/src/service/key_service.rs
@@ -72,9 +72,8 @@ where
 mod tests {
     use super::KeyService;
 
+    use client_common::storage::MemoryStorage;
     use client_common::ErrorKind;
-
-    use crate::test::MemoryStorage;
 
     #[test]
     fn check_flow() {

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -62,9 +62,8 @@ where
 mod tests {
     use super::WalletService;
 
+    use client_common::storage::MemoryStorage;
     use client_common::ErrorKind;
-
-    use crate::test::MemoryStorage;
 
     #[test]
     fn check_flow() {

--- a/client-core/src/test.rs
+++ b/client-core/src/test.rs
@@ -1,7 +1,5 @@
 #![cfg(test)]
 
-mod memory_storage;
 mod mock_chain;
 
-pub use memory_storage::MemoryStorage;
 pub use mock_chain::MockChain;

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -7,10 +7,16 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 client-common = { path = "../client-common" }
-jsonrpc = "0.11"
 failure = "0.1"
 hex = "0.3"
 base64 = "0.10"
 rlp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+bincode = "1.1"
+jsonrpc = { version = "0.11", optional = true }
+
+[features]
+default = ["sled", "rpc"]
+sled = ["client-common/sled"]
+rpc = ["jsonrpc"]

--- a/client-index/src/index.rs
+++ b/client-index/src/index.rs
@@ -1,0 +1,30 @@
+//! Transaction index operations
+#[cfg(all(feature = "sled", feature = "rpc"))]
+mod rpc_sled_index;
+
+#[cfg(all(feature = "sled", feature = "rpc"))]
+pub use rpc_sled_index::RpcSledIndex;
+
+use chain_core::init::coin::Coin;
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::data::{Tx, TxId};
+use client_common::balance::TransactionChange;
+use client_common::Result;
+
+/// Interface for interacting with transaction index
+pub trait Index {
+    /// Synchronizes transaction index with Crypto.com Chain (from last known height)
+    fn sync(&self) -> Result<()>;
+
+    /// Synchronizes transaction index with Crypto.com Chain (from genesis)
+    fn sync_all(&self) -> Result<()>;
+
+    /// Returns all transaction changes for given address
+    fn transaction_changes(&self, address: &ExtendedAddr) -> Result<Vec<TransactionChange>>;
+
+    /// Returns current balance for given address
+    fn balance(&self, address: &ExtendedAddr) -> Result<Coin>;
+
+    /// Returns transaction with given id
+    fn transaction(&self, id: &TxId) -> Result<Option<Tx>>;
+}

--- a/client-index/src/index/rpc_sled_index.rs
+++ b/client-index/src/index/rpc_sled_index.rs
@@ -1,0 +1,167 @@
+#![cfg(all(feature = "sled", feature = "rpc"))]
+
+use std::path::Path;
+
+use chain_core::init::coin::Coin;
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::data::{Tx, TxId};
+use chain_core::tx::TxAux;
+use client_common::balance::{BalanceChange, TransactionChange};
+use client_common::storage::SledStorage;
+use client_common::{ErrorKind, Result};
+
+use crate::service::*;
+use crate::tendermint::{Client, RpcClient};
+use crate::Index;
+
+/// Transaction index backed by `sled` embedded database
+pub struct RpcSledIndex {
+    address_service: AddressService<SledStorage>,
+    balance_service: BalanceService<SledStorage>,
+    global_state_service: GlobalStateService<SledStorage>,
+    transaction_outputs_service: TransactionOutputsService<SledStorage>,
+    transaction_service: TransactionService<SledStorage>,
+    client: RpcClient,
+}
+
+impl RpcSledIndex {
+    /// Creates a new instance of `RpcSledIndex`
+    pub fn new<P: AsRef<Path>>(path: P, url: &str) -> Result<Self> {
+        let storage = SledStorage::new(path)?;
+        let client = RpcClient::new(url);
+
+        Ok(Self {
+            address_service: AddressService::new(storage.clone()),
+            balance_service: BalanceService::new(storage.clone()),
+            global_state_service: GlobalStateService::new(storage.clone()),
+            transaction_outputs_service: TransactionOutputsService::new(storage.clone()),
+            transaction_service: TransactionService::new(storage),
+            client,
+        })
+    }
+
+    fn clear(&self) -> Result<()> {
+        self.address_service.clear()?;
+        self.balance_service.clear()?;
+        self.global_state_service.clear()?;
+        self.transaction_outputs_service.clear()?;
+        self.transaction_service.clear()
+    }
+
+    fn genesis(&self) -> Result<()> {
+        let genesis_transactions = self.client.genesis()?.transactions()?;
+        self.handle_transactions(&genesis_transactions, 0)?;
+
+        Ok(())
+    }
+
+    fn handle_transactions(&self, transactions: &[Tx], height: u64) -> Result<()> {
+        let changes = self.changes(transactions)?;
+
+        for change in changes {
+            self.balance_service
+                .change(&change.address, &change.balance_change)?;
+
+            self.address_service.add(change)?;
+        }
+
+        for transaction in transactions {
+            let id = transaction.id();
+
+            self.transaction_outputs_service
+                .set(&id, &transaction.outputs)?;
+            self.transaction_service.set(&id, transaction)?;
+        }
+
+        self.global_state_service.set_last_block_height(height)?;
+
+        Ok(())
+    }
+
+    fn changes(&self, transactions: &[Tx]) -> Result<Vec<TransactionChange>> {
+        let mut changes = Vec::new();
+
+        for transaction in transactions {
+            let id = transaction.id();
+
+            for input in transaction.inputs.iter() {
+                let index = input.index;
+                let input = self
+                    .transaction_outputs_service
+                    .get(&input.id)?
+                    .into_iter()
+                    .nth(index);
+
+                match input {
+                    None => return Err(ErrorKind::InvalidTransaction.into()),
+                    Some(input) => {
+                        changes.push(TransactionChange {
+                            transaction_id: id,
+                            address: input.address,
+                            balance_change: BalanceChange::Outgoing(input.value),
+                        });
+                    }
+                }
+            }
+
+            for output in transaction.outputs.iter() {
+                changes.push(TransactionChange {
+                    transaction_id: id,
+                    address: output.address.clone(),
+                    balance_change: BalanceChange::Incoming(output.value),
+                });
+            }
+        }
+
+        Ok(changes)
+    }
+}
+
+impl Index for RpcSledIndex {
+    fn sync(&self) -> Result<()> {
+        let last_block_height = match self.global_state_service.last_block_height()? {
+            None => {
+                self.genesis()?;
+                0
+            }
+            Some(last_block_height) => last_block_height,
+        };
+
+        let current_block_height = self.client.status()?.last_block_height()?;
+
+        for height in (last_block_height + 1)..=current_block_height {
+            let valid_ids = self.client.block_results(height)?.ids()?;
+            let transactions = self
+                .client
+                .block(height)?
+                .transactions()?
+                .into_iter()
+                .map(|tx_aux| match tx_aux {
+                    TxAux::TransferTx(tx, _) => tx,
+                })
+                .filter(|tx| valid_ids.contains(&tx.id()))
+                .collect::<Vec<Tx>>();
+
+            self.handle_transactions(&transactions, height)?;
+        }
+
+        Ok(())
+    }
+
+    fn sync_all(&self) -> Result<()> {
+        self.clear()?;
+        self.sync()
+    }
+
+    fn transaction_changes(&self, address: &ExtendedAddr) -> Result<Vec<TransactionChange>> {
+        self.address_service.get(address)
+    }
+
+    fn balance(&self, address: &ExtendedAddr) -> Result<Coin> {
+        self.balance_service.get(address)
+    }
+
+    fn transaction(&self, id: &TxId) -> Result<Option<Tx>> {
+        self.transaction_service.get(id)
+    }
+}

--- a/client-index/src/index/rpc_sled_index.rs
+++ b/client-index/src/index/rpc_sled_index.rs
@@ -40,6 +40,7 @@ impl RpcSledIndex {
         })
     }
 
+    /// Clears all the services
     fn clear(&self) -> Result<()> {
         self.address_service.clear()?;
         self.balance_service.clear()?;
@@ -48,6 +49,7 @@ impl RpcSledIndex {
         self.transaction_service.clear()
     }
 
+    /// Handles genesis transactions
     fn genesis(&self) -> Result<()> {
         let genesis_transactions = self.client.genesis()?.transactions()?;
         self.handle_transactions(&genesis_transactions, 0)?;
@@ -55,6 +57,7 @@ impl RpcSledIndex {
         Ok(())
     }
 
+    /// Handles transactions by calling appropriate functions of different services
     fn handle_transactions(&self, transactions: &[Tx], height: u64) -> Result<()> {
         let changes = self.changes(transactions)?;
 
@@ -78,6 +81,7 @@ impl RpcSledIndex {
         Ok(())
     }
 
+    /// Converts `[Tx] -> [TransactionChange]`
     fn changes(&self, transactions: &[Tx]) -> Result<Vec<TransactionChange>> {
         let mut changes = Vec::new();
 

--- a/client-index/src/lib.rs
+++ b/client-index/src/lib.rs
@@ -4,6 +4,8 @@
 pub mod index;
 pub mod service;
 pub mod tendermint;
+#[cfg(test)]
+pub mod test;
 
 #[doc(inline)]
 pub use crate::index::Index;

--- a/client-index/src/lib.rs
+++ b/client-index/src/lib.rs
@@ -1,4 +1,9 @@
 #![deny(missing_docs, unsafe_code, unstable_features)]
 //! This crate exposes functionality to index transactions committed in Crypto.com Chain.
 
+pub mod index;
+pub mod service;
 pub mod tendermint;
+
+#[doc(inline)]
+pub use crate::index::Index;

--- a/client-index/src/service.rs
+++ b/client-index/src/service.rs
@@ -1,0 +1,12 @@
+//! Management services
+mod address_service;
+mod balance_service;
+mod global_state_service;
+mod transaction_outputs_service;
+mod transaction_service;
+
+pub use address_service::AddressService;
+pub use balance_service::BalanceService;
+pub use global_state_service::GlobalStateService;
+pub use transaction_outputs_service::TransactionOutputsService;
+pub use transaction_service::TransactionService;

--- a/client-index/src/service/address_service.rs
+++ b/client-index/src/service/address_service.rs
@@ -1,0 +1,52 @@
+use rlp::{decode_list, encode, encode_list};
+
+use chain_core::tx::data::address::ExtendedAddr;
+use client_common::balance::TransactionChange;
+use client_common::{Result, Storage};
+
+const KEYSPACE: &str = "index_address";
+
+/// Exposes functionalities for managing addresses
+///
+/// Stores `address -> [tx_changes]` mapping
+pub struct AddressService<S> {
+    storage: S,
+}
+
+impl<S> AddressService<S>
+where
+    S: Storage,
+{
+    /// Creates a new instance of address service
+    pub fn new(storage: S) -> Self {
+        Self { storage }
+    }
+
+    /// Retrieves transaction changes for given address
+    pub fn get(&self, address: &ExtendedAddr) -> Result<Vec<TransactionChange>> {
+        let bytes = self.storage.get(KEYSPACE, encode(address))?;
+
+        match bytes {
+            None => Ok(Default::default()),
+            Some(bytes) => Ok(decode_list(&bytes)),
+        }
+    }
+
+    /// Adds a new transaction change for given address
+    pub fn add(&self, change: TransactionChange) -> Result<()> {
+        let address = change.address.clone();
+
+        let mut changes = self.get(&address)?;
+        changes.push(change);
+
+        self.storage
+            .set(KEYSPACE, encode(&address), encode_list(&changes))?;
+
+        Ok(())
+    }
+
+    /// Clears all storage
+    pub fn clear(&self) -> Result<()> {
+        self.storage.clear(KEYSPACE)
+    }
+}

--- a/client-index/src/service/address_service.rs
+++ b/client-index/src/service/address_service.rs
@@ -50,3 +50,34 @@ where
         self.storage.clear(KEYSPACE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chain_core::init::coin::Coin;
+    use chain_core::tx::data::txid_hash;
+    use client_common::balance::BalanceChange;
+    use client_common::storage::MemoryStorage;
+
+    #[test]
+    fn check_flow() {
+        let address_service = AddressService::new(MemoryStorage::default());
+        let address = ExtendedAddr::BasicRedeem(Default::default());
+        let transaction_change = TransactionChange {
+            transaction_id: txid_hash(&[0, 1, 2]),
+            address: address.clone(),
+            balance_change: BalanceChange::Incoming(
+                Coin::new(30).expect("Unable to create new coin"),
+            ),
+        };
+
+        assert_eq!(0, address_service.get(&address).unwrap().len());
+        assert!(address_service.add(transaction_change.clone()).is_ok());
+        assert_eq!(1, address_service.get(&address).unwrap().len());
+        assert!(address_service.add(transaction_change).is_ok());
+        assert_eq!(2, address_service.get(&address).unwrap().len());
+        assert!(address_service.clear().is_ok());
+        assert_eq!(0, address_service.get(&address).unwrap().len());
+    }
+}

--- a/client-index/src/service/balance_service.rs
+++ b/client-index/src/service/balance_service.rs
@@ -1,0 +1,51 @@
+use failure::ResultExt;
+use rlp::{decode, encode};
+
+use chain_core::init::coin::Coin;
+use chain_core::tx::data::address::ExtendedAddr;
+use client_common::balance::BalanceChange;
+use client_common::{ErrorKind, Result, Storage};
+
+const KEYSPACE: &str = "index_balance";
+
+/// Exposes functionalities for managing balances
+///
+/// Stores `address -> balance` mapping
+pub struct BalanceService<S> {
+    storage: S,
+}
+
+impl<S> BalanceService<S>
+where
+    S: Storage,
+{
+    /// Creates a new instance of balance service
+    pub fn new(storage: S) -> Self {
+        Self { storage }
+    }
+
+    /// Retrieves current balance for given address
+    pub fn get(&self, address: &ExtendedAddr) -> Result<Coin> {
+        let bytes = self.storage.get(KEYSPACE, encode(address))?;
+
+        match bytes {
+            None => Ok(Coin::zero()),
+            Some(bytes) => Ok(decode(&bytes).context(ErrorKind::DeserializationError)?),
+        }
+    }
+
+    /// Changes balance for an address with given balance change
+    pub fn change(&self, address: &ExtendedAddr, change: &BalanceChange) -> Result<Coin> {
+        let current = self.get(address)?;
+        let new = (current + change)?;
+
+        self.storage.set(KEYSPACE, encode(address), encode(&new))?;
+
+        Ok(new)
+    }
+
+    /// Clears all storage
+    pub fn clear(&self) -> Result<()> {
+        self.storage.clear(KEYSPACE)
+    }
+}

--- a/client-index/src/service/balance_service.rs
+++ b/client-index/src/service/balance_service.rs
@@ -49,3 +49,38 @@ where
         self.storage.clear(KEYSPACE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chain_core::init::coin::Coin;
+    use client_common::balance::BalanceChange;
+    use client_common::storage::MemoryStorage;
+
+    #[test]
+    fn check_flow() {
+        let balance_service = BalanceService::new(MemoryStorage::default());
+        let address = ExtendedAddr::BasicRedeem(Default::default());
+
+        assert_eq!(Coin::zero(), balance_service.get(&address).unwrap());
+        assert_eq!(
+            Coin::new(30).unwrap(),
+            balance_service
+                .change(&address, &BalanceChange::Incoming(Coin::new(30).unwrap()))
+                .unwrap()
+        );
+        assert_eq!(
+            Coin::new(10).unwrap(),
+            balance_service
+                .change(&address, &BalanceChange::Outgoing(Coin::new(20).unwrap()))
+                .unwrap()
+        );
+        assert_eq!(
+            Coin::new(10).unwrap(),
+            balance_service.get(&address).unwrap()
+        );
+        assert!(balance_service.clear().is_ok());
+        assert_eq!(Coin::zero(), balance_service.get(&address).unwrap());
+    }
+}

--- a/client-index/src/service/global_state_service.rs
+++ b/client-index/src/service/global_state_service.rs
@@ -50,18 +50,29 @@ where
         }
     }
 
-    /// Synchronizes last block height with Crypto.com Chain and returns old (if exists) and new value
-    // pub fn sync_last_block_height(&self) -> Result<(Option<u64>, u64)> {
-    //     let status = self.client.status()?;
-    //     let last_block_height = status.last_block_height()?;
-
-    //     let old_last_block_height = self.set_last_block_height(last_block_height)?;
-
-    //     Ok((old_last_block_height, last_block_height))
-    // }
-
     /// Clears all storage
     pub fn clear(&self) -> Result<()> {
         self.storage.clear(KEYSPACE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use client_common::storage::MemoryStorage;
+
+    #[test]
+    fn check_flow() {
+        let global_state_service = GlobalStateService::new(MemoryStorage::default());
+
+        assert_eq!(None, global_state_service.last_block_height().unwrap());
+        assert_eq!(None, global_state_service.set_last_block_height(5).unwrap());
+        assert_eq!(
+            5,
+            global_state_service.last_block_height().unwrap().unwrap()
+        );
+        assert!(global_state_service.clear().is_ok());
+        assert_eq!(None, global_state_service.last_block_height().unwrap());
     }
 }

--- a/client-index/src/service/global_state_service.rs
+++ b/client-index/src/service/global_state_service.rs
@@ -1,0 +1,67 @@
+use bincode::{deserialize, serialize};
+use failure::ResultExt;
+
+use client_common::{ErrorKind, Result, Storage};
+
+const KEYSPACE: &str = "index_global_state";
+const LAST_BLOCK_HEIGHT: &str = "last_block_height";
+
+/// Exposes functionalities for managing client's global state
+pub struct GlobalStateService<S> {
+    storage: S,
+}
+
+impl<S> GlobalStateService<S>
+where
+    S: Storage,
+{
+    /// Creates new instance of global state service
+    pub fn new(storage: S) -> Self {
+        Self { storage }
+    }
+
+    /// Returns currently stored last block height
+    pub fn last_block_height(&self) -> Result<Option<u64>> {
+        let bytes = self.storage.get(KEYSPACE, LAST_BLOCK_HEIGHT)?;
+
+        match bytes {
+            None => Ok(None),
+            Some(bytes) => {
+                let last_block_height: u64 =
+                    deserialize(&bytes).context(ErrorKind::DeserializationError)?;
+                Ok(Some(last_block_height))
+            }
+        }
+    }
+
+    /// Updates last block height with given value and returns old value
+    pub fn set_last_block_height(&self, last_block_height: u64) -> Result<Option<u64>> {
+        let bytes = serialize(&last_block_height).context(ErrorKind::SerializationError)?;
+
+        let old_bytes = self.storage.set(KEYSPACE, LAST_BLOCK_HEIGHT, bytes)?;
+
+        match old_bytes {
+            None => Ok(None),
+            Some(bytes) => {
+                let last_block_height: u64 =
+                    deserialize(&bytes).context(ErrorKind::DeserializationError)?;
+                Ok(Some(last_block_height))
+            }
+        }
+    }
+
+    /// Synchronizes last block height with Crypto.com Chain and returns old (if exists) and new value
+    // pub fn sync_last_block_height(&self) -> Result<(Option<u64>, u64)> {
+    //     let status = self.client.status()?;
+    //     let last_block_height = status.last_block_height()?;
+
+    //     let old_last_block_height = self.set_last_block_height(last_block_height)?;
+
+    //     Ok((old_last_block_height, last_block_height))
+    // }
+
+    /// Clears all storage
+    pub fn clear(&self) -> Result<()> {
+        self.storage.clear(KEYSPACE)
+    }
+}

--- a/client-index/src/service/transaction_outputs_service.rs
+++ b/client-index/src/service/transaction_outputs_service.rs
@@ -8,7 +8,7 @@ const KEYSPACE: &str = "index_transaction_outputs";
 
 /// Exposes functionalities for managing transaction outputs
 ///
-/// Stores `tx_id -> [tx_output_address]` mapping
+/// Stores `tx_id -> [tx_outputs]` mapping
 pub struct TransactionOutputsService<S> {
     storage: S,
 }

--- a/client-index/src/service/transaction_outputs_service.rs
+++ b/client-index/src/service/transaction_outputs_service.rs
@@ -1,0 +1,46 @@
+use rlp::{decode_list, encode_list};
+
+use chain_core::tx::data::output::TxOut;
+use chain_core::tx::data::TxId;
+use client_common::{Result, Storage};
+
+const KEYSPACE: &str = "index_transaction_outputs";
+
+/// Exposes functionalities for managing transaction outputs
+///
+/// Stores `tx_id -> [tx_output_address]` mapping
+pub struct TransactionOutputsService<S> {
+    storage: S,
+}
+
+impl<S> TransactionOutputsService<S>
+where
+    S: Storage,
+{
+    /// Creates a new instance of transaction outputs service
+    pub fn new(storage: S) -> Self {
+        Self { storage }
+    }
+
+    /// Retrieves transaction outputs corresponding to given transaction id
+    pub fn get(&self, id: &TxId) -> Result<Vec<TxOut>> {
+        let bytes = self.storage.get(KEYSPACE, id)?;
+
+        match bytes {
+            None => Ok(Default::default()),
+            Some(bytes) => Ok(decode_list(&bytes)),
+        }
+    }
+
+    /// Sets transaction outputs for given transaction id
+    pub fn set(&self, id: &TxId, outputs: &[TxOut]) -> Result<()> {
+        self.storage.set(KEYSPACE, id, encode_list(outputs))?;
+
+        Ok(())
+    }
+
+    /// Clears all storage
+    pub fn clear(&self) -> Result<()> {
+        self.storage.clear(KEYSPACE)
+    }
+}

--- a/client-index/src/service/transaction_outputs_service.rs
+++ b/client-index/src/service/transaction_outputs_service.rs
@@ -44,3 +44,29 @@ where
         self.storage.clear(KEYSPACE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chain_core::init::coin::Coin;
+    use chain_core::tx::data::address::ExtendedAddr;
+    use client_common::storage::MemoryStorage;
+
+    #[test]
+    fn check_flow() {
+        let transaction_outputs_service = TransactionOutputsService::new(MemoryStorage::default());
+        let id = TxId::zero();
+        let outputs = vec![TxOut {
+            address: ExtendedAddr::BasicRedeem(Default::default()),
+            value: Coin::zero(),
+            valid_from: None,
+        }];
+
+        assert_eq!(0, transaction_outputs_service.get(&id).unwrap().len());
+        assert!(transaction_outputs_service.set(&id, &outputs).is_ok());
+        assert_eq!(1, transaction_outputs_service.get(&id).unwrap().len());
+        assert!(transaction_outputs_service.clear().is_ok());
+        assert_eq!(0, transaction_outputs_service.get(&id).unwrap().len());
+    }
+}

--- a/client-index/src/service/transaction_service.rs
+++ b/client-index/src/service/transaction_service.rs
@@ -1,0 +1,48 @@
+use failure::ResultExt;
+use rlp::{decode, encode};
+
+use chain_core::tx::data::{Tx, TxId};
+use client_common::{ErrorKind, Result, Storage};
+
+const KEYSPACE: &str = "index_transaction";
+
+/// Exposes functionalities for managing transactions
+///
+/// Stores `tx_id -> tx` mapping
+pub struct TransactionService<S> {
+    storage: S,
+}
+
+impl<S> TransactionService<S>
+where
+    S: Storage,
+{
+    /// Creates a new instance of transaction service
+    pub fn new(storage: S) -> Self {
+        Self { storage }
+    }
+
+    /// Retrieves transaction with given id
+    pub fn get(&self, id: &TxId) -> Result<Option<Tx>> {
+        let bytes = self.storage.get(KEYSPACE, id)?;
+
+        match bytes {
+            None => Ok(None),
+            Some(bytes) => Ok(Some(
+                decode(&bytes).context(ErrorKind::DeserializationError)?,
+            )),
+        }
+    }
+
+    /// Sets transaction with given id and value
+    pub fn set(&self, id: &TxId, transaction: &Tx) -> Result<()> {
+        self.storage.set(KEYSPACE, id, encode(transaction))?;
+
+        Ok(())
+    }
+
+    /// Clears all storage
+    pub fn clear(&self) -> Result<()> {
+        self.storage.clear(KEYSPACE)
+    }
+}

--- a/client-index/src/service/transaction_service.rs
+++ b/client-index/src/service/transaction_service.rs
@@ -46,3 +46,23 @@ where
         self.storage.clear(KEYSPACE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use client_common::storage::MemoryStorage;
+
+    #[test]
+    fn check_flow() {
+        let transaction_service = TransactionService::new(MemoryStorage::default());
+        let id = TxId::zero();
+        let transaction = Tx::default();
+
+        assert_eq!(None, transaction_service.get(&id).unwrap());
+        assert!(transaction_service.set(&id, &transaction).is_ok());
+        assert_eq!(transaction, transaction_service.get(&id).unwrap().unwrap());
+        assert!(transaction_service.clear().is_ok());
+        assert_eq!(None, transaction_service.get(&id).unwrap());
+    }
+}

--- a/client-index/src/tendermint.rs
+++ b/client-index/src/tendermint.rs
@@ -1,8 +1,10 @@
 //! Tendermint client operations
 mod client;
+#[cfg(feature = "rpc")]
 mod rpc_client;
 
 pub mod types;
 
 pub use client::Client;
+#[cfg(feature = "rpc")]
 pub use rpc_client::RpcClient;

--- a/client-index/src/tendermint/rpc_client.rs
+++ b/client-index/src/tendermint/rpc_client.rs
@@ -1,3 +1,7 @@
+#![cfg(feature = "rpc")]
+
+use std::sync::Arc;
+
 use failure::ResultExt;
 use jsonrpc::client::Client as JsonRpcClient;
 use serde::Deserialize;
@@ -9,14 +13,15 @@ use crate::tendermint::types::*;
 use crate::tendermint::Client;
 
 /// Tendermint RPC Client
+#[derive(Clone)]
 pub struct RpcClient {
-    inner: JsonRpcClient,
+    inner: Arc<JsonRpcClient>,
 }
 
 impl RpcClient {
     /// Creates a new instance of `RpcClient`
     pub fn new(url: &str) -> Self {
-        let inner = JsonRpcClient::new(url.to_owned(), None, None);
+        let inner = Arc::new(JsonRpcClient::new(url.to_owned(), None, None));
 
         Self { inner }
     }

--- a/client-index/src/tendermint/types/block.rs
+++ b/client-index/src/tendermint/types/block.rs
@@ -9,17 +9,17 @@ use client_common::{ErrorKind, Result};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Block {
-    block: BlockInner,
+    pub block: BlockInner,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct BlockInner {
-    data: Data,
+pub struct BlockInner {
+    pub data: Data,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Data {
-    txs: Vec<String>,
+pub struct Data {
+    pub txs: Vec<String>,
 }
 
 impl Block {
@@ -37,27 +37,19 @@ impl Block {
     }
 }
 
-// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
-#[cfg(test)]
-impl Default for Block {
-    fn default() -> Self {
-        Block {
-            block: BlockInner {
-                data: Data {
-                    txs: vec!["+JWA+Erj4qBySKi4J+krjuZi++QuAnQITDv9YzjXV0RcDuk+S7pMeIDh4NaAlHkGYaL9naP+5TyquAhZ7K4SWiCliAAA6IkEI8eKw4GrwPhG+ESAAbhASZdu2rJI4Et7q93KedoEsTVFUOCPt8nyY0pGOqixhI4TvORYPVFmJiG+Lsr6L1wmwBLIwxJenWTyKZ8rKrwfkg==".to_owned()]
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn check_transactions() {
-        let block = Block::default();
+        let block = Block {
+            block: BlockInner {
+                data: Data {
+                    txs: vec!["+JWA+Erj4qBySKi4J+krjuZi++QuAnQITDv9YzjXV0RcDuk+S7pMeIDh4NaAlHkGYaL9naP+5TyquAhZ7K4SWiCliAAA6IkEI8eKw4GrwPhG+ESAAbhASZdu2rJI4Et7q93KedoEsTVFUOCPt8nyY0pGOqixhI4TvORYPVFmJiG+Lsr6L1wmwBLIwxJenWTyKZ8rKrwfkg==".to_owned()]
+                }
+            }
+        };
         assert_eq!(1, block.transactions().unwrap().len());
     }
 

--- a/client-index/src/tendermint/types/block.rs
+++ b/client-index/src/tendermint/types/block.rs
@@ -37,20 +37,27 @@ impl Block {
     }
 }
 
+// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
+#[cfg(test)]
+impl Default for Block {
+    fn default() -> Self {
+        Block {
+            block: BlockInner {
+                data: Data {
+                    txs: vec!["+JWA+Erj4qBySKi4J+krjuZi++QuAnQITDv9YzjXV0RcDuk+S7pMeIDh4NaAlHkGYaL9naP+5TyquAhZ7K4SWiCliAAA6IkEI8eKw4GrwPhG+ESAAbhASZdu2rJI4Et7q93KedoEsTVFUOCPt8nyY0pGOqixhI4TvORYPVFmJiG+Lsr6L1wmwBLIwxJenWTyKZ8rKrwfkg==".to_owned()]
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn check_transactions() {
-        let block = Block {
-            block: BlockInner {
-                data: Data {
-                    txs: vec!["+JWA+Erj4qBySKi4J+krjuZi++QuAnQITDv9YzjXV0RcDuk+S7pMeIDh4NaAlHkGYaL9naP+5TyquAhZ7K4SWiCliAAA6IkEI8eKw4GrwPhG+ESAAbhASZdu2rJI4Et7q93KedoEsTVFUOCPt8nyY0pGOqixhI4TvORYPVFmJiG+Lsr6L1wmwBLIwxJenWTyKZ8rKrwfkg==".to_owned()]
-                }
-            }
-        };
-
+        let block = Block::default();
         assert_eq!(1, block.transactions().unwrap().len());
     }
 

--- a/client-index/src/tendermint/types/block_results.rs
+++ b/client-index/src/tendermint/types/block_results.rs
@@ -10,25 +10,25 @@ use client_common::{ErrorKind, Result};
 
 #[derive(Debug, Deserialize)]
 pub struct BlockResults {
-    height: String,
-    results: Results,
+    pub height: String,
+    pub results: Results,
 }
 
 #[derive(Debug, Deserialize)]
-struct Results {
+pub struct Results {
     #[serde(rename = "DeliverTx")]
-    deliver_tx: Vec<DeliverTx>,
+    pub deliver_tx: Vec<DeliverTx>,
 }
 
 #[derive(Debug, Deserialize)]
-struct DeliverTx {
-    tags: Vec<Tag>,
+pub struct DeliverTx {
+    pub tags: Vec<Tag>,
 }
 
 #[derive(Debug, Deserialize)]
-struct Tag {
-    key: String,
-    value: String,
+pub struct Tag {
+    pub key: String,
+    pub value: String,
 }
 
 impl BlockResults {
@@ -54,11 +54,13 @@ impl BlockResults {
     }
 }
 
-// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
 #[cfg(test)]
-impl Default for BlockResults {
-    fn default() -> Self {
-        BlockResults {
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_ids() {
+        let block_results = BlockResults {
             height: "2".to_owned(),
             results: Results {
                 deliver_tx: vec![DeliverTx {
@@ -68,17 +70,7 @@ impl Default for BlockResults {
                     }],
                 }],
             },
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn check_ids() {
-        let block_results = BlockResults::default();
+        };
         assert_eq!(1, block_results.ids().unwrap().len());
     }
 

--- a/client-index/src/tendermint/types/block_results.rs
+++ b/client-index/src/tendermint/types/block_results.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+use std::collections::HashSet;
 
 use base64::decode;
 use failure::ResultExt;
@@ -32,8 +33,8 @@ struct Tag {
 
 impl BlockResults {
     /// Returns valid transaction ids in block results
-    pub fn ids(&self) -> Result<Vec<TxId>> {
-        let mut transactions: Vec<TxId> = Default::default();
+    pub fn ids(&self) -> Result<HashSet<TxId>> {
+        let mut transactions: HashSet<TxId> = HashSet::with_capacity(self.results.deliver_tx.len());
 
         for transaction in self.results.deliver_tx.iter() {
             for tag in transaction.tags.iter() {
@@ -45,7 +46,7 @@ impl BlockResults {
                 let mut id: [u8; 32] = [0; 32];
                 id.copy_from_slice(&decoded);
 
-                transactions.push(id.into());
+                transactions.insert(id.into());
             }
         }
 

--- a/client-index/src/tendermint/types/block_results.rs
+++ b/client-index/src/tendermint/types/block_results.rs
@@ -54,13 +54,11 @@ impl BlockResults {
     }
 }
 
+// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn check_ids() {
-        let block_results = BlockResults {
+impl Default for BlockResults {
+    fn default() -> Self {
+        BlockResults {
             height: "2".to_owned(),
             results: Results {
                 deliver_tx: vec![DeliverTx {
@@ -70,8 +68,17 @@ mod tests {
                     }],
                 }],
             },
-        };
+        }
+    }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_ids() {
+        let block_results = BlockResults::default();
         assert_eq!(1, block_results.ids().unwrap().len());
     }
 

--- a/client-index/src/tendermint/types/genesis.rs
+++ b/client-index/src/tendermint/types/genesis.rs
@@ -9,24 +9,15 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::Tx;
 use client_common::{ErrorKind, Result};
 
-#[cfg(test)]
-use chain_core::init::address::RedeemAddress;
-#[cfg(test)]
-use chain_core::init::coin::Coin;
-#[cfg(test)]
-use chain_core::init::config::ERC20Owner;
-#[cfg(test)]
-use std::str::FromStr;
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Genesis {
-    genesis: GenesisInner,
+    pub genesis: GenesisInner,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct GenesisInner {
-    chain_id: String,
-    app_state: InitConfig,
+pub struct GenesisInner {
+    pub chain_id: String,
+    pub app_state: InitConfig,
 }
 
 impl Genesis {
@@ -46,11 +37,19 @@ impl Genesis {
     }
 }
 
-// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
 #[cfg(test)]
-impl Default for Genesis {
-    fn default() -> Self {
-        Genesis {
+mod tests {
+    use super::*;
+
+    use std::str::FromStr;
+
+    use chain_core::init::address::RedeemAddress;
+    use chain_core::init::coin::Coin;
+    use chain_core::init::config::ERC20Owner;
+
+    #[test]
+    fn check_transactions() {
+        let genesis = Genesis {
             genesis: GenesisInner {
                 chain_id: "test-chain-4UIy1Wab".to_owned(),
                 app_state: InitConfig::new(vec![ERC20Owner::new(
@@ -58,17 +57,7 @@ impl Default for Genesis {
                     Coin::new(10000000000000000000).unwrap(),
                 )]),
             },
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn check_transactions() {
-        let genesis = Genesis::default();
+        };
         assert_eq!(1, genesis.transactions().unwrap().len());
     }
 

--- a/client-index/src/tendermint/types/genesis.rs
+++ b/client-index/src/tendermint/types/genesis.rs
@@ -9,6 +9,15 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::Tx;
 use client_common::{ErrorKind, Result};
 
+#[cfg(test)]
+use chain_core::init::address::RedeemAddress;
+#[cfg(test)]
+use chain_core::init::coin::Coin;
+#[cfg(test)]
+use chain_core::init::config::ERC20Owner;
+#[cfg(test)]
+use std::str::FromStr;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Genesis {
     genesis: GenesisInner,
@@ -37,19 +46,11 @@ impl Genesis {
     }
 }
 
+// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    use std::str::FromStr;
-
-    use chain_core::init::address::RedeemAddress;
-    use chain_core::init::coin::Coin;
-    use chain_core::init::config::ERC20Owner;
-
-    #[test]
-    fn check_transactions() {
-        let genesis = Genesis {
+impl Default for Genesis {
+    fn default() -> Self {
+        Genesis {
             genesis: GenesisInner {
                 chain_id: "test-chain-4UIy1Wab".to_owned(),
                 app_state: InitConfig::new(vec![ERC20Owner::new(
@@ -57,8 +58,17 @@ mod tests {
                     Coin::new(10000000000000000000).unwrap(),
                 )]),
             },
-        };
+        }
+    }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_transactions() {
+        let genesis = Genesis::default();
         assert_eq!(1, genesis.transactions().unwrap().len());
     }
 

--- a/client-index/src/tendermint/types/status.rs
+++ b/client-index/src/tendermint/types/status.rs
@@ -7,12 +7,12 @@ use client_common::{ErrorKind, Result};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Status {
-    sync_info: SyncInfo,
+    pub sync_info: SyncInfo,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct SyncInfo {
-    latest_block_height: String,
+pub struct SyncInfo {
+    pub latest_block_height: String,
 }
 
 impl Status {
@@ -26,25 +26,17 @@ impl Status {
     }
 }
 
-// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
-#[cfg(test)]
-impl Default for Status {
-    fn default() -> Self {
-        Status {
-            sync_info: SyncInfo {
-                latest_block_height: "1".to_owned(),
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn check_last_block_height() {
-        let status = Status::default();
+        let status = Status {
+            sync_info: SyncInfo {
+                latest_block_height: "1".to_owned(),
+            },
+        };
         assert_eq!(1, status.last_block_height().unwrap());
     }
 

--- a/client-index/src/tendermint/types/status.rs
+++ b/client-index/src/tendermint/types/status.rs
@@ -26,19 +26,26 @@ impl Status {
     }
 }
 
+// Note: Do not change these values. These are tied with tests for `RpcSledIndex`
+#[cfg(test)]
+impl Default for Status {
+    fn default() -> Self {
+        Status {
+            sync_info: SyncInfo {
+                latest_block_height: "1".to_owned(),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn check_last_block_height() {
-        let status = Status {
-            sync_info: SyncInfo {
-                latest_block_height: "2".to_owned(),
-            },
-        };
-
-        assert_eq!(2, status.last_block_height().unwrap());
+        let status = Status::default();
+        assert_eq!(1, status.last_block_height().unwrap());
     }
 
     #[test]

--- a/client-index/src/test.rs
+++ b/client-index/src/test.rs
@@ -1,0 +1,5 @@
+#![cfg(test)]
+
+mod mock_client;
+
+pub use mock_client::MockClient;

--- a/client-index/src/test/mock_client.rs
+++ b/client-index/src/test/mock_client.rs
@@ -1,0 +1,33 @@
+#![cfg(test)]
+
+use client_common::Result;
+
+use crate::tendermint::types::*;
+use crate::tendermint::Client;
+
+#[derive(Clone)]
+pub struct MockClient;
+
+impl MockClient {
+    pub fn new(_: &str) -> Self {
+        Self
+    }
+}
+
+impl Client for MockClient {
+    fn genesis(&self) -> Result<Genesis> {
+        Ok(Default::default())
+    }
+
+    fn status(&self) -> Result<Status> {
+        Ok(Default::default())
+    }
+
+    fn block(&self, _: u64) -> Result<Block> {
+        Ok(Default::default())
+    }
+
+    fn block_results(&self, _: u64) -> Result<BlockResults> {
+        Ok(Default::default())
+    }
+}

--- a/client-index/src/test/mock_client.rs
+++ b/client-index/src/test/mock_client.rs
@@ -1,5 +1,10 @@
 #![cfg(test)]
 
+use std::str::FromStr;
+
+use chain_core::init::address::RedeemAddress;
+use chain_core::init::coin::Coin;
+use chain_core::init::config::{ERC20Owner, InitConfig};
 use client_common::Result;
 
 use crate::tendermint::types::*;
@@ -16,18 +21,46 @@ impl MockClient {
 
 impl Client for MockClient {
     fn genesis(&self) -> Result<Genesis> {
-        Ok(Default::default())
+        Ok(Genesis {
+            genesis: GenesisInner {
+                chain_id: "test-chain-4UIy1Wab".to_owned(),
+                app_state: InitConfig::new(vec![ERC20Owner::new(
+                    RedeemAddress::from_str("0x1fdf22497167a793ca794963ad6c95e6ffa0b971").unwrap(),
+                    Coin::new(10000000000000000000).unwrap(),
+                )]),
+            },
+        })
     }
 
     fn status(&self) -> Result<Status> {
-        Ok(Default::default())
+        Ok(Status {
+            sync_info: SyncInfo {
+                latest_block_height: "1".to_owned(),
+            },
+        })
     }
 
     fn block(&self, _: u64) -> Result<Block> {
-        Ok(Default::default())
+        Ok(Block {
+            block: BlockInner {
+                data: Data {
+                    txs: vec!["+JWA+Erj4qBySKi4J+krjuZi++QuAnQITDv9YzjXV0RcDuk+S7pMeIDh4NaAlHkGYaL9naP+5TyquAhZ7K4SWiCliAAA6IkEI8eKw4GrwPhG+ESAAbhASZdu2rJI4Et7q93KedoEsTVFUOCPt8nyY0pGOqixhI4TvORYPVFmJiG+Lsr6L1wmwBLIwxJenWTyKZ8rKrwfkg==".to_owned()]
+                }
+            }
+        })
     }
 
     fn block_results(&self, _: u64) -> Result<BlockResults> {
-        Ok(Default::default())
+        Ok(BlockResults {
+            height: "2".to_owned(),
+            results: Results {
+                deliver_tx: vec![DeliverTx {
+                    tags: vec![Tag {
+                        key: "dHhpZA==".to_owned(),
+                        value: "kOzcmhZgAAaw5roBdqDNniwRjjKNe+foJEiDAOObTDQ=".to_owned(),
+                    }],
+                }],
+            },
+        })
     }
 }


### PR DESCRIPTION
Solution: Created transaction index

Details:
- `Index` is the main trait which has functions to get balance, transaction history, etc.
- A default implementation of `Index` trait is provided by `RpcSledIndex` which uses `jsonrpc` for making rpc calls to tendermint and `sled` for storage
- There are other services which is used for synchronising current state of `Index` with Crypto.com Chain