### PR TITLE
Problem: (CRO-127) No support for simple schnorr signatures for 1-of-n transactions

### DIFF
--- a/client-core/src/key/public_key.rs
+++ b/client-core/src/key/public_key.rs
@@ -7,6 +7,7 @@ use secp256k1::PublicKey as SecpPublicKey;
 
 use chain_core::common::H256;
 use chain_core::init::address::RedeemAddress;
+use chain_core::tx::witness::tree::RawPubkey;
 use client_common::{ErrorKind, Result};
 
 use crate::SECP;
@@ -74,6 +75,18 @@ impl From<PublicKey> for SecpPublicKey {
 impl From<&PublicKey> for SecpPublicKey {
     fn from(public_key: &PublicKey) -> SecpPublicKey {
         public_key.0
+    }
+}
+
+impl From<PublicKey> for RawPubkey {
+    fn from(public_key: PublicKey) -> RawPubkey {
+        RawPubkey::from(SecpPublicKey::from(public_key).serialize())
+    }
+}
+
+impl From<&PublicKey> for RawPubkey {
+    fn from(public_key: &PublicKey) -> RawPubkey {
+        RawPubkey::from(SecpPublicKey::from(public_key).serialize())
     }
 }
 

--- a/client-core/src/service/multi_sig_session_service.rs
+++ b/client-core/src/service/multi_sig_session_service.rs
@@ -359,13 +359,9 @@ where
         self_private_key: PrivateKey,
         passphrase: &SecUtf8,
     ) -> Result<H256> {
-        if PublicKey::from(&self_private_key) != self_public_key {
+        if PublicKey::from(&self_private_key) != self_public_key || signer_public_keys.len() <= 1 {
             return Err(ErrorKind::InvalidInput.into());
         }
-
-        let mut rng = OsRng::new().context(ErrorKind::KeyGenerationError)?;
-        let session_id = H256::try_from(&MuSigSessionID::new(&mut rng)[..])
-            .context(ErrorKind::DeserializationError)?;
 
         signer_public_keys.sort();
 
@@ -385,6 +381,10 @@ where
                 partial_signature: None,
             })
             .collect::<Vec<Signer>>();
+
+        let mut rng = OsRng::new().context(ErrorKind::KeyGenerationError)?;
+        let session_id = H256::try_from(&MuSigSessionID::new(&mut rng)[..])
+            .context(ErrorKind::DeserializationError)?;
 
         let session = MultiSigSession {
             id: session_id,
@@ -420,6 +420,7 @@ where
         public_key: &PublicKey,
         passphrase: &SecUtf8,
     ) -> Result<()> {
+        // TODO: Implement compare and swap?
         let mut session = self.get_session(session_id, passphrase)?;
         session.add_nonce_commitment(public_key, nonce_commitment)?;
         self.set_session(session_id, session, passphrase)
@@ -443,6 +444,7 @@ where
         public_key: &PublicKey,
         passphrase: &SecUtf8,
     ) -> Result<()> {
+        // TODO: Implement compare and swap?
         let mut session = self.get_session(session_id, passphrase)?;
         session.add_nonce(public_key, nonce)?;
         self.set_session(session_id, session, passphrase)
@@ -466,6 +468,7 @@ where
         public_key: &PublicKey,
         passphrase: &SecUtf8,
     ) -> Result<()> {
+        // TODO: Implement compare and swap?
         let mut session = self.get_session(session_id, passphrase)?;
         session.add_partial_signature(public_key, partial_signature)?;
         self.set_session(session_id, session, passphrase)

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -75,6 +75,7 @@ where
         passphrase: &SecUtf8,
         public_key: PublicKey,
     ) -> Result<()> {
+        // TODO: Implement compare and swap?
         let mut wallet = self.get_wallet(name, passphrase)?;
         wallet.public_keys.push(public_key);
         self.set_wallet(name, passphrase, wallet)
@@ -87,6 +88,7 @@ where
         passphrase: &SecUtf8,
         address: H256,
     ) -> Result<()> {
+        // TODO: Implement compare and swap?
         let mut wallet = self.get_wallet(name, passphrase)?;
         wallet.multi_sig_addresses.push(address);
         self.set_wallet(name, passphrase, wallet)

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -118,6 +118,15 @@ pub trait MultiSigWalletClient: WalletClient {
     /// Returns all the multi-sig addresses in current wallet
     fn multi_sig_addresses(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<ExtendedAddr>>;
 
+    /// Creates a 1-of-n schnorr signature.
+    fn schnorr_signature(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        message: &H256,
+        public_key: &PublicKey,
+    ) -> Result<SchnorrSignature>;
+
     /// Creates a new multi-sig session and returns session-id
     ///
     /// # Arguments


### PR DESCRIPTION
Solution: Added support for simple schnorr signatures for 1-of-n transactions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crypto-com/chain/117)
<!-- Reviewable:end -->
