### PR TITLE
Problem: Client RPC requires passphrase to be a byte array 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quest 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -331,7 +331,7 @@ dependencies = [
  "miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -351,7 +351,7 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)",
- "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
  "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -381,7 +381,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1810,8 +1810,8 @@ dependencies = [
 
 [[package]]
 name = "secstr"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.3.2"
+source = "git+https://github.com/myfreeweb/secstr?tag=v0.3.2#4e17a9fdee092ff9c26bcbbbb58a16c4c97faff4"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2710,7 +2710,7 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)" = "<none>"
-"checksum secstr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "214774070e52ab9db5c35f3ea5076f8b1de357bad5334fd42574159cf7fc3158"
+"checksum secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)" = "<none>"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -12,6 +12,6 @@ client-core = { path = "../client-core" }
 structopt = "0.2"
 failure = "0.1"
 quest = "0.3"
-secstr = "0.3"
+secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2" }
 hex = "0.3"
 prettytable-rs = "0.8"

--- a/client-cli/src/main.rs
+++ b/client-cli/src/main.rs
@@ -4,7 +4,7 @@ mod command;
 
 use failure::ResultExt;
 use quest::{ask, error, password};
-use secstr::SecStr;
+use secstr::SecUtf8;
 use structopt::StructOpt;
 
 use client_common::{ErrorKind, Result};
@@ -45,7 +45,7 @@ pub(crate) fn tendermint_url() -> String {
     }
 }
 
-pub(crate) fn ask_passphrase() -> Result<SecStr> {
+pub(crate) fn ask_passphrase() -> Result<SecUtf8> {
     ask("Enter passphrase: ");
     Ok(password().context(ErrorKind::IoError)?.into())
 }

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -12,7 +12,7 @@ miscreant = "0.4"
 blake2 = "0.8"
 hex = "0.3"
 base64 = "0.10"
-secstr = "0.3"
+secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2" }
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 sled = { version = "0.24", optional = true }

--- a/client-common/src/storage.rs
+++ b/client-common/src/storage.rs
@@ -14,7 +14,7 @@ use failure::ResultExt;
 use miscreant::{Aead, Aes128PmacSivAead};
 use rand::rngs::OsRng;
 use rand::Rng;
-use secstr::SecStr;
+use secstr::SecUtf8;
 
 use crate::{ErrorKind, Result};
 
@@ -54,7 +54,7 @@ pub trait SecureStorage {
         &self,
         keyspace: S,
         key: K,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
     ) -> Result<Option<Vec<u8>>>;
 
     /// Set a key to a new value (after encryption) in given keyspace and return old value.
@@ -63,7 +63,7 @@ pub trait SecureStorage {
         keyspace: S,
         key: K,
         value: Vec<u8>,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
     ) -> Result<Option<Vec<u8>>>;
 }
 
@@ -75,7 +75,7 @@ where
         &self,
         keyspace: S,
         key: K,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
     ) -> Result<Option<Vec<u8>>> {
         let value = self.get(keyspace, &key)?;
 
@@ -98,7 +98,7 @@ where
         keyspace: S,
         key: K,
         value: Vec<u8>,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
     ) -> Result<Option<Vec<u8>>> {
         let old_value = self.get_secure(&keyspace, &key, passphrase)?;
 
@@ -117,7 +117,7 @@ where
     }
 }
 
