### PR TITLE
Problem: (CRO-104) Plain insecure strings for passphrases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -313,6 +314,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)",
+ "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -342,6 +344,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1713,6 +1716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2596,7 @@ dependencies = [
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)" = "<none>"
+"checksum secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "214774070e52ab9db5c35f3ea5076f8b1de357bad5334fd42574159cf7fc3158"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -13,6 +13,7 @@ blake2 = "0.8"
 rlp = "0.3"
 hex = "0.3"
 base64 = "0.10"
+secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 sled = { version = "0.23", optional = true }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -17,6 +17,7 @@ hex = "0.3"
 zeroize = "0.6"
 byteorder = "1.3"
 rlp = "0.3"
+secstr = "0.3"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -3,6 +3,8 @@ mod default_wallet_client;
 
 pub use default_wallet_client::DefaultWalletClient;
 
+use secstr::SecStr;
+
 use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
@@ -19,48 +21,49 @@ pub trait WalletClient: Send + Sync {
     fn wallets(&self) -> Result<Vec<String>>;
 
     /// Creates a new wallet with given name and returns wallet_id
-    fn new_wallet(&self, name: &str, passphrase: &str) -> Result<String>;
+    fn new_wallet(&self, name: &str, passphrase: &SecStr) -> Result<String>;
 
     /// Retrieves all public keys corresponding to given wallet
-    fn private_keys(&self, name: &str, passphrase: &str) -> Result<Vec<PrivateKey>>;
+    fn private_keys(&self, name: &str, passphrase: &SecStr) -> Result<Vec<PrivateKey>>;
 
     /// Retrieves all public keys corresponding to given wallet
-    fn public_keys(&self, name: &str, passphrase: &str) -> Result<Vec<PublicKey>>;
+    fn public_keys(&self, name: &str, passphrase: &SecStr) -> Result<Vec<PublicKey>>;
 
     /// Retrieves all addresses corresponding to given wallet
-    fn addresses(&self, name: &str, passphrase: &str) -> Result<Vec<ExtendedAddr>>;
+    fn addresses(&self, name: &str, passphrase: &SecStr) -> Result<Vec<ExtendedAddr>>;
 
     /// Retrieves private key corresponding to given address
     fn private_key(
         &self,
         name: &str,
-        passphrase: &str,
+        passphrase: &SecStr,
         address: &ExtendedAddr,
     ) -> Result<Option<PrivateKey>>;
 
     /// Generates a new public key for given wallet
-    fn new_public_key(&self, name: &str, passphrase: &str) -> Result<PublicKey>;
+    fn new_public_key(&self, name: &str, passphrase: &SecStr) -> Result<PublicKey>;
 
     /// Generates a new address for given wallet
-    fn new_address(&self, name: &str, passphrase: &str) -> Result<ExtendedAddr>;
+    fn new_address(&self, name: &str, passphrase: &SecStr) -> Result<ExtendedAddr>;
 
     /// Retrieves current balance of wallet
-    fn balance(&self, name: &str, passphrase: &str) -> Result<Coin>;
+    fn balance(&self, name: &str, passphrase: &SecStr) -> Result<Coin>;
 
     /// Retrieves transaction history of wallet
-    fn history(&self, name: &str, passphrase: &str) -> Result<Vec<TransactionChange>>;
+    fn history(&self, name: &str, passphrase: &SecStr) -> Result<Vec<TransactionChange>>;
 
     /// Creates and broadcasts a transaction to Crypto.com Chain
     fn create_and_broadcast_transaction(
         &self,
         name: &str,
-        passphrase: &str,
+        passphrase: &SecStr,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
     ) -> Result<()>;
 
     /// Broadcasts a transaction to Crypto.com Chain
-    fn broadcast_transaction(&self, name: &str, passphrase: &str, transaction: Tx) -> Result<()>;
+    fn broadcast_transaction(&self, name: &str, passphrase: &SecStr, transaction: Tx)
+        -> Result<()>;
 
     /// Synchronizes index with Crypto.com Chain (from last known height)
     fn sync(&self) -> Result<()>;

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.3.2"
+secstr = { version = "0.3", features = ["serde"] }

--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -1,5 +1,6 @@
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::jsonrpc_core;
+use secstr::SecStr;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -95,7 +96,7 @@ where
         if let Err(e) = self.client.new_address(&request.name, &request.passphrase) {
             Err(to_rpc_error(e))
         } else {
-            Ok(request.name.clone())
+            Ok(request.name)
         }
     }
 
@@ -163,7 +164,7 @@ where
 #[derive(Debug, Deserialize)]
 pub struct WalletRequest {
     name: String,
-    passphrase: String,
+    passphrase: SecStr,
 }
 
 #[cfg(test)]
@@ -359,7 +360,7 @@ mod tests {
     fn create_wallet_request(name: &str, passphrase: &str) -> WalletRequest {
         WalletRequest {
             name: name.to_owned(),
-            passphrase: passphrase.to_owned(),
+            passphrase: SecStr::from(passphrase),
         }
     }
 }


### PR DESCRIPTION
**Solution**: Started using secstr which provides secure strings.

**Note on security**: Current implementation uses deserialization feature provided by `secstr` crate which uses `serde`. To obtain a `SecStr` object from `&str`, they copy all the bytes from `&str` provided by serde. Its not possible to zeroize `&str` provided by serde because we never get a mutable reference from serde. [here](https://github.com/myfreeweb/secstr/blob/master/src/lib.rs#L220) is the line where they make a copy of `&str`.
