### PR TITLE
Problem: (CRO-128) Using decorators for unspent transaction configuration is unintuitive

### DIFF
--- a/chain-core/src/tx/data/address.rs
+++ b/chain-core/src/tx/data/address.rs
@@ -17,6 +17,24 @@ pub enum ExtendedAddr {
     OrTree(TreeRoot),
 }
 
+impl ExtendedAddr {
+    /// Returns true if current address is redeem address, false otherwise.
+    pub fn is_redeem(&self) -> bool {
+        match self {
+            ExtendedAddr::BasicRedeem(_) => true,
+            ExtendedAddr::OrTree(_) => false,
+        }
+    }
+
+    /// Returns true if current address is tree address, false otherwise.
+    pub fn is_tree(&self) -> bool {
+        match self {
+            ExtendedAddr::BasicRedeem(_) => false,
+            ExtendedAddr::OrTree(_) => true,
+        }
+    }
+}
+
 impl fmt::Display for ExtendedAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -16,7 +16,7 @@ use chain_core::tx::TransactionId;
 use chain_core::tx::TxAux;
 use client_common::{ErrorKind, Result};
 
-use crate::unspent_transactions::Decorator::*;
+use crate::unspent_transactions::{Filter, Operation, Sorter};
 use crate::{TransactionBuilder, UnspentTransactions, WalletClient};
 
 /// Default implementation of `TransactionBuilder`
