### PR TITLE
Problem: (CRO-99) jsonrpc client does not handle underlying connection reset properly

### DIFF
--- a/client-common/src/tendermint/rpc_client.rs
+++ b/client-common/src/tendermint/rpc_client.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "rpc")]
 
-use std::sync::Arc;
-
 use failure::ResultExt;
 use jsonrpc::client::Client as JsonRpcClient;
 use serde::Deserialize;
@@ -14,25 +12,26 @@ use crate::{ErrorKind, Result};
 /// Tendermint RPC Client
 #[derive(Clone)]
 pub struct RpcClient {
-    inner: Arc<JsonRpcClient>,
+    url: String,
 }
 
 impl RpcClient {
     /// Creates a new instance of `RpcClient`
     pub fn new(url: &str) -> Self {
-        let inner = Arc::new(JsonRpcClient::new(url.to_owned(), None, None));
-
-        Self { inner }
+        Self { url: url.to_owned() }
     }
 
     fn call<T>(&self, name: &str, params: &[Value]) -> Result<T>
     where
         for<'de> T: Deserialize<'de>,
     {
-        let request = self.inner.build_request(name, params);
+        // jsonrpc does not handle Hyper connection reset properly. The current
+        // inefficient workaround is to create a new client on every call.
+        // https://github.com/apoelstra/rust-jsonrpc/issues/26
+        let client = JsonRpcClient::new(self.url.to_owned(), None, None);
+        let request = client.build_request(name, params);
 
-        let response = self
-            .inner
+        let response = client
             .send_request(&request)
             .context(ErrorKind::RpcError)?;
 

--- a/client-common/src/tendermint/rpc_client.rs
+++ b/client-common/src/tendermint/rpc_client.rs
@@ -18,7 +18,9 @@ pub struct RpcClient {
 impl RpcClient {
     /// Creates a new instance of `RpcClient`
     pub fn new(url: &str) -> Self {
-        Self { url: url.to_owned() }
+        Self {
+            url: url.to_owned(),
+        }
     }
 
     fn call<T>(&self, name: &str, params: &[Value]) -> Result<T>
@@ -31,9 +33,7 @@ impl RpcClient {
         let client = JsonRpcClient::new(self.url.to_owned(), None, None);
         let request = client.build_request(name, params);
 
-        let response = client
-            .send_request(&request)
-            .context(ErrorKind::RpcError)?;
+        let response = client.send_request(&request).context(ErrorKind::RpcError)?;
 
         let result = response.result::<T>().context(ErrorKind::RpcError)?;
 


### PR DESCRIPTION
### Background:
On testing the Tendermint RPC client it shows unstable request from time to time. The problem is that the `jsonrpc` crate use Hyper as the underlying HTTP client, but the crate does not handle connection reset correctly, hence causing unstable request. The issue is filed below
https://github.com/apoelstra/rust-jsonrpc/issues/26

### Solution:
Create a new client on every JSON-RPC call as a workaround

### Future:
The current solution is a workaround and is inefficient. In the future we should keep track of the `jsonrpc` issue and take appropriate response.
