### PR TITLE
Problem: (CRO-123) No support for creating tree multi-sig addresses in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "client-index 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=4c178ca90965ccf5b1b235e346e836ca65b2a549)",

--- a/chain-core/src/common/merkle_tree.rs
+++ b/chain-core/src/common/merkle_tree.rs
@@ -185,6 +185,7 @@ impl<T> Proof<T> {
     }
 
     /// Returns root hash of this proof
+    #[inline]
     pub fn root_hash(&self) -> H256 {
         self.root_hash
     }
@@ -295,7 +296,6 @@ impl<T> MerkleTree<T> {
     }
 
     /// Generates inclusion proof for given value. Returns `None` if given value is not present in merkle tree
-    #[inline]
     pub fn generate_proof(&self, value: T) -> Option<Proof<T>>
     where
         T: AsRef<[u8]> + Clone,
@@ -326,7 +326,6 @@ pub enum NodeType {
     Intermediate,
 }
 
-#[inline]
 fn combine(left: &H256, right: &H256) -> H512 {
     let mut hash = [0; HASH_SIZE_256 * 2];
     hash[0..HASH_SIZE_256].copy_from_slice(left);
@@ -361,6 +360,7 @@ pub struct PairIter<T> {
 }
 
 impl<T> From<IntoIter<T>> for PairIter<T> {
+    #[inline]
     fn from(inner: IntoIter<T>) -> Self {
         Self { inner }
     }

--- a/chain-core/src/tx/witness/tree.rs
+++ b/chain-core/src/tx/witness/tree.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt;
 
 use parity_codec::{Decode, Encode, Input, Output};
@@ -29,6 +30,36 @@ impl PartialEq for RawPubkey {
 }
 
 impl Eq for RawPubkey {}
+
+impl PartialOrd for RawPubkey {
+    #[inline]
+    fn partial_cmp(&self, other: &RawPubkey) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&&self.0[..], &&other.0[..])
+    }
+    #[inline]
+    fn lt(&self, other: &RawPubkey) -> bool {
+        PartialOrd::lt(&&self.0[..], &&other.0[..])
+    }
+    #[inline]
+    fn le(&self, other: &RawPubkey) -> bool {
+        PartialOrd::le(&&self.0[..], &&other.0[..])
+    }
+    #[inline]
+    fn ge(&self, other: &RawPubkey) -> bool {
+        PartialOrd::ge(&&self.0[..], &&other.0[..])
+    }
+    #[inline]
+    fn gt(&self, other: &RawPubkey) -> bool {
+        PartialOrd::gt(&&self.0[..], &&other.0[..])
+    }
+}
+
+impl Ord for RawPubkey {
+    #[inline]
+    fn cmp(&self, other: &RawPubkey) -> Ordering {
+        Ord::cmp(&&self.0[..], &&other.0[..])
+    }
+}
 
 impl fmt::Debug for RawPubkey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/client-cli/src/command/wallet_command.rs
