### PR TITLE
Problem: build fails checking out secp256k1-zkp submodule -- should fix #111

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c)",
+ "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=5b3ec792e8e208771cd54ea807a478f7763e3c69)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -273,7 +273,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c)",
+ "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=5b3ec792e8e208771cd54ea807a478f7763e3c69)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -355,7 +355,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c)",
+ "secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=5b3ec792e8e208771cd54ea807a478f7763e3c69)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1790,7 +1790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "secp256k1zkp"
 version = "0.12.2"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c#a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=5b3ec792e8e208771cd54ea807a478f7763e3c69#5b3ec792e8e208771cd54ea807a478f7763e3c69"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2651,7 +2651,7 @@ dependencies = [
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c)" = "<none>"
+"checksum secp256k1zkp 0.12.2 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=5b3ec792e8e208771cd54ea807a478f7763e3c69)" = "<none>"
 "checksum secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb003d53cef244a97516226b01155057c7fa6eb52914933c32f6c98a84182188"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.3"
 protobuf = "2.2.0"
 integer-encoding = "1.0.5"
 clap = { features = ["yaml"], version = "2.33.0" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c" }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "5b3ec792e8e208771cd54ea807a478f7763e3c69" }
 blake2 = "0.8"
 ethbloom = "0.5.0"
 parity-codec = { features = ["derive"], version = "3.5.1" }

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 digest = "0.8"
 sha3 = "0.8"
 hex = "0.3"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c", features = ["serde"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "5b3ec792e8e208771cd54ea807a478f7763e3c69", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 blake2 = "0.8"
 serde_json = "1.0"

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 chain-core = { path = "../chain-core" }
 client-common = { path = "../client-common" }
 client-index = { path = "../client-index" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a67ac07f98e3a9bdd10ff2822ae0340b7962fd2c", features = ["serde", "zeroize", "rand"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "5b3ec792e8e208771cd54ea807a478f7763e3c69", features = ["serde", "zeroize", "rand"] }
 rand = "0.6"
 failure = "0.1"
 hex = "0.3"


### PR DESCRIPTION

Solution: the original dependency's branch was force-pushed rebased and the current HEAD fails to compile schnorr.
this uses a custom fork with a fix