-fn get_algo(passphrase: &SecStr) -> Aes128PmacSivAead {
+fn get_algo(passphrase: &SecUtf8) -> Aes128PmacSivAead {
     let mut hasher = Blake2s::new();
     hasher.input(passphrase.unsecure());
     Aes128PmacSivAead::new(&hasher.result_reset())

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.3"
 zeroize = "0.6"
 byteorder = "1.3"
 parity-codec = { features = ["derive"], version = "3.5.1" }
-secstr = "0.3"
+secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/client-core/src/service/key_service.rs
+++ b/client-core/src/service/key_service.rs
@@ -1,7 +1,7 @@
 use crate::PrivateKey;
 use client_common::{ErrorKind, Result, SecureStorage, Storage};
 use parity_codec::{Decode, Encode};
-use secstr::SecStr;
+use secstr::SecUtf8;
 use zeroize::Zeroize;
 
 const KEYSPACE: &str = "core_key";
@@ -22,7 +22,7 @@ where
     }
 
     /// Generates a new address for given wallet ID
-    pub fn generate(&self, wallet_id: &str, passphrase: &SecStr) -> Result<PrivateKey> {
+    pub fn generate(&self, wallet_id: &str, passphrase: &SecUtf8) -> Result<PrivateKey> {
         let private_key = PrivateKey::new()?;
 
         let private_keys = self.storage.get_secure(KEYSPACE, wallet_id, passphrase)?;
@@ -49,7 +49,7 @@ where
     pub fn get_keys(
         &self,
         wallet_id: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
     ) -> Result<Option<Vec<PrivateKey>>> {
         let private_keys = self.storage.get_secure(KEYSPACE, wallet_id, passphrase)?;
 
@@ -89,15 +89,15 @@ mod tests {
         let key_service = KeyService::new(MemoryStorage::default());
 
         let private_key = key_service
-            .generate("wallet_id", &SecStr::from("passphrase"))
+            .generate("wallet_id", &SecUtf8::from("passphrase"))
             .expect("Unable to generate private key");
 
         let new_private_key = key_service
-            .generate("wallet_id", &SecStr::from("passphrase"))
+            .generate("wallet_id", &SecUtf8::from("passphrase"))
             .expect("Unable to generate private key");
 
         let keys = key_service
-            .get_keys("wallet_id", &SecStr::from("passphrase"))
+            .get_keys("wallet_id", &SecUtf8::from("passphrase"))
             .expect("Unable to get keys from storage")
             .expect("No keys found");
 
@@ -106,7 +106,7 @@ mod tests {
         assert_eq!(new_private_key, keys[1], "Invalid private key found");
 
         let error = key_service
-            .get_keys("wallet_id", &SecStr::from("incorrect_passphrase"))
+            .get_keys("wallet_id", &SecUtf8::from("incorrect_passphrase"))
             .expect_err("Decryption worked with incorrect passphrase");
 
         assert_eq!(
@@ -118,7 +118,7 @@ mod tests {
         assert!(key_service.clear().is_ok());
 
         assert!(key_service
-            .get_keys("wallet_id", &SecStr::from("passphrase"))
+            .get_keys("wallet_id", &SecUtf8::from("passphrase"))
             .unwrap()
             .is_none());
     }

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -1,6 +1,6 @@
 use failure::ResultExt;
 use hex::encode;
-use secstr::SecStr;
+use secstr::SecUtf8;
 use zeroize::Zeroize;
 
 use chain_core::init::address::RedeemAddress;
@@ -26,7 +26,7 @@ where
     }
 
     /// Creates a new wallet and returns wallet ID
-    pub fn create(&self, name: &str, passphrase: &SecStr) -> Result<String> {
+    pub fn create(&self, name: &str, passphrase: &SecUtf8) -> Result<String> {
         if self.storage.contains_key(KEYSPACE, name)? {
             Err(ErrorKind::AlreadyExists.into())
         } else {
@@ -45,7 +45,7 @@ where
     }
 
     /// Retrieves a wallet ID from storage
-    pub fn get(&self, name: &str, passphrase: &SecStr) -> Result<Option<String>> {
+    pub fn get(&self, name: &str, passphrase: &SecUtf8) -> Result<Option<String>> {
         let address = self.storage.get_secure(KEYSPACE, name, passphrase)?;
 
         match address {
@@ -84,23 +84,23 @@ mod tests {
         let wallet_service = WalletService::new(MemoryStorage::default());
 
         let wallet = wallet_service
-            .get("name", &SecStr::from("passphrase"))
+            .get("name", &SecUtf8::from("passphrase"))
             .expect("Error while retrieving wallet information");
 
         assert!(wallet.is_none(), "Wallet is already present in storage");
 
         let wallet_id = wallet_service
-            .create("name", &SecStr::from("passphrase"))
+            .create("name", &SecUtf8::from("passphrase"))
             .expect("Unable to create new wallet");
 
         let error = wallet_service
-            .create("name", &SecStr::from("passphrase_new"))
+            .create("name", &SecUtf8::from("passphrase_new"))
             .expect_err("Able to create wallet with same name as previously created");
 
         assert_eq!(error.kind(), ErrorKind::AlreadyExists, "Invalid error kind");
 
         let wallet_id_new = wallet_service
-            .get("name", &SecStr::from("passphrase"))
+            .get("name", &SecUtf8::from("passphrase"))
             .expect("Error while retrieving wallet information")
             .expect("Wallet with given name not found");
 
@@ -110,7 +110,7 @@ mod tests {
         assert!(wallet_service.clear().is_ok());
 
         assert!(wallet_service
-            .get("name", &SecStr::from("passphrase"))
+            .get("name", &SecUtf8::from("passphrase"))
             .unwrap()
             .is_none());
         assert_eq!(0, wallet_service.names().unwrap().len());

--- a/client-core/src/transaction_builder.rs
+++ b/client-core/src/transaction_builder.rs
@@ -5,7 +5,7 @@ mod unauthorized_transaction_builder;
 pub use default_transaction_builder::DefaultTransactionBuilder;
 pub use unauthorized_transaction_builder::UnauthorizedTransactionBuilder;
 
-use secstr::SecStr;
+use secstr::SecUtf8;
 
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
@@ -21,7 +21,7 @@ pub trait TransactionBuilder: Send + Sync {
     fn build<W: WalletClient>(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
         wallet_client: &W,

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -1,6 +1,6 @@
 use failure::ResultExt;
 use secp256k1::RecoveryId;
-use secstr::SecStr;
+use secstr::SecUtf8;
 
 use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
@@ -94,7 +94,7 @@ where
     fn witnesses<W: WalletClient>(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
         wallet_client: &W,
         transaction: &Tx,
     ) -> Result<TxWitness> {
@@ -216,7 +216,7 @@ where
     fn build_from_estimate<W: WalletClient>(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
         mut transaction: Tx,
         difference_amount: Coin,
         wallet_client: &W,
@@ -241,7 +241,7 @@ where
     fn build<W: WalletClient>(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
         wallet_client: &W,
@@ -347,26 +347,26 @@ mod tests {
             unreachable!()
         }
 
-        fn new_wallet(&self, _: &str, _: &SecStr) -> Result<String> {
+        fn new_wallet(&self, _: &str, _: &SecUtf8) -> Result<String> {
             unreachable!()
         }
 
-        fn private_keys(&self, _: &str, _: &SecStr) -> Result<Vec<PrivateKey>> {
+        fn private_keys(&self, _: &str, _: &SecUtf8) -> Result<Vec<PrivateKey>> {
             unreachable!()
         }
 
-        fn public_keys(&self, _: &str, _: &SecStr) -> Result<Vec<PublicKey>> {
+        fn public_keys(&self, _: &str, _: &SecUtf8) -> Result<Vec<PublicKey>> {
             unreachable!()
         }
 
-        fn addresses(&self, _: &str, _: &SecStr) -> Result<Vec<ExtendedAddr>> {
+        fn addresses(&self, _: &str, _: &SecUtf8) -> Result<Vec<ExtendedAddr>> {
             unreachable!()
         }
 
         fn private_key(
             &self,
             _: &str,
-            _: &SecStr,
+            _: &SecUtf8,
             address: &ExtendedAddr,
         ) -> Result<Option<PrivateKey>> {
             if address == &self.addr_0 {
@@ -396,25 +396,25 @@ mod tests {
             }
         }
 
-        fn new_public_key(&self, _: &str, _: &SecStr) -> Result<PublicKey> {
+        fn new_public_key(&self, _: &str, _: &SecUtf8) -> Result<PublicKey> {
             unreachable!()
         }
 
-        fn new_address(&self, _: &str, _: &SecStr) -> Result<ExtendedAddr> {
+        fn new_address(&self, _: &str, _: &SecUtf8) -> Result<ExtendedAddr> {
             Ok(ExtendedAddr::BasicRedeem(
                 RedeemAddress::from_str("1fdf22497167a793ca794963ad6c95e6ffa0baba").unwrap(),
             ))
         }
 
-        fn balance(&self, _: &str, _: &SecStr) -> Result<Coin> {
+        fn balance(&self, _: &str, _: &SecUtf8) -> Result<Coin> {
             unreachable!()
         }
 
-        fn history(&self, _: &str, _: &SecStr) -> Result<Vec<TransactionChange>> {
+        fn history(&self, _: &str, _: &SecUtf8) -> Result<Vec<TransactionChange>> {
             unreachable!()
         }
 
-        fn unspent_transactions(&self, _: &str, _: &SecStr) -> Result<Vec<(TxoPointer, Coin)>> {
+        fn unspent_transactions(&self, _: &str, _: &SecUtf8) -> Result<Vec<(TxoPointer, Coin)>> {
             Ok(vec![
                 (
                     TxoPointer {
@@ -465,7 +465,7 @@ mod tests {
         fn create_and_broadcast_transaction(
             &self,
             _: &str,
-            _: &SecStr,
+            _: &SecUtf8,
             _: Vec<TxOut>,
             _: TxAttributes,
         ) -> Result<()> {
@@ -491,7 +491,7 @@ mod tests {
         let tx_aux = transaction_builder
             .build(
                 "name",
-                &SecStr::from("passphrase"),
+                &SecUtf8::from("passphrase"),
                 vec![TxOut {
                     address: ExtendedAddr::BasicRedeem(
                         RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20b4")
@@ -527,7 +527,7 @@ mod tests {
         let tx_aux = transaction_builder
             .build(
                 "name",
-                &SecStr::from("passphrase"),
+                &SecUtf8::from("passphrase"),
                 vec![TxOut {
                     address: ExtendedAddr::BasicRedeem(
                         RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20b4")
@@ -560,7 +560,7 @@ mod tests {
 
         let tx_aux = transaction_builder.build(
             "name",
-            &SecStr::from("passphrase"),
+            &SecUtf8::from("passphrase"),
             vec![TxOut {
                 address: ExtendedAddr::BasicRedeem(
                     RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20b4").unwrap(),

--- a/client-core/src/transaction_builder/unauthorized_transaction_builder.rs
+++ b/client-core/src/transaction_builder/unauthorized_transaction_builder.rs
@@ -1,4 +1,4 @@
-use secstr::SecStr;
+use secstr::SecUtf8;
 
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
@@ -15,7 +15,7 @@ impl TransactionBuilder for UnauthorizedTransactionBuilder {
     fn build<W: WalletClient>(
         &self,
         _name: &str,
-        _passphrase: &SecStr,
+        _passphrase: &SecUtf8,
         _outputs: Vec<TxOut>,
         _attributes: TxAttributes,
         _wallet_client: &W,

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -3,7 +3,7 @@ mod default_wallet_client;
 
 pub use default_wallet_client::DefaultWalletClient;
 
-use secstr::SecStr;
+use secstr::SecUtf8;
 
 use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
@@ -22,42 +22,42 @@ pub trait WalletClient: Send + Sync {
     fn wallets(&self) -> Result<Vec<String>>;
 
     /// Creates a new wallet with given name and returns wallet_id
-    fn new_wallet(&self, name: &str, passphrase: &SecStr) -> Result<String>;
+    fn new_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<String>;
 
     /// Retrieves all public keys corresponding to given wallet
-    fn private_keys(&self, name: &str, passphrase: &SecStr) -> Result<Vec<PrivateKey>>;
+    fn private_keys(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<PrivateKey>>;
 
     /// Retrieves all public keys corresponding to given wallet
-    fn public_keys(&self, name: &str, passphrase: &SecStr) -> Result<Vec<PublicKey>>;
+    fn public_keys(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<PublicKey>>;
 
     /// Retrieves all addresses corresponding to given wallet
-    fn addresses(&self, name: &str, passphrase: &SecStr) -> Result<Vec<ExtendedAddr>>;
+    fn addresses(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<ExtendedAddr>>;
 
     /// Retrieves private key corresponding to given address
     fn private_key(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
         address: &ExtendedAddr,
     ) -> Result<Option<PrivateKey>>;
 
     /// Generates a new public key for given wallet
-    fn new_public_key(&self, name: &str, passphrase: &SecStr) -> Result<PublicKey>;
+    fn new_public_key(&self, name: &str, passphrase: &SecUtf8) -> Result<PublicKey>;
 
     /// Generates a new address for given wallet
-    fn new_address(&self, name: &str, passphrase: &SecStr) -> Result<ExtendedAddr>;
+    fn new_address(&self, name: &str, passphrase: &SecUtf8) -> Result<ExtendedAddr>;
 
     /// Retrieves current balance of wallet
-    fn balance(&self, name: &str, passphrase: &SecStr) -> Result<Coin>;
+    fn balance(&self, name: &str, passphrase: &SecUtf8) -> Result<Coin>;
 
     /// Retrieves transaction history of wallet
-    fn history(&self, name: &str, passphrase: &SecStr) -> Result<Vec<TransactionChange>>;
+    fn history(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<TransactionChange>>;
 
     /// Retrieves all unspent transactions of wallet
     fn unspent_transactions(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
     ) -> Result<Vec<(TxoPointer, Coin)>>;
 
     /// Returns output of transaction with given id and index
@@ -67,7 +67,7 @@ pub trait WalletClient: Send + Sync {
     fn create_and_broadcast_transaction(
         &self,
         name: &str,
-        passphrase: &SecStr,
+        passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
     ) -> Result<()>;

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.3.2"
-secstr = { version = "0.3", features = ["serde"] }
+secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2", features = ["serde"] }

--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -1,6 +1,6 @@
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::jsonrpc_core;
-use secstr::SecStr;
+use secstr::SecUtf8;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -164,7 +164,7 @@ where
 #[derive(Debug, Deserialize)]
 pub struct WalletRequest {
     name: String,
-    passphrase: SecStr,
+    passphrase: SecUtf8,
 }
 
 #[cfg(test)]
@@ -382,7 +382,7 @@ mod tests {
     fn create_wallet_request(name: &str, passphrase: &str) -> WalletRequest {
         WalletRequest {
             name: name.to_owned(),
-            passphrase: SecStr::from(passphrase),
+            passphrase: SecUtf8::from(passphrase),
         }
     }
 }

--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -160,7 +160,6 @@ where
     }
 }
 
-// TODO: should use secure string and cleared when no longer needed
 #[derive(Debug, Deserialize)]
 pub struct WalletRequest {
     name: String,


### PR DESCRIPTION
Solution: Use `SecUtf8` instead of `SecStr` which supports deserialization from String to secure string