### PR TITLE
Problem: (CRO-120) SecStr bumped version to 0.3.2 on crates.io but we are still pointing to GitHub repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quest 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -333,7 +333,7 @@ dependencies = [
  "miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -353,7 +353,7 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)",
- "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -383,7 +383,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "secstr"
 version = "0.3.2"
-source = "git+https://github.com/myfreeweb/secstr?tag=v0.3.2#4e17a9fdee092ff9c26bcbbbb58a16c4c97faff4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2712,7 +2712,7 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)" = "<none>"
-"checksum secstr 0.3.2 (git+https://github.com/myfreeweb/secstr?tag=v0.3.2)" = "<none>"
+"checksum secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb003d53cef244a97516226b01155057c7fa6eb52914933c32f6c98a84182188"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -12,6 +12,6 @@ client-core = { path = "../client-core" }
 structopt = "0.2"
 failure = "0.1"
 quest = "0.3"
-secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2" }
+secstr = "0.3.2"
 hex = "0.3"
 prettytable-rs = "0.8"

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -12,7 +12,7 @@ miscreant = "0.4"
 blake2 = "0.8"
 hex = "0.3"
 base64 = "0.10"
-secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2" }
+secstr = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 sled = { version = "0.24", optional = true }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.3"
 zeroize = "0.6"
 byteorder = "1.3"
 parity-codec = { features = ["derive"], version = "3.5.1" }
-secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2" }
+secstr = "0.3.2"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.3.2"
-secstr = { git = "https://github.com/myfreeweb/secstr", tag = "v0.3.2", features = ["serde"] }
+secstr = { version = "0.3.2", features = ["serde"] }


### PR DESCRIPTION
Solution: Changed from pointing to GitHub repository `v0.3.2` tag to crates.io