### PR TITLE
Problem: Client RPC requires passphrase to be a byte array

### DIFF
--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -304,6 +304,31 @@ mod tests {
     }
 
     #[test]
+    fn test_access_wallet_with_incorrect_passphrase() {
+        let wallet_rpc = setup_wallet_rpc();
+
+        assert_eq!(
+            "Default".to_owned(),
+            wallet_rpc
+                .create(create_wallet_request("Default", "123456"))
+                .unwrap()
+        );
+
+        assert_eq!(
+            to_rpc_error(Error::from(ErrorKind::DecryptionError)),
+            wallet_rpc
+                .addresses(create_wallet_request("Default", "789012"))
+                .unwrap_err()
+        );
+        assert_eq!(
+            to_rpc_error(Error::from(ErrorKind::DecryptionError)),
+            wallet_rpc
+                .balance(create_wallet_request("Default", "789012"))
+                .unwrap_err()
+        );
+    }
+
+    #[test]
     fn test_create_and_list_wallet_flow() {
         let wallet_rpc = setup_wallet_rpc();
 

--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -43,7 +43,10 @@ pub trait WalletRpc {
     fn sync_all(&self) -> jsonrpc_core::Result<()>;
 
     #[rpc(name = "wallet_transactions")]
-    fn transactions(&self, request: WalletRequestWithString) -> jsonrpc_core::Result<Vec<TransactionChange>>;
+    fn transactions(
+        &self,
+        request: WalletRequestWithString,
+    ) -> jsonrpc_core::Result<Vec<TransactionChange>>;
 }
 
 pub struct WalletRpcImpl<T: WalletClient + Send + Sync> {
@@ -158,7 +161,10 @@ where
         }
     }
 
-    fn transactions(&self, request: WalletRequestWithString) -> jsonrpc_core::Result<Vec<TransactionChange>> {
+    fn transactions(
+        &self,
+        request: WalletRequestWithString,
+    ) -> jsonrpc_core::Result<Vec<TransactionChange>> {
         let request: WalletRequest = request.into();
 
         self.sync()?;


### PR DESCRIPTION
Solution: Changed client RPC to accept string passphrase and transform to `SecStr`