### PR TITLE
Problem: missing types and integration for account/staking-related functionality (CRO-96 / CRO-97)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starling 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starling 2.5.3 (git+https://github.com/ChosunOne/merkle_bit.git?rev=679a0bfe7ca104a86073ddcf1bf020909d6fd1f1)",
 ]
 
 [[package]]
@@ -1964,8 +1964,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "starling"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.5.3"
+source = "git+https://github.com/ChosunOne/merkle_bit.git?rev=679a0bfe7ca104a86073ddcf1bf020909d6fd1f1#679a0bfe7ca104a86073ddcf1bf020909d6fd1f1"
 
 [[package]]
 name = "stream-cipher"
@@ -2723,7 +2723,7 @@ dependencies = [
 "checksum sled 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a780266d241e270e52cab0010e11aecfc6d52e33aa98e52eb9792023abd23aa"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum starling 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57995493ee3a41061a6a2077d7ee8bef4a4c7dc2c3988b870efa883facef2498"
+"checksum starling 2.5.3 (git+https://github.com/ChosunOne/merkle_bit.git?rev=679a0bfe7ca104a86073ddcf1bf020909d6fd1f1)" = "<none>"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -15,7 +15,7 @@ bit-vec = "0.6.0"
 kvdb = "0.1"
 kvdb-rocksdb = "0.1.4"
 kvdb-memorydb = "0.1"
-starling = "2.5.2"
+starling = { version = "2.5.3", git = "https://github.com/ChosunOne/merkle_bit.git", rev = "679a0bfe7ca104a86073ddcf1bf020909d6fd1f1" }
 byteorder = "1.3.1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -18,6 +18,7 @@ use protobuf::well_known_types::Timestamp;
 use protobuf::Message;
 use serde::{Deserialize, Serialize};
 
+use crate::storage::account::AccountStorage;
 use crate::storage::*;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Encode, Decode)]
