### PR TITLE
(CRO-125) Change Client RPC to use numeric string as amount [NFM][NEED_REVIEW]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "jsonrpc-http-server 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/chain-core/src/init/coin.rs
+++ b/chain-core/src/init/coin.rs
@@ -150,6 +150,12 @@ impl From<Coin> for u64 {
     }
 }
 
+impl From<Coin> for String {
+    fn from(c: Coin) -> String {
+        c.0.to_string()
+    }
+}
+
 impl From<u32> for Coin {
     fn from(c: u32) -> Coin {
         Coin(u64::from(c))
@@ -222,5 +228,21 @@ mod test {
             Coin::new(v as u64).is_ok()
         }
 
+    }
+
+    #[test]
+    fn test_coin_into_u64() {
+        let coin = Coin::new(10000000000000000000).unwrap();
+        let result: u64 = coin.into();
+
+        assert_eq!(result, 10000000000000000000);
+    }
+
+    #[test]
+    fn test_coin_into_string() {
+        let coin = Coin::new(10000000000000000000).unwrap();
+        let result: String = coin.into();
+
+        assert_eq!(result, "10000000000000000000");
     }
 }

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -7,11 +7,11 @@ use structopt::StructOpt;
 
 use chain_core::common::{Timespec, HASH_SIZE_256};
 use chain_core::init::address::RedeemAddress;
-use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use client_common::{ErrorKind, Result};
+use client_common::serializable::SerializableCoin;
 use client_core::WalletClient;
 
 use crate::ask_passphrase;