@@ -257,10 +257,12 @@ where
         attributes: TxAttributes,
         wallet_client: &W,
     ) -> Result<TxAux> {
+        let operations = &[
+            Operation::Filter(Filter::OnlyRedeemAddresses),
+            Operation::Sort(Sorter::HighestValueFirst),
+        ];
         let mut unspent_transactions = wallet_client.unspent_transactions(name, passphrase)?;
-        unspent_transactions
-            .decorate_with(OnlyRedeemAddresses)
-            .decorate_with(HighestValueFirst);
+        unspent_transactions.apply_all(operations);
 
         let (select_until, difference_amount) =
             self.transaction_estimate(&outputs, &attributes, &unspent_transactions)?;

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -9,10 +9,7 @@ use chain_core::tx::data::output::TxOut;
 /// # Usage
 ///
 /// ```no_run
-/// # use chain_core::tx::data::input::TxoPointer;
-/// # use chain_core::tx::data::output::TxOut;
 /// # use client_core::unspent_transactions::*;
-/// # use client_core::wallet::DefaultWalletClient;
 /// // Retrieve a list of unspent transactions from an external source (e.g. WalletClient)
 /// let mut unspent_transactions = UnspentTransactions::default();
 ///

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -45,7 +45,7 @@ impl DerefMut for UnspentTransactions {
 impl UnspentTransactions {
     /// Creates a new instance of unspent transactions
     #[inline]
-    pub fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> UnspentTransactions {
+    pub fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> Self {
         Self {
             inner: unspent_transactions,
         }
@@ -87,7 +87,7 @@ enum Inner {
 impl Builder {
     /// Creates a new instance of unspent transaction builder
     #[inline]
-    fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> Builder {
+    fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> Self {
         Self {
             inner: Inner::Normal(unspent_transactions),
         }
@@ -169,6 +169,7 @@ impl Builder {
 
                 let mut unspent_transactions = left.build();
                 unspent_transactions.extend(right.build().unwrap());
+                unspent_transactions.shrink_to_fit();
                 unspent_transactions
             }
         }

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -1,7 +1,6 @@
 //! Operations on unspent transactions
 use std::ops::{Deref, DerefMut};
 
-use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 
@@ -12,21 +11,20 @@ use chain_core::tx::data::output::TxOut;
 /// ```no_run
 /// # use chain_core::tx::data::input::TxoPointer;
 /// # use chain_core::tx::data::output::TxOut;
-/// # use client_core::unspent_transactions::{UnspentTransactions, Decorator::*};
+/// # use client_core::unspent_transactions::*;
 /// # use client_core::wallet::DefaultWalletClient;
-/// // Retrieve a list of unspent transactions from an external source
-/// let unspent_transactions: Vec<(TxoPointer, TxOut)> = Vec::new();
+/// // Retrieve a list of unspent transactions from an external source (e.g. WalletClient)
+/// let mut unspent_transactions = UnspentTransactions::default();
 ///
-/// // Resolve these unspent transactions into `TxOut`
-/// let mut unspent_transactions = UnspentTransactions::new(unspent_transactions);
+/// // A list of operations to apply: only transactions with redeem addresses and in
+/// // decreasing order of their value.
+/// let operations = &[Operation::Filter(Filter::OnlyRedeemAddresses),
+///     Operation::Sort(Sorter::HighestValueFirst)];
 ///
-/// // This will filter and sort unspent transactions: only transactions with
-/// // redeem addresses and in decreasing order of their value.
-/// unspent_transactions
-///     .decorate_with(OnlyRedeemAddresses)
-///     .decorate_with(HighestValueFirst);
+/// // Apply operations
+/// unspent_transactions.apply_all(operations);
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct UnspentTransactions {
     inner: Vec<(TxoPointer, TxOut)>,
 }
@@ -34,12 +32,14 @@ pub struct UnspentTransactions {
 impl Deref for UnspentTransactions {
     type Target = Vec<(TxoPointer, TxOut)>;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 impl DerefMut for UnspentTransactions {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
@@ -47,69 +47,241 @@ impl DerefMut for UnspentTransactions {
 
 impl UnspentTransactions {
     /// Creates a new instance of unspent transactions
-    pub fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> Self {
+    #[inline]
+    pub fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> UnspentTransactions {
         Self {
             inner: unspent_transactions,
         }
     }
 
-    /// Decorates unspent transactions with a decorator
-    pub fn decorate_with(&mut self, decorator: Decorator) -> &mut Self {
-        decorator.decorate(self);
-        self.shrink_to_fit();
-        self
-    }
+    /// Applies operations on current unspent transactions
+    pub fn apply_all(&mut self, operations: &[Operation]) {
+        let mut temp = UnspentTransactions::default();
+        std::mem::swap(self, &mut temp);
 
-    /// Decorates unspent transactions with a list of decorators
-    pub fn decorate_with_all(&mut self, decorators: &[Decorator]) -> &mut Self {
-        for decorator in decorators {
-            decorator.decorate(self);
+        let mut builder = Builder::new(temp.unwrap());
+
+        for operation in operations {
+            builder = builder.apply(*operation);
         }
-        self.shrink_to_fit();
-        self
+
+        temp = builder.build();
+
+        std::mem::swap(self, &mut temp);
     }
 
     /// Returns inner vector of unspent transactions
+    #[inline]
     pub fn unwrap(self) -> Vec<(TxoPointer, TxOut)> {
         self.inner
     }
 }
 
-/// Decorators for unspent transactions
-pub enum Decorator {
+/// Builder for unspent transactions
+struct Builder {
+    inner: Inner,
+}
+
+enum Inner {
+    Normal(Vec<(TxoPointer, TxOut)>),
+    Grouped(Box<Builder>, Box<Builder>),
+}
+
+impl Builder {
+    /// Creates a new instance of unspent transaction builder
+    #[inline]
+    fn new(unspent_transactions: Vec<(TxoPointer, TxOut)>) -> Builder {
+        Self {
+            inner: Inner::Normal(unspent_transactions),
+        }
+    }
+
+    /// Applies sorting operation
+    fn sort_by(&mut self, sorter: Sorter) {
+        match self.inner {
+            Inner::Normal(ref mut unspent_transactions) => sorter.sort(unspent_transactions),
+            Inner::Grouped(ref mut left, ref mut right) => {
+                left.sort_by(sorter);
+                right.sort_by(sorter);
+            }
+        }
+    }
+
+    /// Applies filtering operation
+    fn filter_by(&mut self, filter: Filter) {
+        match self.inner {
+            Inner::Normal(ref mut unspent_transactions) => filter.filter(unspent_transactions),
+            Inner::Grouped(ref mut left, ref mut right) => {
+                left.filter_by(filter);
+                right.filter_by(filter);
+            }
+        }
+    }
+
+    /// Applies grouping operation
+    fn group_by(&mut self, group_by: GroupBy) {
+        let mut temp = Inner::Normal(Vec::new());
+        std::mem::swap(&mut self.inner, &mut temp);
+
+        let (left, right) = match temp {
+            Inner::Normal(unspent_transactions) => {
+                let (left, right) = group_by.group_by(unspent_transactions);
+                (
+                    Box::new(Builder {
+                        inner: Inner::Normal(left),
+                    }),
+                    Box::new(Builder {
+                        inner: Inner::Normal(right),
+                    }),
+                )
+            }
+            Inner::Grouped(mut left, mut right) => {
+                left.group_by(group_by);
+                right.group_by(group_by);
+
+                (left, right)
+            }
+        };
+
+        self.inner = Inner::Grouped(left, right);
+    }
+
+    /// Applies an operation
+    fn apply(mut self, operation: Operation) -> Self {
+        match operation {
+            Operation::Filter(filter_by) => self.filter_by(filter_by),
+            Operation::Sort(sort_by) => self.sort_by(sort_by),
+            Operation::Group(group_by) => self.group_by(group_by),
+        }
+
+        self
+    }
+
+    /// Freezes current builder and returns unspent transactions after applying all operations
+    fn build(self) -> UnspentTransactions {
+        match self.inner {
+            Inner::Normal(mut unspent_transactions) => {
+                unspent_transactions.shrink_to_fit();
+                UnspentTransactions {
+                    inner: unspent_transactions,
+                }
+            }
+            Inner::Grouped(left, right) => {
+                let left: Builder = *left;
+                let right: Builder = *right;
+
+                let mut unspent_transactions = left.build();
+                unspent_transactions.extend(right.build().unwrap());
+                unspent_transactions
+            }
+        }
+    }
+}
+
+/// Operations on unspent transactions
+#[derive(Debug, Clone, Copy)]
+pub enum Operation {
+    /// Filter operations
+    Filter(Filter),
+    /// Sort operations
+    Sort(Sorter),
+    /// Grouping operations
+    Group(GroupBy),
+}
+
+/// Filters for unspent transactions
+#[derive(Debug, Clone, Copy)]
+pub enum Filter {
     /// Filters out all the unspent transactions without redeem addresses
     OnlyRedeemAddresses,
     /// Filters out all the unspent transactions without tree addresses
     OnlyTreeAddresses,
-    /// Sorts unspent transactions such that ones with highest value are selected first
-    HighestValueFirst,
 }
 
-impl Decorator {
-    /// Decorates unspent transactions
-    fn decorate(&self, unspent_transactions: &mut UnspentTransactions) {
-        use Decorator::*;
-
+impl Filter {
+    /// Filters unspent transactions
+    fn filter(self, unspent_transactions: &mut Vec<(TxoPointer, TxOut)>) {
         match self {
-            OnlyRedeemAddresses => unspent_transactions.retain(|(_, unspent_transaction)| {
-                match unspent_transaction.address {
-                    ExtendedAddr::BasicRedeem(_) => true,
-                    ExtendedAddr::OrTree(_) => false,
-                }
-            }),
-            OnlyTreeAddresses => unspent_transactions.retain(|(_, unspent_transaction)| {
-                match unspent_transaction.address {
-                    ExtendedAddr::BasicRedeem(_) => false,
-                    ExtendedAddr::OrTree(_) => true,
-                }
-            }),
-            HighestValueFirst => {
-                unspent_transactions
-                    .sort_by_key(|(_, unspent_transaction)| unspent_transaction.value);
-                unspent_transactions.reverse();
+            Filter::OnlyRedeemAddresses => unspent_transactions
+                .retain(|(_, unspent_transaction)| unspent_transaction.address.is_redeem()),
+            Filter::OnlyTreeAddresses => unspent_transactions
+                .retain(|(_, unspent_transaction)| unspent_transaction.address.is_tree()),
+        }
+    }
+}
+
+/// Sorters for unspent transactions
+#[derive(Debug, Clone, Copy)]
+pub enum Sorter {
+    /// Sorts unspent transactions such that ones with highest value are selected first
+    HighestValueFirst,
+    /// Sorts unspent transactions such that ones with highest value are selected first
+    LowestValueFirst,
+}
+
+impl Sorter {
+    /// Sorts unspent transactions
+    fn sort(self, unspent_transactions: &mut Vec<(TxoPointer, TxOut)>) {
+        match self {
+            Sorter::HighestValueFirst => {
+                unspent_transactions.sort_by(|(_, a), (_, b)| a.value.cmp(&b.value).reverse())
+            }
+            Sorter::LowestValueFirst => {
+                unspent_transactions.sort_by(|(_, a), (_, b)| a.value.cmp(&b.value))
             }
         }
     }
+}
+
+/// Grouping clause for unspent transactions
+#[derive(Debug, Clone, Copy)]
+pub enum GroupBy {
+    /// Groups unspent transactions by address type
+    AddressType(AddressTypeOrder),
+}
+
+impl GroupBy {
+    /// Groups unspent transactions
+    #[allow(clippy::type_complexity)]
+    fn group_by(
+        self,
+        unspent_transactions: Vec<(TxoPointer, TxOut)>,
+    ) -> (Vec<(TxoPointer, TxOut)>, Vec<(TxoPointer, TxOut)>) {
+        let mut left = Vec::new();
+        let mut right = Vec::new();
+
+        match self {
+            GroupBy::AddressType(AddressTypeOrder::RedeemAddressFirst) => unspent_transactions
+                .into_iter()
+                .for_each(|(txo_pointer, tx_out)| {
+                    if tx_out.address.is_redeem() {
+                        left.push((txo_pointer, tx_out));
+                    } else {
+                        right.push((txo_pointer, tx_out))
+                    }
+                }),
+            GroupBy::AddressType(AddressTypeOrder::TreeAddressFirst) => unspent_transactions
+                .into_iter()
+                .for_each(|(txo_pointer, tx_out)| {
+                    if tx_out.address.is_redeem() {
+                        right.push((txo_pointer, tx_out));
+                    } else {
+                        left.push((txo_pointer, tx_out))
+                    }
+                }),
+        }
+
+        (left, right)
+    }
+}
+
+/// Ordering clause for address type groups in unspent transactions
+#[derive(Debug, Clone, Copy)]
+pub enum AddressTypeOrder {
+    /// Orders groups such that redeem address comes first
+    RedeemAddressFirst,
+    /// Orders groups such that tree address comes first
+    TreeAddressFirst,
 }
 
 #[cfg(test)]
@@ -120,6 +292,7 @@ mod tests {
 
     use chain_core::init::address::RedeemAddress;
     use chain_core::init::coin::Coin;
+    use chain_core::tx::data::address::ExtendedAddr;
 
     use crate::{PrivateKey, PublicKey};
 
@@ -166,29 +339,30 @@ mod tests {
             TxOut::new(ExtendedAddr::OrTree(random()), Coin::new(250).unwrap()),
         ));
 
-        UnspentTransactions {
-            inner: unspent_transactions,
-        }
+        UnspentTransactions::new(unspent_transactions)
     }
 
     #[test]
     fn check_only_redeem_addresses() {
+        let operations = &[Operation::Filter(Filter::OnlyRedeemAddresses)];
         let mut unspent_transactions = sample();
-        unspent_transactions.decorate_with(Decorator::OnlyRedeemAddresses);
+        unspent_transactions.apply_all(operations);
         assert_eq!(3, unspent_transactions.len());
     }
 
     #[test]
     fn check_only_tree_addresses() {
+        let operations = &[Operation::Filter(Filter::OnlyTreeAddresses)];
         let mut unspent_transactions = sample();
-        unspent_transactions.decorate_with(Decorator::OnlyTreeAddresses);
+        unspent_transactions.apply_all(operations);
         assert_eq!(2, unspent_transactions.len());
     }
 
     #[test]
     fn check_highest_value_first() {
+        let operations = &[Operation::Sort(Sorter::HighestValueFirst)];
         let mut unspent_transactions = sample();
-        unspent_transactions.decorate_with(Decorator::HighestValueFirst);
+        unspent_transactions.apply_all(operations);
         assert_eq!(5, unspent_transactions.len());
 
         let mut coin = Coin::max();
@@ -200,17 +374,54 @@ mod tests {
     }
 
     #[test]
-    fn check_decorate_with_all() {
+    fn check_grouped_redeem_first_sort() {
+        let operations = &[
+            Operation::Group(GroupBy::AddressType(AddressTypeOrder::RedeemAddressFirst)),
+            Operation::Sort(Sorter::LowestValueFirst),
+        ];
         let mut unspent_transactions = sample();
-        unspent_transactions
-            .decorate_with_all(&[Decorator::OnlyRedeemAddresses, Decorator::HighestValueFirst]);
+        unspent_transactions.apply_all(operations);
+        assert_eq!(5, unspent_transactions.len());
+
+        assert_eq!(unspent_transactions[0].1.value, Coin::new(100).unwrap());
+        assert_eq!(unspent_transactions[1].1.value, Coin::new(200).unwrap());
+        assert_eq!(unspent_transactions[2].1.value, Coin::new(300).unwrap());
+
+        assert_eq!(unspent_transactions[3].1.value, Coin::new(150).unwrap());
+        assert_eq!(unspent_transactions[4].1.value, Coin::new(250).unwrap());
+    }
+
+    #[test]
+    fn check_grouped_tree_first_sort() {
+        let operations = &[
+            Operation::Group(GroupBy::AddressType(AddressTypeOrder::TreeAddressFirst)),
+            Operation::Sort(Sorter::LowestValueFirst),
+        ];
+        let mut unspent_transactions = sample();
+        unspent_transactions.apply_all(operations);
+        assert_eq!(5, unspent_transactions.len());
+
+        assert_eq!(unspent_transactions[0].1.value, Coin::new(150).unwrap());
+        assert_eq!(unspent_transactions[1].1.value, Coin::new(250).unwrap());
+
+        assert_eq!(unspent_transactions[2].1.value, Coin::new(100).unwrap());
+        assert_eq!(unspent_transactions[3].1.value, Coin::new(200).unwrap());
+        assert_eq!(unspent_transactions[4].1.value, Coin::new(300).unwrap());
+    }
+
+    #[test]
+    fn check_grouped_tree_first_sort_with_redeem_filter() {
+        let operations = &[
+            Operation::Group(GroupBy::AddressType(AddressTypeOrder::TreeAddressFirst)),
+            Operation::Sort(Sorter::LowestValueFirst),
+            Operation::Filter(Filter::OnlyRedeemAddresses),
+        ];
+        let mut unspent_transactions = sample();
+        unspent_transactions.apply_all(operations);
         assert_eq!(3, unspent_transactions.len());
 
-        let mut coin = Coin::max();
-
-        for (_, tx_out) in unspent_transactions.iter() {
-            assert!(tx_out.value < coin);
-            coin = tx_out.value;
-        }
+        assert_eq!(unspent_transactions[0].1.value, Coin::new(100).unwrap());
+        assert_eq!(unspent_transactions[1].1.value, Coin::new(200).unwrap());
+        assert_eq!(unspent_transactions[2].1.value, Coin::new(300).unwrap());
     }
 }


### PR DESCRIPTION
**Solution**: 

Added a concept of operations that can be applied to unspent transactions:
- There are three type of operations:
  - Filter
  - Sort
  - GroupBy
- Filter and Sort are self explanatory
- GroupBy will divide unspent transactions in two groups and will apply subsequent operations
  to each group separately.
- This can be used to achieve a usecase where we want all the unspent transaction separated
  in two groups of redeem address and tree address respectively and both groups should
  individually be sorted by descending order of their value.

**Usage**:

```
// Retrieve a list of unspent transactions from an external source (e.g. WalletClient)
let mut unspent_transactions = UnspentTransactions::default();

// A list of operations to apply: only transactions with redeem addresses and in
// decreasing order of their value.
let operations = &[Operation::Filter(Filter::OnlyRedeemAddresses),
    Operation::Sort(Sorter::HighestValueFirst)];

// Apply operations
unspent_transactions.apply_all(operations);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crypto-com/chain/129)
<!-- Reviewable:end -->