@@ -38,6 +39,8 @@ pub struct ChainNodeState {
 pub struct ChainNodeApp {
     /// the underlying key-value storage (+ possibly some info in the future)
     pub storage: Storage,
+    /// account trie storage
+    pub accounts: AccountStorage,
     /// valid transactions after DeliverTx before EndBlock/Commit
     pub delivered_txs: Vec<TxAux>,
     /// a reference to genesis (used when there is no committed state)
@@ -54,6 +57,7 @@ impl ChainNodeApp {
         genesis_app_hash: [u8; HASH_SIZE_256],
         chain_id: &str,
         storage: Storage,
+        accounts: AccountStorage,
     ) -> Self {
         let stored_gah = storage
             .db
@@ -84,6 +88,7 @@ impl ChainNodeApp {
             .expect("failed to decode two last hex digits in chain ID")[0];
         ChainNodeApp {
             storage,
+            accounts,
             delivered_txs: Vec::new(),
             chain_hex_id,
             genesis_app_hash,
@@ -99,7 +104,13 @@ impl ChainNodeApp {
     /// * `gah` - hex-encoded genesis app hash
     /// * `chain_id` - the chain ID set in Tendermint genesis.json (our name convention is that the last two characters should be hex digits)
     /// * `storage` - underlying storage to be used (in-mem or persistent)
-    pub fn new_with_storage(gah: &str, chain_id: &str, storage: Storage) -> Self {
+    /// * `accounts` - underlying storage for account tries to be used (in-mem or persistent)    
+    pub fn new_with_storage(
+        gah: &str,
+        chain_id: &str,
+        storage: Storage,
+        accounts: AccountStorage,
+    ) -> Self {
         let decoded_gah = hex::decode(gah).expect("failed to decode genesis app hash");
         let mut genesis_app_hash = [0u8; HASH_SIZE_256];
         genesis_app_hash.copy_from_slice(&decoded_gah[..]);
@@ -113,7 +124,13 @@ impl ChainNodeApp {
             let data = last_app_state.to_vec();
             let last_state =
                 ChainNodeState::decode(&mut data.as_slice()).expect("deserialize app state");
-            ChainNodeApp::restore_from_storage(last_state, genesis_app_hash, chain_id, storage)
+            ChainNodeApp::restore_from_storage(
+                last_state,
+                genesis_app_hash,
+                chain_id,
+                storage,
+                accounts,
+            )
         } else {
             info!("no last app state stored");
             let chain_hex_id = hex::decode(&chain_id[chain_id.len() - 2..])
@@ -127,6 +144,7 @@ impl ChainNodeApp {
                 .expect("genesis app hash should be stored");
             ChainNodeApp {
                 storage,
+                accounts,
                 delivered_txs: Vec::new(),
                 chain_hex_id,
                 genesis_app_hash,
@@ -141,9 +159,20 @@ impl ChainNodeApp {
     ///
     /// * `gah` - hex-encoded genesis app hash
     /// * `chain_id` - the chain ID set in Tendermint genesis.json (our name convention is that the last two characters should be hex digits)
-    /// * `storage_config` - configuration for storage (currently only the path, but TODO: more options, e.g. SSD or HDD params)
-    pub fn new(gah: &str, chain_id: &str, storage_config: &StorageConfig<'_>) -> ChainNodeApp {
-        ChainNodeApp::new_with_storage(gah, chain_id, Storage::new(storage_config))
+    /// * `node_storage_config` - configuration for node storage (currently only the path, but TODO: more options, e.g. SSD or HDD params)
+    /// * `account_storage_config` - configuration for account storage
+    pub fn new(
+        gah: &str,
+        chain_id: &str,
+        node_storage_config: &StorageConfig<'_>,
+        account_storage_config: &StorageConfig<'_>,
+    ) -> ChainNodeApp {
+        ChainNodeApp::new_with_storage(
+            gah,
+            chain_id,
+            Storage::new(node_storage_config),
+            AccountStorage::new(Storage::new(account_storage_config), 20).expect("account db"),
+        )
     }
 
     fn check_and_store_consensus_params(

--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -31,7 +31,7 @@ impl ChainNodeApp {
                         inittx.put(COL_WITNESS, &txid[..], &witness.encode());
                         update_utxos_commit(&tx, self.storage.db.clone(), &mut inittx);
                     }
-                    _ => unimplemented!("TODO -- account-related TX commits"),
+                    _ => unimplemented!("MUST_TODO -- account-related TX commits"),
                 }
             }
             new_state.rewards_pool.last_block_height = new_state.last_block_height;

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -266,6 +266,7 @@ mod tests {
             block_time: 0,
             rewards_pool: RewardsPoolState::new(1.into(), 0),
             fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
+            last_account_root_hash: [0u8; 32],
         }
     }
 

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -76,8 +76,10 @@ impl ChainNodeApp {
                         min_fee_computed: min_fee,
                         chain_hex_id: self.chain_hex_id,
                         previous_block_time: state.block_time,
+                        last_account_root_hash: state.last_account_root_hash,
                     },
                     self.storage.db.clone(),
+                    &self.accounts,
                 );
                 if fee_paid.is_ok() {
                     resp.set_code(0);

--- a/chain-abci/src/main.rs
+++ b/chain-abci/src/main.rs
@@ -27,7 +27,8 @@ fn main() {
         ChainNodeApp::new(
             &genesis_app_hash,
             &chain_id,
-            &StorageConfig { db_path: data },
+            &StorageConfig::new(data, StorageType::Node),
+            &StorageConfig::new(data, StorageType::AccountTrie),
         ),
     );
 }

--- a/chain-abci/src/storage/account/tree.rs
+++ b/chain-abci/src/storage/account/tree.rs
@@ -116,7 +116,7 @@ impl Branch for TreeBranch {
     }
 
     #[inline]
-    fn deconstruct(self) -> (u64, [u8; KEY_LEN], [u8; KEY_LEN], u8, [u8; KEY_LEN]) {
+    fn decompose(self) -> (u64, [u8; KEY_LEN], [u8; KEY_LEN], u8, [u8; KEY_LEN]) {
         (
             self.get_count(),
             self.zero,
@@ -172,7 +172,7 @@ impl Leaf for TreeLeaf {
 
     /// Decomposes the struct into its constituent parts.
     #[inline]
-    fn deconstruct(self) -> ([u8; KEY_LEN], [u8; KEY_LEN]) {
+    fn decompose(self) -> ([u8; KEY_LEN], [u8; KEY_LEN]) {
         (self.key, self.data)
     }
 }

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -1,16 +1,22 @@
+use crate::storage::account::AccountStorage;
 use crate::storage::{COL_BODIES, COL_TX_META};
 use bit_vec::BitVec;
 use chain_core::common::Timespec;
 use chain_core::init::coin::{Coin, CoinError};
+use chain_core::state::account::{AccountOpWitness, DepositBondTx, UnbondTx, WithdrawUnbondedTx};
 use chain_core::tx::fee::Fee;
+use chain_core::tx::witness::TxWitness;
 use chain_core::tx::{data::Tx, TxAux};
 use kvdb::{DBTransaction, KeyValueDB};
 use parity_codec::Decode;
 use secp256k1;
+use starling::constants::KEY_LEN;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::{fmt, io};
+
+pub type StarlingFixedKey = [u8; KEY_LEN];
 
 /// All possible TX validation errors
 #[derive(Debug)]
@@ -90,115 +96,169 @@ pub struct ChainInfo {
     pub min_fee_computed: Fee,
     pub chain_hex_id: u8,
     pub previous_block_time: Timespec,
+    pub last_account_root_hash: StarlingFixedKey,
+}
+
+/// checks TransferTx -- TODO: this will be moved to an enclave
+/// TODO: when more address/sigs available, check Redeem addresses are never in outputs?
+fn verify_transfer(
+    maintx: &Tx,
+    witness: &TxWitness,
+    extra_info: ChainInfo,
+    db: Arc<dyn KeyValueDB>,
+) -> Result<Coin, Error> {
+    // TODO: check other attributes?
+    // check that chain IDs match
+    if extra_info.chain_hex_id != maintx.attributes.chain_hex_id {
+        return Err(Error::WrongChainHexId);
+    }
+    // check that there are inputs
+    if maintx.inputs.is_empty() {
+        return Err(Error::NoInputs);
+    }
+
+    // check that there are outputs
+    if maintx.outputs.is_empty() {
+        return Err(Error::NoOutputs);
+    }
+
+    // check that there are no duplicate inputs
+    let mut inputs = BTreeSet::new();
+    if !maintx.inputs.iter().all(|x| inputs.insert(x)) {
+        return Err(Error::DuplicateInputs);
+    }
+
+    // check that all outputs have a non-zero amount
+    if !maintx.outputs.iter().all(|x| x.value > Coin::zero()) {
+        return Err(Error::ZeroCoin);
+    }
+
+    // Note: we don't need to check against MAX_COIN because Coin's
+    // constructor should already do it.
+
+    // TODO: check address attributes?
+
+    // verify transaction witnesses
+    if maintx.inputs.len() < witness.len() {
+        return Err(Error::UnexpectedWitnesses);
+    }
+
+    if maintx.inputs.len() > witness.len() {
+        return Err(Error::MissingWitnesses);
+    }
+
+    let mut incoins = Coin::zero();
+
+    // verify that txids of inputs correspond to the owner/signer
+    // and it'd check they are not spent
+    for (txin, in_witness) in maintx.inputs.iter().zip(witness.iter()) {
+        let txo = db.get(COL_TX_META, &txin.id[..]);
+        match txo {
+            Ok(Some(v)) => {
+                let bv = BitVec::from_bytes(&v).get(txin.index);
+                if bv.is_none() {
+                    return Err(Error::InvalidInput);
+                }
+                if bv.unwrap() {
+                    return Err(Error::InputSpent);
+                }
+                let txdata = db.get(COL_BODIES, &txin.id[..]).unwrap().unwrap().to_vec();
+                let tx = Tx::decode(&mut txdata.as_slice()).unwrap();
+                if txin.index >= tx.outputs.len() {
+                    return Err(Error::InvalidInput);
+                }
+                let txout = &tx.outputs[txin.index];
+                if let Some(valid_from) = &txout.valid_from {
+                    if *valid_from > extra_info.previous_block_time {
+                        return Err(Error::OutputInTimelock);
+                    }
+                }
+
+                let wv = in_witness.verify_tx_address(&maintx, &txout.address);
+                if wv.is_err() {
+                    return Err(Error::EcdsaCrypto(wv.unwrap_err()));
+                }
+                let sum = incoins + txout.value;
+                if sum.is_err() {
+                    return Err(Error::InvalidSum(sum.unwrap_err()));
+                } else {
+                    incoins = sum.unwrap();
+                }
+            }
+            Ok(None) => {
+                return Err(Error::InvalidInput);
+            }
+            Err(e) => {
+                return Err(Error::IoError(e));
+            }
+        }
+    }
+    // check sum(input amounts) >= sum(output amounts) + minimum fee
+    // TODO: should the fee be fixed / validation would reject TX if it pays more than the below minimum?
+    let min_fee: Coin = extra_info.min_fee_computed.to_coin();
+
+    let outsum = maintx.get_output_total().and_then(|x| x + min_fee);
+    if outsum.is_err() {
+        return Err(Error::InvalidSum(outsum.unwrap_err()));
+    }
+    let outcoins = outsum.unwrap();
+    if incoins < outcoins {
+        return Err(Error::InputOutputDoNotMatch);
+    }
+    Ok((incoins - outcoins).and_then(|x| x + min_fee).unwrap())
+}
+
+// MUST_TODO
+fn verify_bonded_deposit(
+    _maintx: &DepositBondTx,
+    _witness: &TxWitness,
+    _extra_info: ChainInfo,
+    _db: Arc<dyn KeyValueDB>,
+    _accounts: &AccountStorage,
+) -> Result<Coin, Error> {
+    unimplemented!("MUST_TODO -- account-related TX validation")
+}
+
+// MUST_TODO
+fn verify_unbonding(
+    _maintx: &UnbondTx,
+    _witness: &AccountOpWitness,
+    _extra_info: ChainInfo,
+    _accounts: &AccountStorage,
+) -> Result<Coin, Error> {
+    unimplemented!("MUST_TODO -- account-related TX validation")
+}
+
+// MUST_TODO
+fn verify_unbonded_withdraw(
+    _maintx: &WithdrawUnbondedTx,
+    _witness: &AccountOpWitness,
+    _extra_info: ChainInfo,
+    _db: Arc<dyn KeyValueDB>,
+    _accounts: &AccountStorage,
+) -> Result<Coin, Error> {
+    unimplemented!("MUST_TODO -- account-related TX validation")
 }
 
 /// Checks TX against the current DB and returns an `Error` if something fails.
 /// If OK, returns the paid fee.
-/// TODO: when more address/sigs available, check Redeem addresses are never in outputs?
-pub fn verify(txaux: &TxAux, extra_info: ChainInfo, db: Arc<dyn KeyValueDB>) -> Result<Fee, Error> {
+pub fn verify(
+    txaux: &TxAux,
+    extra_info: ChainInfo,
+    db: Arc<dyn KeyValueDB>,
+    accounts: &AccountStorage,
+) -> Result<Fee, Error> {
     let paid_fee = match txaux {
-        TxAux::TransferTx(maintx, witness) => {
-            // TODO: check other attributes?
-            // check that chain IDs match
-            if extra_info.chain_hex_id != maintx.attributes.chain_hex_id {
-                return Err(Error::WrongChainHexId);
-            }
-            // check that there are inputs
-            if maintx.inputs.is_empty() {
-                return Err(Error::NoInputs);
-            }
-
-            // check that there are outputs
-            if maintx.outputs.is_empty() {
-                return Err(Error::NoOutputs);
-            }
-
-            // check that there are no duplicate inputs
-            let mut inputs = BTreeSet::new();
-            if !maintx.inputs.iter().all(|x| inputs.insert(x)) {
-                return Err(Error::DuplicateInputs);
-            }
-
-            // check that all outputs have a non-zero amount
-            if !maintx.outputs.iter().all(|x| x.value > Coin::zero()) {
-                return Err(Error::ZeroCoin);
-            }
-
-            // Note: we don't need to check against MAX_COIN because Coin's
-            // constructor should already do it.
-
-            // TODO: check address attributes?
-
-            // verify transaction witnesses
-            if maintx.inputs.len() < witness.len() {
-                return Err(Error::UnexpectedWitnesses);
-            }
-
-            if maintx.inputs.len() > witness.len() {
-                return Err(Error::MissingWitnesses);
-            }
-
-            let mut incoins = Coin::zero();
-
-            // verify that txids of inputs correspond to the owner/signer
-            // and it'd check they are not spent
-            for (txin, in_witness) in maintx.inputs.iter().zip(witness.iter()) {
-                let txo = db.get(COL_TX_META, &txin.id[..]);
-                match txo {
-                    Ok(Some(v)) => {
-                        let bv = BitVec::from_bytes(&v).get(txin.index);
-                        if bv.is_none() {
-                            return Err(Error::InvalidInput);
-                        }
-                        if bv.unwrap() {
-                            return Err(Error::InputSpent);
-                        }
-                        let txdata = db.get(COL_BODIES, &txin.id[..]).unwrap().unwrap().to_vec();
-                        let tx = Tx::decode(&mut txdata.as_slice()).unwrap();
-                        if txin.index >= tx.outputs.len() {
-                            return Err(Error::InvalidInput);
-                        }
-                        let txout = &tx.outputs[txin.index];
-                        if let Some(valid_from) = &txout.valid_from {
-                            if *valid_from > extra_info.previous_block_time {
-                                return Err(Error::OutputInTimelock);
-                            }
-                        }
-
-                        let wv = in_witness.verify_tx_address(&maintx, &txout.address);
-                        if wv.is_err() {
-                            return Err(Error::EcdsaCrypto(wv.unwrap_err()));
-                        }
-                        let sum = incoins + txout.value;
-                        if sum.is_err() {
-                            return Err(Error::InvalidSum(sum.unwrap_err()));
-                        } else {
-                            incoins = sum.unwrap();
-                        }
-                    }
-                    Ok(None) => {
-                        return Err(Error::InvalidInput);
-                    }
-                    Err(e) => {
-                        return Err(Error::IoError(e));
-                    }
-                }
-            }
-            // check sum(input amounts) >= sum(output amounts) + minimum fee
-            // TODO: should the fee be fixed / validation would reject TX if it pays more than the below minimum?
-            let min_fee: Coin = extra_info.min_fee_computed.to_coin();
-
-            let outsum = maintx.get_output_total().and_then(|x| x + min_fee);
-            if outsum.is_err() {
-                return Err(Error::InvalidSum(outsum.unwrap_err()));
-            }
-            let outcoins = outsum.unwrap();
-            if incoins < outcoins {
-                return Err(Error::InputOutputDoNotMatch);
-            }
-            (incoins - outcoins).and_then(|x| x + min_fee).unwrap()
+        TxAux::TransferTx(maintx, witness) => verify_transfer(maintx, witness, extra_info, db)?,
+        TxAux::DepositStakeTx(maintx, witness) => {
+            verify_bonded_deposit(maintx, witness, extra_info, db, accounts)?
         }
-        _ => unimplemented!("TODO -- account-related TX validation"),
+        TxAux::UnbondStakeTx(maintx, witness) => {
+            verify_unbonding(maintx, witness, extra_info, accounts)?
+        }
+        TxAux::WithdrawUnbondedStakeTx(maintx, witness) => {
+            verify_unbonded_withdraw(maintx, witness, extra_info, db, accounts)?
+        }
     };
     Ok(Fee::new(paid_fee))
 }
@@ -206,7 +266,7 @@ pub fn verify(txaux: &TxAux, extra_info: ChainInfo, db: Arc<dyn KeyValueDB>) -> 
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::storage::{COL_TX_META, NUM_COLUMNS};
+    use crate::storage::{Storage, COL_TX_META, NUM_COLUMNS};
     use chain_core::init::address::RedeemAddress;
     use chain_core::tx::data::{address::ExtendedAddr, input::TxoPointer, output::TxOut};
     use chain_core::tx::fee::FeeAlgorithm;
@@ -234,7 +294,14 @@ pub mod tests {
 
     fn prepare_app_valid_tx(
         timelocked: bool,
-    ) -> (Arc<dyn KeyValueDB>, TxAux, Tx, TxWitness, SecretKey) {
+    ) -> (
+        Arc<dyn KeyValueDB>,
+        TxAux,
+        Tx,
+        TxWitness,
+        SecretKey,
+        AccountStorage,
+    ) {
         let db = create_db();
 
         let mut tx = Tx::new();
@@ -274,22 +341,30 @@ pub mod tests {
 
         let witness: Vec<TxInWitness> = vec![get_tx_witness(secp, &tx, &secret_key)];
         let txaux = TxAux::new(tx.clone(), witness.clone().into());
-        (db, txaux, tx.clone(), witness.into(), secret_key)
+        (
+            db,
+            txaux,
+            tx.clone(),
+            witness.into(),
+            secret_key,
+            AccountStorage::new(Storage::new_db(create_db()), 20).expect("account db"),
+        )
     }
 
     const DEFAULT_CHAIN_ID: u8 = 0;
 
     #[test]
     fn existing_utxo_input_tx_should_verify() {
-        let (db, txaux, _, _, _) = prepare_app_valid_tx(false);
+        let (db, txaux, _, _, _, accounts) = prepare_app_valid_tx(false);
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
                 .expect("invalid fee policy"),
             chain_hex_id: DEFAULT_CHAIN_ID,
             previous_block_time: 0,
+            last_account_root_hash: [0u8; 32],
         };
-        let result = verify(&txaux, extra_info, db);
+        let result = verify(&txaux, extra_info, db, &accounts);
         assert!(result.is_ok());
     }
 
@@ -306,19 +381,20 @@ pub mod tests {
 
     #[test]
     fn test_verify_fail() {
-        let (db, txaux, tx, witness, secret_key) = prepare_app_valid_tx(false);
+        let (db, txaux, tx, witness, secret_key, accounts) = prepare_app_valid_tx(false);
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
                 .expect("invalid fee policy"),
             chain_hex_id: DEFAULT_CHAIN_ID,
             previous_block_time: 0,
+            last_account_root_hash: [0u8; 32],
         };
         // WrongChainHexId
         {
             let mut extra_info = extra_info.clone();
             extra_info.chain_hex_id = DEFAULT_CHAIN_ID + 1;
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::WrongChainHexId);
         }
         // NoInputs
@@ -326,7 +402,7 @@ pub mod tests {
             let mut tx = tx.clone();
             tx.inputs.clear();
             let txaux = TxAux::TransferTx(tx, witness.clone());
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::NoInputs);
         }
         // NoOutputs
@@ -334,7 +410,7 @@ pub mod tests {
             let mut tx = tx.clone();
             tx.outputs.clear();
             let txaux = TxAux::TransferTx(tx, witness.clone());
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::NoOutputs);
         }
         // DuplicateInputs
@@ -343,7 +419,7 @@ pub mod tests {
             let inp = tx.inputs[0].clone();
             tx.inputs.push(inp);
             let txaux = TxAux::TransferTx(tx, witness.clone());
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::DuplicateInputs);
         }
         // ZeroCoin
@@ -351,7 +427,7 @@ pub mod tests {
             let mut tx = tx.clone();
             tx.outputs[0].value = Coin::zero();
             let txaux = TxAux::TransferTx(tx, witness.clone());
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::ZeroCoin);
         }
         // UnexpectedWitnesses
@@ -360,13 +436,13 @@ pub mod tests {
             let wp = witness[0].clone();
             witness.push(wp);
             let txaux = TxAux::TransferTx(tx.clone(), witness);
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::UnexpectedWitnesses);
         }
         // MissingWitnesses
         {
             let txaux = TxAux::TransferTx(tx.clone(), vec![].into());
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::MissingWitnesses);
         }
         // InvalidSum
@@ -378,7 +454,7 @@ pub mod tests {
             let mut witness = witness.clone();
             witness[0] = get_tx_witness(Secp256k1::new(), &tx, &secret_key);
             let txaux = TxAux::TransferTx(tx, witness);
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(
                 &result,
                 Error::InvalidSum(CoinError::OutOfBound(Coin::max().into())),
@@ -394,7 +470,7 @@ pub mod tests {
             );
             db.write(inittx).unwrap();
 
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::InputSpent);
 
             let mut reset = db.transaction();
@@ -415,7 +491,7 @@ pub mod tests {
                 &SecretKey::from_slice(&[0x11; 32]).expect("32 bytes, within curve order"),
             );
             let txaux = TxAux::TransferTx(tx.clone(), witness);
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(
                 &result,
                 Error::EcdsaCrypto(secp256k1::Error::InvalidPublicKey),
@@ -423,7 +499,7 @@ pub mod tests {
         }
         // InvalidInput
         {
-            let result = verify(&txaux, extra_info, create_db());
+            let result = verify(&txaux, extra_info, create_db(), &accounts);
             expect_error(&result, Error::InvalidInput);
         }
         // InputOutputDoNotMatch
@@ -434,13 +510,13 @@ pub mod tests {
             tx.outputs[0].value = (tx.outputs[0].value + Coin::one()).unwrap();
             witness[0] = get_tx_witness(Secp256k1::new(), &tx, &secret_key);
             let txaux = TxAux::TransferTx(tx, witness);
-            let result = verify(&txaux, extra_info, db.clone());
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::InputOutputDoNotMatch);
         }
         // OutputInTimelock
         {
-            let (db, txaux, _, _, _) = prepare_app_valid_tx(true);
-            let result = verify(&txaux, extra_info, db.clone());
+            let (db, txaux, _, _, _, accounts) = prepare_app_valid_tx(true);
+            let result = verify(&txaux, extra_info, db.clone(), &accounts);
             expect_error(&result, Error::OutputInTimelock);
         }
     }

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -198,6 +198,7 @@ pub fn verify(txaux: &TxAux, extra_info: ChainInfo, db: Arc<dyn KeyValueDB>) -> 
             }
             (incoins - outcoins).and_then(|x| x + min_fee).unwrap()
         }
+        _ => unimplemented!("TODO -- account-related TX validation"),
     };
     Ok(Fee::new(paid_fee))
 }

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -1,8 +1,14 @@
 use crate::common::{hash256, Timespec, HASH_SIZE_256};
 use crate::init::address::RedeemAddress;
 use crate::init::coin::Coin;
+use crate::tx::data::input::TxoPointer;
+use crate::tx::data::output::TxOut;
+use crate::tx::witness::{tree::RawSignature, EcdsaSignature};
 use blake2::Blake2s;
-use parity_codec::{Decode, Encode};
+use parity_codec::{Decode, Encode, Input, Output};
+use secp256k1::{RecoverableSignature, RecoveryId};
+use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// reference counter in the sparse patricia merkle tree/trie
 pub type Count = u64;
@@ -49,5 +55,93 @@ impl Account {
     /// the account address itself is ETH-style address (20 bytes from keccak hash of public key)
     pub fn key(&self) -> [u8; HASH_SIZE_256] {
         hash256::<Blake2s>(&self.address)
+    }
+}
+
+/// attributes in account-related transactions
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct AccountOpAttributes {
+    pub chain_hex_id: [u8; 1],
+    // TODO: Other attributes?
+}
+
+/// takes UTXOs inputs, deposits them in the specified account's bonded amount - fee
+/// (updates account's bonded + nonce)
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct DepositBondTx {
+    pub inputs: Vec<TxoPointer>,
+    pub to_account: RedeemAddress,
+    pub value: Coin,
+    pub attributes: AccountOpAttributes,
+}
+
+impl fmt::Display for DepositBondTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for input in self.inputs.iter() {
+            writeln!(f, "-> {}", input)?;
+        }
+        writeln!(f, "   {} {} (bonded) ->", self.to_account, self.value)?;
+        write!(f, "")
+    }
+}
+
+/// updates the account (TODO: implicit from the witness?) by moving some of the bonded amount - fee into unbonded,
+/// and setting the unbonded_from to last_block_time+min_unbonding_time (network parameter)
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct UnbondTx {
+    pub value: Coin,
+    pub nonce: Nonce,
+    pub attributes: AccountOpAttributes,
+}
+
+impl fmt::Display for UnbondTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "unbonded: {} (nonce: {})", self.value, self.nonce)?;
+        write!(f, "")
+    }
+}
+
+/// takes the account (TODO: implicit from the witness?) and creates UTXOs
+/// (update's account's unbonded + nonce)
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct WithdrawUnbondedTx {
+    pub value: Coin,
+    pub nonce: Nonce,
+    pub outputs: Vec<TxOut>,
+    pub attributes: AccountOpAttributes,
+}
+
+impl fmt::Display for WithdrawUnbondedTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "-> {} (unbonded) (nonce: {})", self.value, self.nonce)?;
+        for output in self.outputs.iter() {
+            writeln!(f, "   {} ->", output)?;
+        }
+        write!(f, "")
+    }
+}
+
+/// A witness for account operations
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AccountOpWitness(EcdsaSignature);
+
+impl Encode for AccountOpWitness {
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        let (recovery_id, serialized_sig) = self.0.serialize_compact();
+        // recovery_id is one of 0 | 1 | 2 | 3
+        let rid = recovery_id.to_i32() as u8;
+        dest.push_byte(rid);
+        serialized_sig.encode_to(dest);
+    }
+}
+
+impl Decode for AccountOpWitness {
+    fn decode<I: Input>(input: &mut I) -> Option<Self> {
+        let rid: u8 = input.read_byte()?;
+        let raw_sig = RawSignature::decode(input)?;
+        let recovery_id = RecoveryId::from_i32(i32::from(rid)).ok()?;
+        let sig = RecoverableSignature::from_compact(&raw_sig, recovery_id).ok()?;
+        Some(AccountOpWitness(sig))
     }
 }

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -59,10 +59,32 @@ impl Account {
 }
 
 /// attributes in account-related transactions
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct AccountOpAttributes {
-    pub chain_hex_id: [u8; 1],
+    pub chain_hex_id: u8,
     // TODO: Other attributes?
+}
+
+impl Encode for AccountOpAttributes {
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        dest.push_byte(0);
+        dest.push_byte(1);
+        dest.push_byte(self.chain_hex_id);
+    }
+}
+
+impl Decode for AccountOpAttributes {
+    fn decode<I: Input>(input: &mut I) -> Option<Self> {
+        let tag = input.read_byte()?;
+        let constructor_len = input.read_byte()?;
+        match (tag, constructor_len) {
+            (0, 1) => {
+                let chain_hex_id: u8 = input.read_byte()?;
+                Some(AccountOpAttributes { chain_hex_id })
+            }
+            _ => None,
+        }
+    }
 }
 
 /// takes UTXOs inputs, deposits them in the specified account's bonded amount - fee