@@ -88,8 +88,9 @@ impl TransactionCommand {
             ask("Enter amount: ");
             let amount = text()
                 .context(ErrorKind::IoError)?
-                .parse::<Coin>()
+                .parse::<SerializableCoin>()
                 .context(ErrorKind::DeserializationError)?;
+            let amount = amount.inner();
 
             ask("Enter timelock (seconds from UNIX epoch) (leave blank if output is not time locked): ");
             let timelock = text().context(ErrorKind::IoError)?;

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -10,8 +10,8 @@ use chain_core::init::address::RedeemAddress;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
-use client_common::{ErrorKind, Result};
 use client_common::serializable::SerializableCoin;
+use client_common::{ErrorKind, Result};
 use client_core::WalletClient;
 
 use crate::ask_passphrase;

--- a/client-common/src/balance/balance_change.rs
+++ b/client-common/src/balance/balance_change.rs
@@ -69,7 +69,9 @@ mod tests {
     #[test]
     fn add_incoming() {
         let coin = Coin::zero()
-            + BalanceChange::Incoming(SerializableCoin(Coin::new(30).expect("Unable to create new coin")));
+            + BalanceChange::Incoming(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            ));
 
         assert_eq!(
             Coin::new(30).expect("Unable to create new coin"),
@@ -81,7 +83,9 @@ mod tests {
     #[test]
     fn add_incoming_fail() {
         let coin = Coin::max()
-            + BalanceChange::Incoming(SerializableCoin(Coin::new(30).expect("Unable to create new coin")));
+            + BalanceChange::Incoming(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            ));
 
         assert!(coin.is_err(), "Created coin greater than max value")
     }
@@ -89,7 +93,9 @@ mod tests {
     #[test]
     fn add_outgoing() {
         let coin = Coin::new(40).expect("Unable to create new coin")
-            + BalanceChange::Outgoing(SerializableCoin(Coin::new(30).expect("Unable to create new coin")));
+            + BalanceChange::Outgoing(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            ));
 
         assert_eq!(
             Coin::new(10).expect("Unable to create new coin"),
@@ -101,7 +107,9 @@ mod tests {
     #[test]
     fn add_outgoing_fail() {
         let coin = Coin::zero()
-            + BalanceChange::Outgoing(SerializableCoin(Coin::new(30).expect("Unable to create new coin")));
+            + BalanceChange::Outgoing(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            ));
 
         assert!(coin.is_err(), "Created negative coin")
     }
@@ -112,8 +120,9 @@ mod tests {
 
         #[test]
         fn test_serialize_should_return_coin_amount_in_numeric_string() {
-            let balance_change =
-                BalanceChange::Incoming(SerializableCoin(Coin::new(99999).expect("Unable to create new coin")));
+            let balance_change = BalanceChange::Incoming(SerializableCoin(
+                Coin::new(99999).expect("Unable to create new coin"),
+            ));
             let actual_json =
                 serde_json::to_string(&balance_change).expect("Unable to serialize BalanceChange");
 
@@ -122,8 +131,9 @@ mod tests {
 
         #[test]
         fn test_serialize_incoming_balance_change_should_work() {
-            let balance_change =
-                BalanceChange::Incoming(SerializableCoin(Coin::new(30).expect("Unable to create new coin")));
+            let balance_change = BalanceChange::Incoming(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            ));
             let actual_json =
                 serde_json::to_string(&balance_change).expect("Unable to serialize BalanceChange");
 
@@ -132,8 +142,9 @@ mod tests {
 
         #[test]
         fn test_serialize_outgoing_balance_change_should_work() {
-            let balance_change =
-                BalanceChange::Outgoing(SerializableCoin(Coin::new(30).expect("Unable to create new coin")));
+            let balance_change = BalanceChange::Outgoing(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            ));
             let actual_json =
                 serde_json::to_string(&balance_change).expect("Unable to serialize BalanceChange");
 
@@ -142,9 +153,9 @@ mod tests {
 
         #[test]
         fn test_serialize_large_amount_should_work() {
-            let balance_change = BalanceChange::Incoming(
-                SerializableCoin(Coin::new(10000000000000000000).expect("Unable to create new coin")),
-            );
+            let balance_change = BalanceChange::Incoming(SerializableCoin(
+                Coin::new(10000000000000000000).expect("Unable to create new coin"),
+            ));
             let actual_json =
                 serde_json::to_string(&balance_change).expect("Unable to serialize BalanceChange");
 

--- a/client-common/src/balance/transaction_change.rs
+++ b/client-common/src/balance/transaction_change.rs
@@ -79,6 +79,8 @@ mod tests {
 
     use chain_core::tx::data::txid_hash;
 
+    use crate::serializable::SerializableCoin;
+
     fn get_transaction_change(balance_change: BalanceChange) -> TransactionChange {
         TransactionChange {
             transaction_id: txid_hash(&[0, 1, 2]),
@@ -93,7 +95,7 @@ mod tests {
     fn add_incoming() {
         let coin = Coin::zero()
             + get_transaction_change(BalanceChange::Incoming(
-                Coin::new(30).expect("Unable to create new coin"),
+                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
             ));
 
         assert_eq!(
@@ -107,7 +109,7 @@ mod tests {
     fn add_incoming_fail() {
         let coin = Coin::max()
             + get_transaction_change(BalanceChange::Incoming(
-                Coin::new(30).expect("Unable to create new coin"),
+                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
             ));
 
         assert!(coin.is_err(), "Created coin greater than max value")
@@ -117,7 +119,7 @@ mod tests {
     fn add_outgoing() {
         let coin = Coin::new(40).expect("Unable to create new coin")
             + get_transaction_change(BalanceChange::Outgoing(
-                Coin::new(30).expect("Unable to create new coin"),
+                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
             ));
 
         assert_eq!(
@@ -131,7 +133,7 @@ mod tests {
     fn add_outgoing_fail() {
         let coin = Coin::zero()
             + get_transaction_change(BalanceChange::Outgoing(
-                Coin::new(30).expect("Unable to create new coin"),
+                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
             ));
 
         assert!(coin.is_err(), "Created negative coin")

--- a/client-common/src/balance/transaction_change.rs
+++ b/client-common/src/balance/transaction_change.rs
@@ -94,9 +94,9 @@ mod tests {
     #[test]
     fn add_incoming() {
         let coin = Coin::zero()
-            + get_transaction_change(BalanceChange::Incoming(
-                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
-            ));
+            + get_transaction_change(BalanceChange::Incoming(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            )));
 
         assert_eq!(
             Coin::new(30).expect("Unable to create new coin"),
@@ -108,9 +108,9 @@ mod tests {
     #[test]
     fn add_incoming_fail() {
         let coin = Coin::max()
-            + get_transaction_change(BalanceChange::Incoming(
-                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
-            ));
+            + get_transaction_change(BalanceChange::Incoming(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            )));
 
         assert!(coin.is_err(), "Created coin greater than max value")
     }
@@ -118,9 +118,9 @@ mod tests {
     #[test]
     fn add_outgoing() {
         let coin = Coin::new(40).expect("Unable to create new coin")
-            + get_transaction_change(BalanceChange::Outgoing(
-                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
-            ));
+            + get_transaction_change(BalanceChange::Outgoing(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            )));
 
         assert_eq!(
             Coin::new(10).expect("Unable to create new coin"),
@@ -132,9 +132,9 @@ mod tests {
     #[test]
     fn add_outgoing_fail() {
         let coin = Coin::zero()
-            + get_transaction_change(BalanceChange::Outgoing(
-                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
-            ));
+            + get_transaction_change(BalanceChange::Outgoing(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            )));
 
         assert!(coin.is_err(), "Created negative coin")
     }

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod balance;
 pub mod error;
+pub mod serializable;
 pub mod storage;
 pub mod tendermint;
 

--- a/client-common/src/serializable.rs
+++ b/client-common/src/serializable.rs
@@ -1,0 +1,4 @@
+//! Types for serializable structures external system
+mod serializable_coin;
+
+pub use self::serializable_coin::SerializableCoin;

--- a/client-common/src/serializable/serializable_coin.rs
+++ b/client-common/src/serializable/serializable_coin.rs
@@ -12,8 +12,8 @@ pub struct SerializableCoin(pub Coin);
 
 impl SerializableCoin {
     /// Returns the inner Coin
-    pub fn inner(&self) -> Coin {
-        self.0.clone()
+    pub fn inner(self) -> Coin {
+        self.0
     }
 }
 

--- a/client-common/src/serializable/serializable_coin.rs
+++ b/client-common/src/serializable/serializable_coin.rs
@@ -1,0 +1,202 @@
+use std::convert::From;
+use std::fmt;
+use parity_codec::{Decode, Encode};
+use serde::de::{Deserialize, Deserializer, Error, Visitor};
+use serde::{Serialize, Serializer};
+
+use chain_core::init::coin::{Coin, CoinError};
+
+/// Coin wrapper that support serialize to and deserialize from string
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+pub struct SerializableCoin(pub Coin);
+
+impl SerializableCoin {
+    /// Returns the inner Coin
+    pub fn inner(&self) -> Coin {
+        self.0.clone()
+    }
+}
+
+impl fmt::Display for SerializableCoin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Serialize for SerializableCoin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&String::from(self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for SerializableCoin {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrVisitor;
+
+        impl<'de> Visitor<'de> for StrVisitor {
+            type Value = SerializableCoin;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .write_str("the coin amount in the range (0..total supply) as numeric string")
+            }
+
+            #[inline]
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let amount: u64 = value
+                    .parse()
+                    .map_err(|_| E::custom("coin amount is not a valid numeric string"))?;
+
+                let coin = Coin::new(amount).map_err(|err| E::custom(format!("{}", err)))?;
+
+                Ok(SerializableCoin(coin))
+            }
+        }
+
+        deserializer.deserialize_str(StrVisitor)
+    }
+}
+
+impl ::std::str::FromStr for SerializableCoin {
+    type Err = CoinError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let coin = s.parse::<Coin>()?;
+
+        Ok(SerializableCoin(coin))
+    }
+}
+
+impl From<SerializableCoin> for Coin {
+    fn from(item: SerializableCoin) -> Coin {
+        item.inner()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_inner_should_return_coin() {
+        let coin = Coin::new(10000000000000000000).expect("Unable to create new coin");
+        let serializable_coin = SerializableCoin(coin.clone());
+
+        assert_eq!(serializable_coin.inner(), coin);
+    }
+
+    #[test]
+    fn test_from_str_into_serializable_coin() {
+        let amount_str = "10000000000000000000";
+
+        assert!(amount_str.parse::<SerializableCoin>().is_ok());
+    }
+
+    #[test]
+    fn test_serializable_coin_into_coin() {
+        let coin = Coin::new(10000000000000000000).expect("Unable to create new coin");
+        let serializable_coin = SerializableCoin(coin.clone());
+
+        let actual_coin: Coin = serializable_coin.into();
+
+        assert_eq!(actual_coin, coin);
+    }
+
+    mod serializer_deserializer_test {
+        use super::*;
+        use serde_json;
+
+        #[test]
+        fn test_serialize_to_string() {
+            let coin = Coin::new(10000000000000000000).expect("Unable to create new coin");
+            let serializable_coin = SerializableCoin(coin);
+
+            let json = serde_json::to_string(&serializable_coin).expect("Unable to serialize SerializableCoin");
+            assert_eq!(json, "\"10000000000000000000\"");
+        }
+
+        #[test]
+        fn test_deserialize_from_number_should_give_error() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("99999");
+
+            assert!(deserialize_result.is_err());
+        }
+
+        #[test]
+        fn test_deserialize_from_empty_string_should_give_error() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"\"");
+
+            assert!(deserialize_result.is_err());
+        }
+
+        #[test]
+        fn test_deserialize_from_out_of_range_should_give_error() {
+            let deserialize_result =
+                serde_json::from_str::<SerializableCoin>("\"10000000000000000001\"");
+
+            assert!(deserialize_result.is_err());
+        }
+
+        #[test]
+        fn test_deserialize_from_negative_should_give_error() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"-1\"");
+
+            assert!(deserialize_result.is_err());
+        }
+
+        #[test]
+        fn test_deserialize_from_hexadecimal_should_give_error() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"0xAB\"");
+            assert!(deserialize_result.is_err());
+
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"AB\"");
+            assert!(deserialize_result.is_err());
+        }
+
+        #[test]
+        fn test_deserialize_from_non_number_should_give_error() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"Crypto.com\"");
+
+            assert!(deserialize_result.is_err());
+        }
+
+        #[test]
+        fn test_deserialize_from_plus_prefix_should_work() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"+99999\"");
+
+            assert_eq!(
+                deserialize_result.expect("Unable to deserialize to SerializableCoin"),
+                SerializableCoin(Coin::new(99999).expect("Unable to create new coin"))
+            );
+        }
+
+        #[test]
+        fn test_deserialize_from_string_should_work() {
+            let deserialize_result = serde_json::from_str::<SerializableCoin>("\"99999\"");
+
+            assert_eq!(
+                deserialize_result.expect("Unable to deserialize to SerializableCoin"),
+                SerializableCoin(Coin::new(99999).expect("Unable to create new coin"))
+            );
+        }
+
+        #[test]
+        fn test_deserialize_from_large_amount_should_work() {
+            let deserialize_result =
+                serde_json::from_str::<SerializableCoin>("\"10000000000000000000\"");
+
+            assert_eq!(
+                deserialize_result.expect("Unable to deserialize to SerializableCoin"),
+                SerializableCoin(Coin::new(10000000000000000000).expect("Unable to create new coin"))
+            );
+        }
+    }
+}

--- a/client-common/src/serializable/serializable_coin.rs
+++ b/client-common/src/serializable/serializable_coin.rs
@@ -1,8 +1,8 @@
-use std::convert::From;
-use std::fmt;
 use parity_codec::{Decode, Encode};
 use serde::de::{Deserialize, Deserializer, Error, Visitor};
 use serde::{Serialize, Serializer};
+use std::convert::From;
+use std::fmt;
 
 use chain_core::init::coin::{Coin, CoinError};
 
@@ -119,7 +119,8 @@ mod test {
             let coin = Coin::new(10000000000000000000).expect("Unable to create new coin");
             let serializable_coin = SerializableCoin(coin);
 
-            let json = serde_json::to_string(&serializable_coin).expect("Unable to serialize SerializableCoin");
+            let json = serde_json::to_string(&serializable_coin)
+                .expect("Unable to serialize SerializableCoin");
             assert_eq!(json, "\"10000000000000000000\"");
         }
 
@@ -195,7 +196,9 @@ mod test {
 
             assert_eq!(
                 deserialize_result.expect("Unable to deserialize to SerializableCoin"),
-                SerializableCoin(Coin::new(10000000000000000000).expect("Unable to create new coin"))
+                SerializableCoin(
+                    Coin::new(10000000000000000000).expect("Unable to create new coin")
+                )
             );
         }
     }

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -251,7 +251,10 @@ where
     ) -> Result<TxAux> {
         let mut unspent_transactions = wallet_client.unspent_transactions(name, passphrase)?;
         unspent_transactions.sort_by(|a, b| a.1.cmp(&b.1).reverse());
-        let mut unspent_transactions = unspent_transactions.iter().map(|(tx_out, serializable_coin)| (tx_out.clone(), serializable_coin.inner())).collect::<Vec<(TxoPointer, Coin)>>();
+        let mut unspent_transactions = unspent_transactions
+            .iter()
+            .map(|(tx_out, serializable_coin)| (tx_out.clone(), serializable_coin.inner()))
+            .collect::<Vec<(TxoPointer, Coin)>>();
         let unspent_transactions_slice = unspent_transactions.as_slice();
 
         let (select_until, difference_amount) =
@@ -438,7 +441,11 @@ mod tests {
             unreachable!()
         }
 
-        fn unspent_transactions(&self, _: &str, _: &SecUtf8) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
+        fn unspent_transactions(
+            &self,
+            _: &str,
+            _: &SecUtf8,
+        ) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
             Ok(vec![
                 (
                     TxoPointer {

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -7,7 +7,6 @@ use secp256k1::schnorrsig::SchnorrSignature;
 use secstr::SecUtf8;
 
 use chain_core::common::{Proof, H256};
-use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
@@ -15,6 +14,7 @@ use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::TxId;
 use chain_core::tx::witness::tree::RawPubkey;
 use client_common::balance::TransactionChange;
+use client_common::serializable::SerializableCoin;
 use client_common::Result;
 
 use crate::{PrivateKey, PublicKey};
@@ -55,7 +55,7 @@ pub trait WalletClient: Send + Sync {
     fn new_address(&self, name: &str, passphrase: &SecUtf8) -> Result<ExtendedAddr>;
 
     /// Retrieves current balance of wallet
-    fn balance(&self, name: &str, passphrase: &SecUtf8) -> Result<Coin>;
+    fn balance(&self, name: &str, passphrase: &SecUtf8) -> Result<SerializableCoin>;
 
     /// Retrieves transaction history of wallet
     fn history(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<TransactionChange>>;
@@ -65,7 +65,7 @@ pub trait WalletClient: Send + Sync {
         &self,
         name: &str,
         passphrase: &SecUtf8,
-    ) -> Result<Vec<(TxoPointer, Coin)>>;
+    ) -> Result<Vec<(TxoPointer, SerializableCoin)>>;
 
     /// Returns output of transaction with given id and index
     fn output(&self, id: &TxId, index: usize) -> Result<TxOut>;

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -146,7 +146,9 @@ where
             .collect::<Result<Vec<SerializableCoin>>>()?;
         let balances = balances.iter().map(|balance| balance.inner());
 
-        Ok(SerializableCoin(sum_coins(balances.into_iter()).context(ErrorKind::BalanceAdditionError)?))
+        Ok(SerializableCoin(
+            sum_coins(balances.into_iter()).context(ErrorKind::BalanceAdditionError)?,
+        ))
     }
 
     fn history(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<TransactionChange>> {
@@ -521,14 +523,18 @@ mod tests {
                     TransactionChange {
                         transaction_id: [0u8; 32],
                         address: address.clone(),
-                        balance_change: BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap())),
+                        balance_change: BalanceChange::Incoming(SerializableCoin(
+                            Coin::new(30).unwrap(),
+                        )),
                         height: 1,
                         time: DateTime::from(SystemTime::now()),
                     },
                     TransactionChange {
                         transaction_id: [1u8; 32],
                         address: address.clone(),
-                        balance_change: BalanceChange::Outgoing(SerializableCoin(Coin::new(30).unwrap())),
+                        balance_change: BalanceChange::Outgoing(SerializableCoin(
+                            Coin::new(30).unwrap(),
+                        )),
                         height: 2,
                         time: DateTime::from(SystemTime::now()),
                     },
@@ -539,14 +545,18 @@ mod tests {
                         TransactionChange {
                             transaction_id: [1u8; 32],
                             address: address.clone(),
-                            balance_change: BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap())),
+                            balance_change: BalanceChange::Incoming(SerializableCoin(
+                                Coin::new(30).unwrap(),
+                            )),
                             height: 1,
                             time: DateTime::from(SystemTime::now()),
                         },
                         TransactionChange {
                             transaction_id: [2u8; 32],
                             address: address.clone(),
-                            balance_change: BalanceChange::Outgoing(SerializableCoin(Coin::new(30).unwrap())),
+                            balance_change: BalanceChange::Outgoing(SerializableCoin(
+                                Coin::new(30).unwrap(),
+                            )),
                             height: 2,
                             time: DateTime::from(SystemTime::now()),
                         },
@@ -555,7 +565,9 @@ mod tests {
                     Ok(vec![TransactionChange {
                         transaction_id: [1u8; 32],
                         address: address.clone(),
-                        balance_change: BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap())),
+                        balance_change: BalanceChange::Incoming(SerializableCoin(
+                            Coin::new(30).unwrap(),
+                        )),
                         height: 2,
                         time: DateTime::from(SystemTime::now()),
                     }])
@@ -564,7 +576,9 @@ mod tests {
                 Ok(vec![TransactionChange {
                     transaction_id: [1u8; 32],
                     address: address.clone(),
-                    balance_change: BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap())),
+                    balance_change: BalanceChange::Incoming(SerializableCoin(
+                        Coin::new(30).unwrap(),
+                    )),
                     height: 2,
                     time: DateTime::from(SystemTime::now()),
                 }])
@@ -589,7 +603,10 @@ mod tests {
             }
         }
 
-        fn unspent_transactions(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
+        fn unspent_transactions(
+            &self,
+            address: &ExtendedAddr,
+        ) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
             if address == &self.addr_1 {
                 Ok(Default::default())
             } else if address == &self.addr_2 {

--- a/client-index/src/index.rs
+++ b/client-index/src/index.rs
@@ -5,12 +5,12 @@ mod unauthorized_index;
 pub use default_index::DefaultIndex;
 pub use unauthorized_index::UnauthorizedIndex;
 
-use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::{Tx, TxId};
 use client_common::balance::TransactionChange;
+use client_common::serializable::SerializableCoin;
 use client_common::Result;
 
 /// Interface for interacting with transaction index
@@ -25,10 +25,10 @@ pub trait Index: Send + Sync {
     fn transaction_changes(&self, address: &ExtendedAddr) -> Result<Vec<TransactionChange>>;
 
     /// Returns current balance for given address
-    fn balance(&self, address: &ExtendedAddr) -> Result<Coin>;
+    fn balance(&self, address: &ExtendedAddr) -> Result<SerializableCoin>;
 
     /// Returns all the unspent transactions corresponding to given address
-    fn unspent_transactions(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, Coin)>>;
+    fn unspent_transactions(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>>;
 
     /// Returns transaction with given id
     fn transaction(&self, id: &TxId) -> Result<Option<Tx>>;

--- a/client-index/src/index.rs
+++ b/client-index/src/index.rs
@@ -28,7 +28,10 @@ pub trait Index: Send + Sync {
     fn balance(&self, address: &ExtendedAddr) -> Result<SerializableCoin>;
 
     /// Returns all the unspent transactions corresponding to given address
-    fn unspent_transactions(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>>;
+    fn unspent_transactions(
+        &self,
+        address: &ExtendedAddr,
+    ) -> Result<Vec<(TxoPointer, SerializableCoin)>>;
 
     /// Returns transaction with given id
     fn transaction(&self, id: &TxId) -> Result<Option<Tx>>;

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -117,8 +117,10 @@ where
                     .change(&change.address, &change.balance_change)?;
 
                 // Update unspent transactions
-                self.unspent_transaction_service
-                    .add(&change.address, (TxoPointer::new(id, i), SerializableCoin(output.value)))?;
+                self.unspent_transaction_service.add(
+                    &change.address,
+                    (TxoPointer::new(id, i), SerializableCoin(output.value)),
+                )?;
 
                 // Update transaction history
                 self.address_service.add(change)?;
@@ -185,7 +187,10 @@ where
         self.balance_service.get(address)
     }
 
-    fn unspent_transactions(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
+    fn unspent_transactions(
+        &self,
+        address: &ExtendedAddr,
+    ) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
         self.unspent_transaction_service.get(address)
     }
 
@@ -343,7 +348,10 @@ mod tests {
         );
 
         assert!(index.sync_all().is_ok());
-        assert_eq!(SerializableCoin(Coin::zero()), index.balance(&spend_address).unwrap());
+        assert_eq!(
+            SerializableCoin(Coin::zero()),
+            index.balance(&spend_address).unwrap()
+        );
         assert_eq!(
             SerializableCoin(Coin::new(10000000000000000000).unwrap()),
             index.balance(&view_address).unwrap()

--- a/client-index/src/index/unauthorized_index.rs
+++ b/client-index/src/index/unauthorized_index.rs
@@ -29,7 +29,10 @@ impl Index for UnauthorizedIndex {
         Err(ErrorKind::PermissionDenied.into())
     }
 
-    fn unspent_transactions(&self, _address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
+    fn unspent_transactions(
+        &self,
+        _address: &ExtendedAddr,
+    ) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
         Err(ErrorKind::PermissionDenied.into())
     }
 

--- a/client-index/src/index/unauthorized_index.rs
+++ b/client-index/src/index/unauthorized_index.rs
@@ -1,9 +1,9 @@
-use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::{Tx, TxId};
 use client_common::balance::TransactionChange;
+use client_common::serializable::SerializableCoin;
 use client_common::{ErrorKind, Result};
 
 use crate::Index;
@@ -25,11 +25,11 @@ impl Index for UnauthorizedIndex {
         Err(ErrorKind::PermissionDenied.into())
     }
 
-    fn balance(&self, _address: &ExtendedAddr) -> Result<Coin> {
+    fn balance(&self, _address: &ExtendedAddr) -> Result<SerializableCoin> {
         Err(ErrorKind::PermissionDenied.into())
     }
 
-    fn unspent_transactions(&self, _address: &ExtendedAddr) -> Result<Vec<(TxoPointer, Coin)>> {
+    fn unspent_transactions(&self, _address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
         Err(ErrorKind::PermissionDenied.into())
     }
 

--- a/client-index/src/service/address_service.rs
+++ b/client-index/src/service/address_service.rs
@@ -64,6 +64,7 @@ mod tests {
     use chain_core::init::coin::Coin;
     use chain_core::tx::data::txid_hash;
     use client_common::balance::BalanceChange;
+    use client_common::serializable::SerializableCoin;
     use client_common::storage::MemoryStorage;
 
     #[test]
@@ -74,7 +75,7 @@ mod tests {
             transaction_id: txid_hash(&[0, 1, 2]),
             address: address.clone(),
             balance_change: BalanceChange::Incoming(
-                Coin::new(30).expect("Unable to create new coin"),
+                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
             ),
             height: 1,
             time: DateTime::from(SystemTime::now()),

--- a/client-index/src/service/address_service.rs
+++ b/client-index/src/service/address_service.rs
@@ -74,9 +74,9 @@ mod tests {
         let transaction_change = TransactionChange {
             transaction_id: txid_hash(&[0, 1, 2]),
             address: address.clone(),
-            balance_change: BalanceChange::Incoming(
-                SerializableCoin(Coin::new(30).expect("Unable to create new coin")),
-            ),
+            balance_change: BalanceChange::Incoming(SerializableCoin(
+                Coin::new(30).expect("Unable to create new coin"),
+            )),
             height: 1,
             time: DateTime::from(SystemTime::now()),
         };

--- a/client-index/src/service/balance_service.rs
+++ b/client-index/src/service/balance_service.rs
@@ -1,6 +1,7 @@
 use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use client_common::balance::BalanceChange;
+use client_common::serializable::SerializableCoin;
 use client_common::{ErrorKind, Result, Storage};
 use parity_codec::{Decode, Encode};
 
@@ -24,25 +25,25 @@ where
     }
 
     /// Retrieves current balance for given address
-    pub fn get(&self, address: &ExtendedAddr) -> Result<Coin> {
+    pub fn get(&self, address: &ExtendedAddr) -> Result<SerializableCoin> {
         let bytes = self.storage.get(KEYSPACE, address.encode())?;
 
         match bytes {
-            None => Ok(Coin::zero()),
+            None => Ok(SerializableCoin(Coin::zero())),
             Some(bytes) => {
-                Ok(Coin::decode(&mut bytes.as_slice()).ok_or(ErrorKind::DeserializationError)?)
+                Ok(SerializableCoin::decode(&mut bytes.as_slice()).ok_or(ErrorKind::DeserializationError)?)
             }
         }
     }
 
     /// Changes balance for an address with given balance change
-    pub fn change(&self, address: &ExtendedAddr, change: &BalanceChange) -> Result<Coin> {
+    pub fn change(&self, address: &ExtendedAddr, change: &BalanceChange) -> Result<SerializableCoin> {
         let current = self.get(address)?;
-        let new = (current + change)?;
+        let new = (current.inner() + change)?;
 
         self.storage.set(KEYSPACE, address.encode(), new.encode())?;
 
-        Ok(new)
+        Ok(SerializableCoin(new))
     }
 
     /// Clears all storage
@@ -57,6 +58,7 @@ mod tests {
 
     use chain_core::init::coin::Coin;
     use client_common::balance::BalanceChange;
+    use client_common::serializable::SerializableCoin;
     use client_common::storage::MemoryStorage;
 
     #[test]
@@ -64,24 +66,24 @@ mod tests {
         let balance_service = BalanceService::new(MemoryStorage::default());
         let address = ExtendedAddr::BasicRedeem(Default::default());
 
-        assert_eq!(Coin::zero(), balance_service.get(&address).unwrap());
+        assert_eq!(SerializableCoin(Coin::zero()), balance_service.get(&address).unwrap());
         assert_eq!(
-            Coin::new(30).unwrap(),
+            SerializableCoin(Coin::new(30).unwrap()),
             balance_service
-                .change(&address, &BalanceChange::Incoming(Coin::new(30).unwrap()))
+                .change(&address, &BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap())))
                 .unwrap()
         );
         assert_eq!(
-            Coin::new(10).unwrap(),
+            SerializableCoin(Coin::new(10).unwrap()),
             balance_service
-                .change(&address, &BalanceChange::Outgoing(Coin::new(20).unwrap()))
+                .change(&address, &BalanceChange::Outgoing(SerializableCoin(Coin::new(20).unwrap())))
                 .unwrap()
         );
         assert_eq!(
-            Coin::new(10).unwrap(),
+            SerializableCoin(Coin::new(10).unwrap()),
             balance_service.get(&address).unwrap()
         );
         assert!(balance_service.clear().is_ok());
-        assert_eq!(Coin::zero(), balance_service.get(&address).unwrap());
+        assert_eq!(SerializableCoin(Coin::zero()), balance_service.get(&address).unwrap());
     }
 }

--- a/client-index/src/service/balance_service.rs
+++ b/client-index/src/service/balance_service.rs
@@ -30,14 +30,17 @@ where
 
         match bytes {
             None => Ok(SerializableCoin(Coin::zero())),
-            Some(bytes) => {
-                Ok(SerializableCoin::decode(&mut bytes.as_slice()).ok_or(ErrorKind::DeserializationError)?)
-            }
+            Some(bytes) => Ok(SerializableCoin::decode(&mut bytes.as_slice())
+                .ok_or(ErrorKind::DeserializationError)?),
         }
     }
 
     /// Changes balance for an address with given balance change
-    pub fn change(&self, address: &ExtendedAddr, change: &BalanceChange) -> Result<SerializableCoin> {
+    pub fn change(
+        &self,
+        address: &ExtendedAddr,
+        change: &BalanceChange,
+    ) -> Result<SerializableCoin> {
         let current = self.get(address)?;
         let new = (current.inner() + change)?;
 
@@ -66,17 +69,26 @@ mod tests {
         let balance_service = BalanceService::new(MemoryStorage::default());
         let address = ExtendedAddr::BasicRedeem(Default::default());
 
-        assert_eq!(SerializableCoin(Coin::zero()), balance_service.get(&address).unwrap());
+        assert_eq!(
+            SerializableCoin(Coin::zero()),
+            balance_service.get(&address).unwrap()
+        );
         assert_eq!(
             SerializableCoin(Coin::new(30).unwrap()),
             balance_service
-                .change(&address, &BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap())))
+                .change(
+                    &address,
+                    &BalanceChange::Incoming(SerializableCoin(Coin::new(30).unwrap()))
+                )
                 .unwrap()
         );
         assert_eq!(
             SerializableCoin(Coin::new(10).unwrap()),
             balance_service
-                .change(&address, &BalanceChange::Outgoing(SerializableCoin(Coin::new(20).unwrap())))
+                .change(
+                    &address,
+                    &BalanceChange::Outgoing(SerializableCoin(Coin::new(20).unwrap()))
+                )
                 .unwrap()
         );
         assert_eq!(
@@ -84,6 +96,9 @@ mod tests {
             balance_service.get(&address).unwrap()
         );
         assert!(balance_service.clear().is_ok());
-        assert_eq!(SerializableCoin(Coin::zero()), balance_service.get(&address).unwrap());
+        assert_eq!(
+            SerializableCoin(Coin::zero()),
+            balance_service.get(&address).unwrap()
+        );
     }
 }

--- a/client-index/src/service/unspent_transaction_service.rs
+++ b/client-index/src/service/unspent_transaction_service.rs
@@ -1,13 +1,13 @@
-use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::input::TxoPointer;
+use client_common::serializable::SerializableCoin;
 use client_common::{ErrorKind, Result, Storage};
 use parity_codec::{Decode, Encode};
 
 const KEYSPACE: &str = "index_unspent_transaction";
 /// Exposes functionalities for managing unspent transactions
 ///
-/// Stores `address -> [(TxoPointer, Coin)]` mapping
+/// Stores `address -> [(TxoPointer, SerializableCoin)]` mapping
 #[derive(Default, Clone)]
 pub struct UnspentTransactionService<S: Storage> {
     storage: S,
@@ -23,7 +23,7 @@ where
     }
 
     /// Retrieves all the unspent transactions for an address
-    pub fn get(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, Coin)>> {
+    pub fn get(&self, address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
         let bytes = self.storage.get(KEYSPACE, address.encode())?;
 
         match bytes {
@@ -38,7 +38,7 @@ where
     pub fn add(
         &self,
         address: &ExtendedAddr,
-        unspent_transaction: (TxoPointer, Coin),
+        unspent_transaction: (TxoPointer, SerializableCoin),
     ) -> Result<()> {
         let mut unspent_transactions = self.get(address)?;
         unspent_transactions.push(unspent_transaction);

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -17,3 +17,6 @@ structopt = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.3.2"
 secstr = { version = "0.3.2", features = ["serde"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -218,7 +218,10 @@ mod tests {
             Ok(SerializableCoin(Coin::new(30).unwrap()))
         }
 
-        fn unspent_transactions(&self, _address: &ExtendedAddr) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
+        fn unspent_transactions(
+            &self,
+            _address: &ExtendedAddr,
+        ) -> Result<Vec<(TxoPointer, SerializableCoin)>> {
             Ok(Vec::new())
         }
 

--- a/integration-tests/client-rpc/test/wallet-balance.test.ts
+++ b/integration-tests/client-rpc/test/wallet-balance.test.ts
@@ -17,7 +17,7 @@ describe("Wallet balance", () => {
 
     return expect(
       client.request("wallet_balance", [walletRequest])
-    ).to.eventually.deep.eq(new BigNumber("2500000000000000000"));
+    ).to.eventually.deep.eq("2500000000000000000");
   });
 
   it("User can retrieve correct balance after send funds", async () => {
@@ -25,7 +25,7 @@ describe("Wallet balance", () => {
 
     await expect(
       client.request("wallet_balance", [walletRequest])
-    ).to.eventually.deep.eq(new BigNumber("2500000000000000000"));
+    ).to.eventually.deep.eq("2500000000000000000");
 
     await client.request("wallet_sendtoaddress", [
       walletRequest,
@@ -37,7 +37,7 @@ describe("Wallet balance", () => {
 
     return expect(
       client.request("wallet_balance", [walletRequest])
-    ).to.eventually.deep.eq(new BigNumber("2000000000000000000"));
+    ).to.eventually.deep.eq("2000000000000000000");
   });
 
   it("User can retrieve correct balance after receive funds", async () => {
@@ -46,7 +46,7 @@ describe("Wallet balance", () => {
 
     await expect(
       client.request("wallet_balance", [viewWalletRequest])
-    ).to.eventually.deep.eq(new BigNumber("3000000000000000000"));
+    ).to.eventually.deep.eq("3000000000000000000");
 
     const amountToSpend = 500000000000000000;
     await client.request("wallet_sendtoaddress", [
@@ -59,6 +59,6 @@ describe("Wallet balance", () => {
 
     return expect(
       client.request("wallet_balance", [viewWalletRequest])
-    ).to.eventually.deep.eq(new BigNumber("3000000000000000000").plus(amountToSpend));
+    ).to.eventually.deep.eq("3000000000000000000").plus(amountToSpend);
   });
 });

--- a/integration-tests/client-rpc/test/wallet-balance.test.ts
+++ b/integration-tests/client-rpc/test/wallet-balance.test.ts
@@ -1,7 +1,6 @@
 import "mocha";
 import chaiAsPromised = require("chai-as-promised");
 import { use as chaiUse, expect } from "chai";
-import BigNumber from "bignumber.js";
 import { RpcClient } from "./core/rpc-client";
 import { newRpcClient, newWalletRequest, sleep, RECEIVE_WALLET_ADDRESS, VIEW_WALLET_ADDRESS } from "./core/setup";
 chaiUse(chaiAsPromised);
@@ -30,7 +29,7 @@ describe("Wallet balance", () => {
     await client.request("wallet_sendtoaddress", [
       walletRequest,
       RECEIVE_WALLET_ADDRESS,
-      500000000000000000
+      "500000000000000000"
     ]);
 
     await sleep(2000);
@@ -48,17 +47,16 @@ describe("Wallet balance", () => {
       client.request("wallet_balance", [viewWalletRequest])
     ).to.eventually.deep.eq("3000000000000000000");
 
-    const amountToSpend = 500000000000000000;
     await client.request("wallet_sendtoaddress", [
       spendWalletRequest,
       VIEW_WALLET_ADDRESS,
-      amountToSpend
+      "500000000000000000"
     ]);
 
     await sleep(2000);
 
     return expect(
       client.request("wallet_balance", [viewWalletRequest])
-    ).to.eventually.deep.eq("3000000000000000000").plus(amountToSpend);
+    ).to.eventually.deep.eq("8000000000000000000");
   });
 });

--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -31,7 +31,7 @@ describe("Wallet transaction", () => {
     expectTransactionShouldBe(firstTransaction, {
       address: SPEND_WALLET_ADDRESS,
       direction: TransactionDirection.INCOMING,
-      amount: new BigNumber("3000000000000000000"),
+      amount: "3000000000000000000",
       height: 0
     });
   });
@@ -39,7 +39,7 @@ describe("Wallet transaction", () => {
   it("User cannot send funds larger than wallet balance", async () => {
     const walletRequest = newWalletRequest("Spend");
 
-    const totalCROSupply = 10000000000000000000;
+    const totalCROSupply = "10000000000000000000";
     return expect(
       client.request("wallet_sendtoaddress", [
         walletRequest,
@@ -61,7 +61,7 @@ describe("Wallet transaction", () => {
       [spendWalletRequest]
     );
 
-    const amountToSpend = 500000000000000000;
+    const amountToSpend = "500000000000000000";
     await expect(
       client.request("wallet_sendtoaddress", [
         spendWalletRequest,
@@ -133,13 +133,13 @@ describe("Wallet transaction", () => {
 
     await expect(
       client.request("wallet_balance", [receiveWalletRequest])
-    ).to.eventually.deep.eq(new BigNumber(0));
+    ).to.eventually.deep.eq(0);
 
     await expect(
       client.request("wallet_sendtoaddress", [
         spendWalletRequest,
         receiveWalletAddress,
-        500000000000000000
+        "500000000000000000"
       ])
     ).to.eventually.deep.eq(null);
 
@@ -154,12 +154,12 @@ describe("Wallet transaction", () => {
     expectTransactionShouldBe(lastTransaction, {
       address: receiveWalletAddress,
       direction: TransactionDirection.INCOMING,
-      amount: new BigNumber("500000000000000000")
+      amount: "500000000000000000"
     });
 
     return expect(
       client.request("wallet_balance", [receiveWalletRequest])
-    ).to.eventually.deep.eq(new BigNumber("500000000000000000"));
+    ).to.eventually.deep.eq("500000000000000000");
   });
 
   it("User can receive funds", async () => {
@@ -179,7 +179,7 @@ describe("Wallet transaction", () => {
       client.request("wallet_sendtoaddress", [
         spendWalletRequest,
         RECEIVE_WALLET_ADDRESS,
-        500000000000000000
+        "500000000000000000"
       ])
     ).to.eventually.deep.eq(null);
 
@@ -200,7 +200,7 @@ describe("Wallet transaction", () => {
     expectTransactionShouldBe(lastTransaction, {
       address: RECEIVE_WALLET_ADDRESS,
       direction: TransactionDirection.INCOMING,
-      amount: new BigNumber("500000000000000000")
+      amount: "500000000000000000"
     });
 
     const expectedReceiveWalletBalanceAfterSend = receiveWalletBalanceBeforeSend.plus(
@@ -230,7 +230,7 @@ describe("Wallet transaction", () => {
       client.request("wallet_sendtoaddress", [
         walletRequest,
         RECEIVE_WALLET_ADDRESS,
-        500000000000000000
+        "500000000000000000"
       ])
     ).to.eventually.deep.eq(null);
 
@@ -296,7 +296,7 @@ const expectTransactionShouldBe = (
   });
 
   if (typeof expected.height !== "undefined") {
-    expect(actual.height).to.deep.eq(new BigNumber(expected.height));
+    expect(actual.height).to.deep.eq(expected.height);
   } else {
     expect(actual.height.isGreaterThan(0)).to.eq(true);
   }


### PR DESCRIPTION
This is a draft PR to try to introduce `SerializedCoin` which survives only in `client-*`. Test cases haven't passed but the skeleton is there.

### `SerializedCoin`
- Designed to be a data structure wrapping `Coin`
- Responsible only to do serialization, deserialization and conversion between string, u64 and Coin.

### This PR is for draft review only
I realized on the way of changing everything in `client-*` to use `SerializedCoin` that, some places are relying on `Coin` to do computation. They require conversion between different types, making the code looks clumsy.

But at the same time, I don't think it is a good idea to implement again the arithmetic operation on `SerializedCoin`. So I am considering to use @tomtau  suggestion to change the `Coin` struct directly by changing its serialization and deserialization is even better. @tomtau @devashishdxt more comment is welcomed.