+++ b/client-cli/src/command/wallet_command.rs
@@ -27,9 +27,9 @@ impl WalletCommand {
 
     fn new_wallet<T: WalletClient>(wallet_client: T, name: &str) -> Result<()> {
         let passphrase = ask_passphrase()?;
-        let wallet_id = wallet_client.new_wallet(name, &passphrase)?;
+        wallet_client.new_wallet(name, &passphrase)?;
 
-        success(&format!("Wallet created with ID: {}", wallet_id));
+        success(&format!("Wallet created with name: {}", name));
         Ok(())
     }
 

--- a/client-common/src/error.rs
+++ b/client-common/src/error.rs
@@ -44,6 +44,9 @@ pub enum ErrorKind {
     /// Wallet not found
     #[fail(display = "Wallet not found")]
     WalletNotFound,
+    /// Address not found
+    #[fail(display = "Address not found")]
+    AddressNotFound,
     /// Error while locking a shared resource
     #[fail(display = "Error while locking a shared resource")]
     LockError,

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -17,6 +17,7 @@ zeroize = "0.6"
 byteorder = "1.3"
 parity-codec = { features = ["derive"], version = "3.5.1" }
 secstr = "0.3.2"
+itertools = "0.8"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -19,7 +19,7 @@ pub use key::{PrivateKey, PublicKey};
 #[doc(inline)]
 pub use transaction_builder::TransactionBuilder;
 #[doc(inline)]
-pub use wallet::WalletClient;
+pub use wallet::{MultiSigWalletClient, WalletClient};
 
 use secp256k1::{All, Secp256k1};
 

--- a/client-core/src/service.rs
+++ b/client-core/src/service.rs
@@ -1,6 +1,8 @@
 //! Management services
 mod key_service;
+mod multi_sig_service;
 mod wallet_service;
 
 pub use self::key_service::KeyService;
+pub use self::multi_sig_service::MultiSigService;
 pub use self::wallet_service::WalletService;

--- a/client-core/src/service/multi_sig_service.rs
+++ b/client-core/src/service/multi_sig_service.rs
@@ -1,0 +1,238 @@
+use itertools::Itertools;
+use parity_codec::{Decode, Encode};
+use secp256k1::PublicKey as SecpPublicKey;
+use secstr::SecUtf8;
+
+use chain_core::common::{MerkleTree, Proof, H256};
+use chain_core::tx::witness::tree::RawPubkey;
+use client_common::{ErrorKind, Result, SecureStorage, Storage};
+
+use crate::PublicKey;
+
+const KEYSPACE: &str = "core_multi_sig";
+
+/// m-of-n multi-sig address
+#[derive(Debug, Encode, Decode)]
+struct MultiSigAddress {
+    /// Number of required co-signers
+    pub m: usize,
+    /// Total number of co-signers
+    pub n: usize,
+    /// Merkle tree with different combinations of `n` public keys as leaf nodes
+    pub merkle_tree: MerkleTree<RawPubkey>,
+}
+
+/// Maintains mapping `multi-sig-public-key -> multi-sig address`
+#[derive(Debug, Default, Clone)]
+pub struct MultiSigService<T: Storage> {
+    storage: T,
+}
+
+impl<T> MultiSigService<T>
+where
+    T: Storage,
+{
+    /// Creates a new instance of multi-sig service
+    pub fn new(storage: T) -> Self {
+        Self { storage }
+    }
+
+    /// Creates and persists new multi-sig address
+    pub fn new_multi_sig_address(
+        &self,
+        public_keys: Vec<PublicKey>,
+        m: usize,
+        n: usize,
+        passphrase: &SecUtf8,
+    ) -> Result<H256> {
+        if m > n || public_keys.is_empty() || public_keys.len() != n {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
+        let combinations = combinations(public_keys, m)?;
+        let merkle_tree = MerkleTree::new(combinations);
+        let root_hash = merkle_tree.root_hash();
+
+        let multi_sig_address = MultiSigAddress { m, n, merkle_tree };
+
+        self.storage
+            .set_secure(KEYSPACE, root_hash, multi_sig_address.encode(), passphrase)?;
+
+        Ok(root_hash)
+    }
+
+    /// Generates inclusion proof for set of addresses in multi-sig address
+    pub fn generate_proof(
+        &self,
+        address: &H256,
+        mut public_keys: Vec<PublicKey>,
+        passphrase: &SecUtf8,
+    ) -> Result<Proof<RawPubkey>> {
+        match self.storage.get_secure(KEYSPACE, address, passphrase)? {
+            None => Err(ErrorKind::AddressNotFound.into()),
+            Some(address_bytes) => {
+                let address = MultiSigAddress::decode(&mut address_bytes.as_slice())
+                    .ok_or_else(|| client_common::Error::from(ErrorKind::DeserializationError))?;
+
+                if public_keys.len() != address.m {
+                    return Err(ErrorKind::InvalidInput.into());
+                }
+
+                public_keys.sort();
+
+                let raw_public_key = RawPubkey::from(
+                    SecpPublicKey::from(PublicKey::combine(&public_keys)?).serialize(),
+                );
+
+                match address.merkle_tree.generate_proof(raw_public_key) {
+                    None => Err(ErrorKind::InvalidInput.into()),
+                    Some(proof) => Ok(proof),
+                }
+            }
+        }
+    }
+
+    /// Returns the number of required cosigners for given address
+    pub fn required_signers(&self, address: &H256, passphrase: &SecUtf8) -> Result<usize> {
+        match self.storage.get_secure(KEYSPACE, address, passphrase)? {
+            None => Err(ErrorKind::AddressNotFound.into()),
+            Some(address_bytes) => {
+                let address = MultiSigAddress::decode(&mut address_bytes.as_slice())
+                    .ok_or_else(|| client_common::Error::from(ErrorKind::DeserializationError))?;
+                Ok(address.m)
+            }
+        }
+    }
+
+    /// Clears all storage
+    pub fn clear(&self) -> Result<()> {
+        self.storage.clear(KEYSPACE)
+    }
+}
+
+fn combinations(public_keys: Vec<PublicKey>, n: usize) -> Result<Vec<RawPubkey>> {
+    if public_keys.is_empty() || n > public_keys.len() {
+        return Err(ErrorKind::InvalidInput.into());
+    }
+
+    let mut combinations = public_keys
+        .into_iter()
+        .combinations(n)
+        .map(|mut combination| {
+            combination.sort();
+            Ok(RawPubkey::from(
+                SecpPublicKey::from(PublicKey::combine(&combination)?).serialize(),
+            ))
+        })
+        .collect::<Result<Vec<RawPubkey>>>()?;
+
+    combinations.sort();
+    Ok(combinations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use client_common::storage::MemoryStorage;
+
+    use crate::PrivateKey;
+
+    #[test]
+    fn check_multi_sig_flow() {
+        let multi_sig_service = MultiSigService::new(MemoryStorage::default());
+        let passphrase = SecUtf8::from("passphrase");
+
+        let public_keys = vec![
+            PublicKey::from(&PrivateKey::new().unwrap()),
+            PublicKey::from(&PrivateKey::new().unwrap()),
+            PublicKey::from(&PrivateKey::new().unwrap()),
+        ];
+
+        assert_eq!(
+            ErrorKind::InvalidInput,
+            multi_sig_service
+                .new_multi_sig_address(public_keys.clone(), 2, 4, &passphrase)
+                .expect_err("Created invalid multi-sig address")
+                .kind()
+        );
+
+        assert_eq!(
+            ErrorKind::InvalidInput,
+            multi_sig_service
+                .new_multi_sig_address(vec![], 0, 0, &passphrase)
+                .expect_err("Created invalid multi-sig address")
+                .kind()
+        );
+
+        let multi_sig_address = multi_sig_service
+            .new_multi_sig_address(public_keys.clone(), 2, 3, &passphrase)
+            .unwrap();
+
+        assert_eq!(
+            2,
+            multi_sig_service
+                .required_signers(&multi_sig_address, &passphrase)
+                .unwrap()
+        );
+
+        assert_eq!(
+            ErrorKind::AddressNotFound,
+            multi_sig_service
+                .required_signers(&[0u8; 32], &passphrase)
+                .expect_err("Found non-existent address")
+                .kind()
+        );
+
+        assert_eq!(
+            ErrorKind::InvalidInput,
+            multi_sig_service
+                .generate_proof(&multi_sig_address, public_keys.clone(), &passphrase)
+                .expect_err("Generated proof for invalid signer count")
+                .kind()
+        );
+
+        let proof = multi_sig_service
+            .generate_proof(
+                &multi_sig_address,
+                vec![public_keys[0].clone(), public_keys[1].clone()],
+                &passphrase,
+            )
+            .unwrap();
+
+        assert!(proof.verify(&multi_sig_address));
+
+        let rev_proof = multi_sig_service
+            .generate_proof(
+                &multi_sig_address,
+                vec![public_keys[1].clone(), public_keys[0].clone()],
+                &passphrase,
+            )
+            .unwrap();
+
+        assert_eq!(proof, rev_proof);
+
+        assert_eq!(
+            ErrorKind::InvalidInput,
+            multi_sig_service
+                .generate_proof(
+                    &multi_sig_address,
+                    vec![
+                        public_keys[0].clone(),
+                        PublicKey::from(&PrivateKey::new().unwrap())
+                    ],
+                    &passphrase
+                )
+                .expect_err("Generated proof for invalid signer count")
+                .kind()
+        );
+
+        let mut signers = vec![public_keys[0].clone(), public_keys[1].clone()];
+        signers.sort();
+
+        let signer =
+            RawPubkey::from(SecpPublicKey::from(PublicKey::combine(&signers).unwrap()).serialize());
+
+        assert_eq!(proof.value(), &signer);
+    }
+}

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -103,9 +103,12 @@ where
         for input in &transaction.inputs {
             let input = wallet_client.output(&input.id, input.index)?;
 
-            match wallet_client.private_key(name, passphrase, &input.address)? {
-                None => return Err(ErrorKind::PrivateKeyNotFound.into()),
-                Some(private_key) => witnesses.push(private_key.sign(&transaction.id())?),
+            match wallet_client.public_key(name, passphrase, &input.address)? {
+                None => return Err(ErrorKind::WalletNotFound.into()),
+                Some(public_key) => match wallet_client.private_key(passphrase, &public_key)? {
+                    None => return Err(ErrorKind::PrivateKeyNotFound.into()),
+                    Some(private_key) => witnesses.push(private_key.sign(&transaction.id())?),
+                },
             }
         }
 
@@ -292,6 +295,12 @@ mod tests {
         txid_0: TxId,
         txid_1: TxId,
         txid_2: TxId,
+        private_key_0: PrivateKey,
+        private_key_1: PrivateKey,
+        private_key_2: PrivateKey,
+        public_key_0: PublicKey,
+        public_key_1: PublicKey,
+        public_key_2: PublicKey,
         addr_0: ExtendedAddr,
         addr_1: ExtendedAddr,
         addr_2: ExtendedAddr,
@@ -325,19 +334,43 @@ mod tests {
 
     impl Default for MockWalletClient {
         fn default() -> Self {
+            let private_key_0 = PrivateKey::deserialize_from(&[
+                197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138, 33, 159,
+                188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 194,
+            ])
+            .unwrap();
+            let private_key_1 = PrivateKey::deserialize_from(&[
+                197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138, 33, 159,
+                188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 195,
+            ])
+            .unwrap();
+            let private_key_2 = PrivateKey::deserialize_from(&[
+                197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138, 33, 159,
+                188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 196,
+            ])
+            .unwrap();
+
+            let public_key_0 = PublicKey::from(&private_key_0);
+            let public_key_1 = PublicKey::from(&private_key_1);
+            let public_key_2 = PublicKey::from(&private_key_2);
+
+            let addr_0 = ExtendedAddr::BasicRedeem(RedeemAddress::from(&public_key_0));
+            let addr_1 = ExtendedAddr::BasicRedeem(RedeemAddress::from(&public_key_1));
+            let addr_2 = ExtendedAddr::BasicRedeem(RedeemAddress::from(&public_key_2));
+
             Self {
                 txid_0: [0u8; 32],
                 txid_1: [1u8; 32],
                 txid_2: [2u8; 32],
-                addr_0: ExtendedAddr::BasicRedeem(
-                    RedeemAddress::from_str("1fdf22497167a793ca794963ad6c95e6ffa0b971").unwrap(),
-                ),
-                addr_1: ExtendedAddr::BasicRedeem(
-                    RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20a5").unwrap(),
-                ),
-                addr_2: ExtendedAddr::BasicRedeem(
-                    RedeemAddress::from_str("780661a2fd9da3fee53caab80859ecae105a20b6").unwrap(),
-                ),
+                private_key_0,
+                private_key_1,
+                private_key_2,
+                public_key_0,
+                public_key_1,
+                public_key_2,
+                addr_0,
+                addr_1,
+                addr_2,
             }
         }
     }
@@ -347,11 +380,7 @@ mod tests {
             unreachable!()
         }
 
-        fn new_wallet(&self, _: &str, _: &SecUtf8) -> Result<String> {
-            unreachable!()
-        }
-
-        fn private_keys(&self, _: &str, _: &SecUtf8) -> Result<Vec<PrivateKey>> {
+        fn new_wallet(&self, _: &str, _: &SecUtf8) -> Result<()> {
             unreachable!()
         }
 
@@ -363,36 +392,28 @@ mod tests {
             unreachable!()
         }
 
-        fn private_key(
+        fn public_key(
             &self,
             _: &str,
             _: &SecUtf8,
             address: &ExtendedAddr,
-        ) -> Result<Option<PrivateKey>> {
+        ) -> Result<Option<PublicKey>> {
             if address == &self.addr_0 {
-                Ok(Some(
-                    PrivateKey::deserialize_from(&[
-                        197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138,
-                        33, 159, 188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 194,
-                    ])
-                    .unwrap(),
-                ))
+                Ok(Some(self.public_key_0.clone()))
             } else if address == &self.addr_1 {
-                Ok(Some(
-                    PrivateKey::deserialize_from(&[
-                        197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138,
-                        33, 159, 188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 195,
-                    ])
-                    .unwrap(),
-                ))
+                Ok(Some(self.public_key_1.clone()))
             } else {
-                Ok(Some(
-                    PrivateKey::deserialize_from(&[
-                        197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138,
-                        33, 159, 188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 196,
-                    ])
-                    .unwrap(),
-                ))
+                Ok(Some(self.public_key_2.clone()))
+            }
+        }
+
+        fn private_key(&self, _: &SecUtf8, public_key: &PublicKey) -> Result<Option<PrivateKey>> {
+            if public_key == &self.public_key_0 {
+                Ok(Some(self.private_key_0.clone()))
+            } else if public_key == &self.public_key_1 {
+                Ok(Some(self.private_key_1.clone()))
+            } else {
+                Ok(Some(self.private_key_2.clone()))
             }
         }
 

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -21,11 +21,8 @@ pub trait WalletClient: Send + Sync {
     /// Retrieves names of all wallets stored
     fn wallets(&self) -> Result<Vec<String>>;
 
-    /// Creates a new wallet with given name and returns wallet_id
-    fn new_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<String>;
-
-    /// Retrieves all public keys corresponding to given wallet
-    fn private_keys(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<PrivateKey>>;
+    /// Creates a new wallet with given name and passphrase
+    fn new_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<()>;
 
     /// Retrieves all public keys corresponding to given wallet
     fn public_keys(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<PublicKey>>;
@@ -33,12 +30,19 @@ pub trait WalletClient: Send + Sync {
     /// Retrieves all addresses corresponding to given wallet
     fn addresses(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<ExtendedAddr>>;
 
-    /// Retrieves private key corresponding to given address
-    fn private_key(
+    /// Retrieves public key corresponding to given address
+    fn public_key(
         &self,
         name: &str,
         passphrase: &SecUtf8,
         address: &ExtendedAddr,
+    ) -> Result<Option<PublicKey>>;
+
+    /// Retrieves private key corresponding to given public key
+    fn private_key(
+        &self,
+        passphrase: &SecUtf8,
+        public_key: &PublicKey,
     ) -> Result<Option<PrivateKey>>;
 
     /// Generates a new public key for given wallet
@@ -77,4 +81,28 @@ pub trait WalletClient: Send + Sync {
 
     /// Synchronizes index with Crypto.com Chain (from genesis)
     fn sync_all(&self) -> Result<()>;
+}
+
+/// Interface for a generic wallet for multi-signature transactions
+pub trait MultiSigWalletClient: WalletClient {
+    /// Creates multi-sig address for creating m-of-n transactions
+    ///
+    /// # Arguments
+    ///
+    /// `name`: Name of wallet
+    /// `passphrase`: passphrase of wallet
+    /// `public_keys`: Public keys of co-signers
+    /// `m`: Number of required co-signers
+    /// `n`: Total number of co-signers
+    fn new_multi_sig_address(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        public_keys: Vec<PublicKey>,
+        m: usize,
+        n: usize,
+    ) -> Result<ExtendedAddr>;
+
+    /// Returns all the multi-sig addresses in current wallet
+    fn multi_sig_addresses(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<ExtendedAddr>>;
 }


### PR DESCRIPTION
Solution: Added a basic support for creating m-of-n tree addresses in client
- This PR only has support for creating addresses is and not signing multi-sig transactions.
- Signing will be a part of different PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crypto-com/chain/108)
<!-- Reviewable:end -->