--- a/chain-core/src/state/mod.rs
+++ b/chain-core/src/state/mod.rs
@@ -1,7 +1,9 @@
 pub mod account;
 
 use crate::common::{hash256, H256};
+use crate::init::address::RedeemAddress;
 use crate::init::coin::Coin;
+use crate::tx::witness::tree::RawPubkey;
 use blake2::Blake2s;
 use parity_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
@@ -30,4 +32,27 @@ impl RewardsPoolState {
             last_block_height,
         }
     }
+}
+
+/// The protobuf structure currently has "String" to denote the type / length
+/// and variable length byte array. In this internal representation,
+/// it's desirable to keep it restricted and compact. (TM should be encoding using the compressed form.)
+#[derive(Encode, Decode)]
+pub enum TendermintValidatorPubKey {
+    Ed25519([u8; 32]),
+    Secp256k1(RawPubkey),
+    // there's also PubKeyMultisigThreshold, but that probably wouldn't be used for individual nodes / validators
+    // TODO: some other schemes when they are added in TM?
+}
+
+/// holds state about a node responsible for transaction validation / block signing and service node whitelist management
+#[derive(Encode, Decode)]
+pub struct CouncilNode {
+    // account with the required staked amount
+    pub staking_account_address: RedeemAddress,
+    // Tendermint consensus validator-associated public key
+    pub consensus_pubkey: TendermintValidatorPubKey,
+    // update counter
+    pub nonce: usize,
+    // TODO: public keys / addresses for other operations
 }

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -514,6 +514,9 @@ mod tests {
                 assert_eq!(1, tx.outputs.len());
                 wallet_client.assert_fee(fee, tx);
             }
+            _ => unreachable!(
+                "TODO: client-core transaction builder doesn't do account/staking-related TX"
+            ),
         }
     }
 
@@ -548,6 +551,9 @@ mod tests {
                 assert_eq!(2, tx.outputs.len());
                 wallet_client.assert_fee(fee, tx);
             }
+            _ => unreachable!(
+                "TODO: client-core transaction builder doesn't do account/staking-related TX"
+            ),
         }
     }
 

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -515,7 +515,7 @@ mod tests {
                 wallet_client.assert_fee(fee, tx);
             }
             _ => unreachable!(
-                "TODO: client-core transaction builder doesn't do account/staking-related TX"
+                "MUST_TODO: client-core transaction builder doesn't do account/staking-related TX"
             ),
         }
     }
@@ -552,7 +552,7 @@ mod tests {
                 wallet_client.assert_fee(fee, tx);
             }
             _ => unreachable!(
-                "TODO: client-core transaction builder doesn't do account/staking-related TX"
+                "MUST_TODO: client-core transaction builder doesn't do account/staking-related TX"
             ),
         }
     }

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -158,6 +158,9 @@ where
                 .into_iter()
                 .map(|tx_aux| match tx_aux {
                     TxAux::TransferTx(tx, _) => tx,
+                    _ => unimplemented!(
+                        "TODO: client-index processing of account/staking-related operations"
+                    ),
                 })
                 .filter(|tx| valid_ids.contains(&tx.id()))
                 .collect::<Vec<Tx>>();

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -159,7 +159,7 @@ where
                 .map(|tx_aux| match tx_aux {
                     TxAux::TransferTx(tx, _) => tx,
                     _ => unimplemented!(
-                        "TODO: client-index processing of account/staking-related operations"
+                        "MUST_TODO: client-index processing of account/staking-related operations"
                     ),
                 })
                 .filter(|tx| valid_ids.contains(&tx.id()))


### PR DESCRIPTION
Solution: extended TX types, added TODO stubs in pattern matches; extended storage to choose between main and account-related storage; moved to use a nightly merkle_bit crate (as the old struct wasn't Sync+Send)

--

this is more of WIP PR to add core data types before breaking changes due to InitConfig, InitChain processing, TX validation etc. come in.