### PR TITLE
Problem: (CRO-128) 1-of-n schnorr signatures are not supported by transaction builder

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -11,6 +11,7 @@ use client_common::balance::BalanceChange;
 use client_common::storage::SledStorage;
 use client_common::tendermint::{Client, RpcClient};
 use client_common::Result;
+use client_core::signer::DefaultSigner;
 use client_core::transaction_builder::DefaultTransactionBuilder;
 use client_core::wallet::{DefaultWalletClient, WalletClient};
 use client_index::index::DefaultIndex;
@@ -98,8 +99,11 @@ impl Command {
             } => {
                 let storage = SledStorage::new(storage_path())?;
                 let tendermint_client = RpcClient::new(&tendermint_url());
-                let transaction_builder =
-                    DefaultTransactionBuilder::new(tendermint_client.genesis()?.fee_policy());
+                let signer = DefaultSigner::new(storage.clone());
+                let transaction_builder = DefaultTransactionBuilder::new(
+                    signer,
+                    tendermint_client.genesis()?.fee_policy(),
+                );
                 let transaction_index = DefaultIndex::new(storage.clone(), tendermint_client);
                 let wallet_client = DefaultWalletClient::builder()
                     .with_wallet(storage)

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -12,7 +12,6 @@ use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use client_common::{ErrorKind, Result};
-use client_core::unspent_transactions::{Filter, Operation, Sorter};
 use client_core::WalletClient;
 
 use crate::ask_passphrase;
@@ -53,17 +52,13 @@ impl TransactionCommand {
         let outputs = Self::ask_outputs()?;
 
         let return_address = wallet_client.new_redeem_address(name, &passphrase)?;
-        let operations = &[
-            Operation::Filter(Filter::OnlyRedeemAddresses),
-            Operation::Sort(Sorter::HighestValueFirst),
-        ];
 
         let transaction = wallet_client.create_transaction(
             name,
             &passphrase,
             outputs,
             attributes,
-            operations,
+            None,
             return_address,
         )?;
 

--- a/client-core/src/input_selection.rs
+++ b/client-core/src/input_selection.rs
@@ -1,0 +1,34 @@
+//! Input selection operations
+use crate::unspent_transactions::{Operation, Sorter};
+
+/// Different strategies for input selection
+#[derive(Debug)]
+pub enum InputSelectionStrategy {
+    /// Selects unspent transactions with highest value first
+    HighestValueFirst,
+    /// Selects unspent transactions with lowest value first
+    LowestValueFirst,
+    /// Selects unspent transactions randomly
+    Random,
+}
+
+impl Default for InputSelectionStrategy {
+    #[inline]
+    fn default() -> Self {
+        InputSelectionStrategy::HighestValueFirst
+    }
+}
+
+impl AsRef<[Operation]> for InputSelectionStrategy {
+    fn as_ref(&self) -> &[Operation] {
+        match self {
+            InputSelectionStrategy::HighestValueFirst => {
+                &[Operation::Sort(Sorter::HighestValueFirst)]
+            }
+            InputSelectionStrategy::LowestValueFirst => {
+                &[Operation::Sort(Sorter::LowestValueFirst)]
+            }
+            InputSelectionStrategy::Random => &[],
+        }
+    }
+}

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Transaction creation and signing (with automatic unspent transaction selection)
 pub mod key;
 pub mod service;
+pub mod signer;
 pub mod transaction_builder;
 pub mod unspent_transactions;
 pub mod wallet;
@@ -18,9 +19,11 @@ pub mod wallet;
 #[doc(inline)]
 pub use key::{PrivateKey, PublicKey};
 #[doc(inline)]
+pub use signer::Signer;
+#[doc(inline)]
 pub use transaction_builder::TransactionBuilder;
 #[doc(inline)]
-pub use unspent_transactions::UnspentTransactions;
+pub use unspent_transactions::{SelectedUnspentTransactions, UnspentTransactions};
 #[doc(inline)]
 pub use wallet::{MultiSigWalletClient, WalletClient};
 

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! - Balance tracking
 //! - Transaction history
 //! - Transaction creation and signing (with automatic unspent transaction selection)
+pub mod input_selection;
 pub mod key;
 pub mod service;
 pub mod signer;
@@ -16,6 +17,8 @@ pub mod transaction_builder;
 pub mod unspent_transactions;
 pub mod wallet;
 
+#[doc(inline)]
+pub use input_selection::InputSelectionStrategy;
 #[doc(inline)]
 pub use key::{PrivateKey, PublicKey};
 #[doc(inline)]

--- a/client-core/src/service/root_hash_service.rs
+++ b/client-core/src/service/root_hash_service.rs
@@ -233,6 +233,13 @@ mod tests {
         );
 
         assert_eq!(
+            public_keys[0].clone(),
+            root_hash_service
+                .public_key(&root_hash, &passphrase)
+                .unwrap()
+        );
+
+        assert_eq!(
             ErrorKind::AddressNotFound,
             root_hash_service
                 .required_signers(&[0u8; 32], &passphrase)

--- a/client-core/src/service/root_hash_service.rs
+++ b/client-core/src/service/root_hash_service.rs
@@ -53,6 +53,7 @@ where
             || m == 0
             || !public_keys.contains(&self_public_key)
         {
+            // TODO: Return different error kinds for different input errors
             return Err(ErrorKind::InvalidInput.into());
         }
 

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -18,7 +18,7 @@ struct Wallet {
     pub root_hashes: Vec<H256>,
 }
 
-/// Maintains mapping `wallet-name -> Vec<wallet>`
+/// Maintains mapping `wallet-name -> wallet-details`
 #[derive(Debug, Default, Clone)]
 pub struct WalletService<T: Storage> {
     storage: T,

--- a/client-core/src/signer.rs
+++ b/client-core/src/signer.rs
@@ -1,0 +1,25 @@
+//! Transaction signing
+mod default_signer;
+mod unauthorized_signer;
+
+pub use default_signer::DefaultSigner;
+pub use unauthorized_signer::UnauthorizedSigner;
+
+use secstr::SecUtf8;
+
+use chain_core::tx::witness::TxWitness;
+use client_common::Result;
+
+use crate::SelectedUnspentTransactions;
+
+/// Interface for signing transactions
+pub trait Signer: Send + Sync {
+    /// Signs given transaction with private keys corresponding to selected unspent transactions
+    fn sign<T: AsRef<[u8]>>(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        message: T,
+        selected_unspent_transactions: SelectedUnspentTransactions,
+    ) -> Result<TxWitness>;
+}

--- a/client-core/src/signer/default_signer.rs
+++ b/client-core/src/signer/default_signer.rs
@@ -87,3 +87,170 @@ where
         Ok(witnesses.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chain_core::init::coin::Coin;
+    use chain_core::tx::data::input::TxoPointer;
+    use chain_core::tx::data::output::TxOut;
+    use chain_core::tx::data::Tx;
+    use chain_core::tx::TransactionId;
+    use client_common::storage::MemoryStorage;
+
+    use crate::wallet::DefaultWalletClient;
+    use crate::{UnspentTransactions, WalletClient};
+
+    #[test]
+    fn check_redeem_signing_flow() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+        let message = Tx::new().id();
+
+        let storage = MemoryStorage::default();
+
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage.clone())
+            .build()
+            .unwrap();
+
+        wallet_client.new_wallet(name, passphrase).unwrap();
+
+        let redeem_addresses = vec![
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+        ];
+
+        let unspent_transactions = UnspentTransactions::new(vec![
+            (
+                TxoPointer::new([0; 32], 0),
+                TxOut::new(redeem_addresses[0].clone(), Coin::zero()),
+            ),
+            (
+                TxoPointer::new([1; 32], 0),
+                TxOut::new(redeem_addresses[1].clone(), Coin::zero()),
+            ),
+            (
+                TxoPointer::new([2; 32], 0),
+                TxOut::new(redeem_addresses[2].clone(), Coin::zero()),
+            ),
+        ]);
+        let selected_unspent_transactions = unspent_transactions.select_all();
+
+        let signer = DefaultSigner::new(storage);
+
+        let witness = signer
+            .sign(name, passphrase, message, selected_unspent_transactions)
+            .expect("Unable to sign transaction");
+
+        assert!(witness[0]
+            .verify_tx_address(&message, &redeem_addresses[0])
+            .is_ok());
+        assert!(witness[1]
+            .verify_tx_address(&message, &redeem_addresses[1])
+            .is_ok());
+        assert!(witness[2]
+            .verify_tx_address(&message, &redeem_addresses[2])
+            .is_ok());
+    }
+
+    #[test]
+    fn check_1_of_n_signing_flow() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+        let message = Tx::new().id();
+
+        let storage = MemoryStorage::default();
+
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage.clone())
+            .build()
+            .unwrap();
+
+        wallet_client.new_wallet(name, passphrase).unwrap();
+
+        let public_keys = vec![
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+        ];
+
+        let tree_address = wallet_client
+            .new_tree_address(
+                name,
+                passphrase,
+                public_keys.clone(),
+                public_keys[0].clone(),
+                1,
+                3,
+            )
+            .unwrap();
+
+        let unspent_transactions = UnspentTransactions::new(vec![(
+            TxoPointer::new([0; 32], 0),
+            TxOut::new(tree_address.clone(), Coin::zero()),
+        )]);
+        let selected_unspent_transactions = unspent_transactions.select_all();
+
+        let signer = DefaultSigner::new(storage);
+
+        let witness = signer
+            .sign(name, passphrase, message, selected_unspent_transactions)
+            .expect("Unable to sign transaction");
+
+        assert!(witness[0]
+            .verify_tx_address(&message, &tree_address)
+            .is_ok());
+    }
+
+    #[test]
+    fn check_2_of_3_invalid_signing_flow() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+        let message = Tx::new().id();
+
+        let storage = MemoryStorage::default();
+
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage.clone())
+            .build()
+            .unwrap();
+
+        wallet_client.new_wallet(name, passphrase).unwrap();
+
+        let public_keys = vec![
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+        ];
+
+        let tree_address = wallet_client
+            .new_tree_address(
+                name,
+                passphrase,
+                public_keys.clone(),
+                public_keys[0].clone(),
+                2,
+                3,
+            )
+            .unwrap();
+
+        let unspent_transactions = UnspentTransactions::new(vec![(
+            TxoPointer::new([0; 32], 0),
+            TxOut::new(tree_address.clone(), Coin::zero()),
+        )]);
+        let selected_unspent_transactions = unspent_transactions.select_all();
+
+        let signer = DefaultSigner::new(storage);
+
+        assert_eq!(
+            ErrorKind::InvalidTransaction,
+            signer
+                .sign(name, passphrase, message, selected_unspent_transactions)
+                .expect_err("Unable to sign transaction")
+                .kind()
+        );
+    }
+}

--- a/client-core/src/signer/default_signer.rs
+++ b/client-core/src/signer/default_signer.rs
@@ -1,0 +1,89 @@
+use either::Either;
+use secstr::SecUtf8;
+
+use chain_core::tx::witness::{TxInWitness, TxWitness};
+use client_common::{ErrorKind, Result, Storage};
+
+use crate::service::{KeyService, RootHashService, WalletService};
+use crate::{SelectedUnspentTransactions, Signer};
+
+/// Default implementation of `Signer`
+#[derive(Debug)]
+pub struct DefaultSigner<S: Storage> {
+    key_service: KeyService<S>,
+    root_hash_service: RootHashService<S>,
+    wallet_service: WalletService<S>,
+}
+
+impl<S> DefaultSigner<S>
+where
+    S: Storage + Clone,
+{
+    /// Creates a new instance of default signer
+    pub fn new(storage: S) -> Self {
+        Self {
+            key_service: KeyService::new(storage.clone()),
+            root_hash_service: RootHashService::new(storage.clone()),
+            wallet_service: WalletService::new(storage),
+        }
+    }
+}
+
+impl<S> Signer for DefaultSigner<S>
+where
+    S: Storage,
+{
+    fn sign<T: AsRef<[u8]>>(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        message: T,
+        selected_unspent_transactions: SelectedUnspentTransactions,
+    ) -> Result<TxWitness> {
+        let mut witnesses = Vec::with_capacity(selected_unspent_transactions.len());
+
+        for (_, output) in selected_unspent_transactions.iter() {
+            match self
+                .wallet_service
+                .find(name, passphrase, &output.address)?
+            {
+                None => return Err(ErrorKind::AddressNotFound.into()),
+                Some(Either::Left(public_key)) => {
+                    match self.key_service.private_key(&public_key, passphrase)? {
+                        None => return Err(ErrorKind::PrivateKeyNotFound.into()),
+                        Some(private_key) => witnesses.push(private_key.sign(&message)?),
+                    }
+                }
+                Some(Either::Right(root_hash)) => {
+                    if self
+                        .root_hash_service
+                        .required_signers(&root_hash, passphrase)?
+                        != 1
+                    {
+                        return Err(ErrorKind::InvalidTransaction.into());
+                    }
+
+                    let public_key = self.root_hash_service.public_key(&root_hash, passphrase)?;
+
+                    match self.key_service.private_key(&public_key, passphrase)? {
+                        None => return Err(ErrorKind::PrivateKeyNotFound.into()),
+                        Some(private_key) => {
+                            let proof = self.root_hash_service.generate_proof(
+                                &root_hash,
+                                vec![public_key],
+                                passphrase,
+                            )?;
+
+                            witnesses.push(TxInWitness::TreeSig(
+                                private_key.schnorr_sign(&message)?,
+                                proof,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(witnesses.into())
+    }
+}

--- a/client-core/src/signer/unauthorized_signer.rs
+++ b/client-core/src/signer/unauthorized_signer.rs
@@ -1,0 +1,22 @@
+use secstr::SecUtf8;
+
+use chain_core::tx::witness::TxWitness;
+use client_common::{ErrorKind, Result};
+
+use crate::{SelectedUnspentTransactions, Signer};
+
+/// `TransactionBuilder` which returns `PermissionDenied` error for each function call.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnauthorizedSigner;
+
+impl Signer for UnauthorizedSigner {
+    fn sign<T: AsRef<[u8]>>(
+        &self,
+        _: &str,
+        _: &SecUtf8,
+        _: T,
+        _: SelectedUnspentTransactions,
+    ) -> Result<TxWitness> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+}

--- a/client-core/src/transaction_builder.rs
+++ b/client-core/src/transaction_builder.rs
@@ -7,23 +7,34 @@ pub use unauthorized_transaction_builder::UnauthorizedTransactionBuilder;
 
 use secstr::SecUtf8;
 
+use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
 use client_common::Result;
 
-use crate::WalletClient;
+use crate::UnspentTransactions;
 
 /// Interface for transaction building from output addresses and amount. This trait is also responsible for UTXO
 /// selection.
 pub trait TransactionBuilder: Send + Sync {
-    /// Builds a transaction by returning extra coins to `return_address`.
-    fn build<W: WalletClient>(
+    /// Builds a transaction
+    ///
+    /// # Attributes
+    ///
+    /// - `name`: Name of wallet
+    /// - `passphrase`: Passphrase of wallet
+    /// - `outputs`: Transaction outputs
+    /// - `attributes`: Transaction attributes,
+    /// - `unspent_transactions`: Unspent transactions
+    /// - `return_address`: Address to which change amount will get returned
+    fn build(
         &self,
         name: &str,
         passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
-        wallet_client: &W,
+        unspent_transactions: UnspentTransactions,
+        return_address: ExtendedAddr,
     ) -> Result<TxAux>;
 }

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -1,669 +1,120 @@
-use either::Either;
 use failure::ResultExt;
-use secp256k1::RecoveryId;
 use secstr::SecUtf8;
 
-use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
-use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::Tx;
-use chain_core::tx::fee::{Fee, FeeAlgorithm};
-use chain_core::tx::witness::{EcdsaSignature, TxInWitness, TxWitness};
-use chain_core::tx::TransactionId;
-use chain_core::tx::TxAux;
+use chain_core::tx::fee::FeeAlgorithm;
+use chain_core::tx::{TransactionId, TxAux};
 use client_common::{ErrorKind, Result};
 
-use crate::unspent_transactions::{Filter, Operation, Sorter};
-use crate::{TransactionBuilder, UnspentTransactions, WalletClient};
+use crate::{SelectedUnspentTransactions, Signer, TransactionBuilder, UnspentTransactions};
 
 /// Default implementation of `TransactionBuilder`
-///
-/// # Algorithm
-///
-/// 1. Retrieve a list of unspent transactions and sort it in descending order of amounts.
-/// 2. Calculate the number of unspent transactions to select from beginning and the amount to be returned back from
-///    transaction estimation algorithm.
-/// 3. Build a transaction from above data.
-///
-/// # Transaction Estimation Algorithm
-///
-/// 1. Initialize `fee = 0`.
-/// 2. Build a transaction with zero fee.
-/// 3. Calculate `new_fee`.
-/// 4. Do steps 5 - 8 until `fee < new_fee`.
-/// 5. Calculate amount to transfer (fee + sum of amounts of outputs).
-/// 6. Select unspent transactions from beginning such that amount of unspent transactions is greater than amount to
-///    transfer.
-/// 7. Add dummy values for output and witnesses and calculate `revised_fee`.
-/// 8. `fee = new_fee` and `new_fee = revised_fee`.
-/// 9. When the above loop is done, return number of selected unspent transactions and difference amount.
 #[derive(Debug)]
-pub struct DefaultTransactionBuilder<F>
+pub struct DefaultTransactionBuilder<S, F>
 where
+    S: Signer,
     F: FeeAlgorithm,
 {
+    signer: S,
     fee_algorithm: F,
 }
 
-impl<F> DefaultTransactionBuilder<F>
+impl<S, F> DefaultTransactionBuilder<S, F>
 where
+    S: Signer,
     F: FeeAlgorithm,
 {
-    /// Creates a new instance of `DefaultTransactionBuilder`
-    pub fn new(fee_algorithm: F) -> Self {
-        Self { fee_algorithm }
-    }
-
-    /// Adds amounts in all outputs and fee
-    fn amount_to_transfer(&self, outputs: &[TxOut], fee: Fee) -> Result<Coin> {
-        let mut amount_to_transfer = fee.to_coin();
-        for output in outputs.iter() {
-            amount_to_transfer =
-                (amount_to_transfer + output.value).context(ErrorKind::BalanceAdditionError)?;
+    /// Creates a new instance of transaction builder
+    pub fn new(signer: S, fee_algorithm: F) -> Self {
+        Self {
+            signer,
+            fee_algorithm,
         }
-
-        Ok(amount_to_transfer)
-    }
-
-    /// Returns the index until which transactions were selected and difference amount between selected transactions
-    /// and amount to transfer (`transferred_amount - amount_to_transfer`)
-    fn select_transactions(
-        &self,
-        unspent_transactions: &UnspentTransactions,
-        amount_to_transfer: Coin,
-    ) -> Result<(usize, Coin)> {
-        let mut transferred_amount = Coin::zero();
-
-        for (i, (_, unspent_transaction)) in unspent_transactions.iter().enumerate() {
-            transferred_amount = (transferred_amount + unspent_transaction.value)
-                .context(ErrorKind::BalanceAdditionError)?;
-
-            if transferred_amount >= amount_to_transfer {
-                return Ok((
-                    i + 1,
-                    (transferred_amount - amount_to_transfer)
-                        .context(ErrorKind::BalanceAdditionError)?,
-                ));
-            }
-        }
-
-        Err(ErrorKind::InsufficientBalance.into())
-    }
-
-    /// Signs the transaction and returns witnesses
-    fn witnesses<W: WalletClient>(
-        &self,
-        name: &str,
-        passphrase: &SecUtf8,
-        wallet_client: &W,
-        transaction: &Tx,
-    ) -> Result<TxWitness> {
-        let mut witnesses = Vec::with_capacity(transaction.inputs.len());
-
-        for input in &transaction.inputs {
-            let input = wallet_client.output(&input.id, input.index)?;
-
-            match wallet_client.find(name, passphrase, &input.address)? {
-                None => return Err(ErrorKind::AddressNotFound.into()),
-                Some(Either::Left(public_key)) => {
-                    match wallet_client.private_key(passphrase, &public_key)? {
-                        None => return Err(ErrorKind::PrivateKeyNotFound.into()),
-                        Some(private_key) => witnesses.push(private_key.sign(&transaction.id())?),
-                    }
-                }
-                Some(Either::Right(_root_hash)) => {
-                    return Err(ErrorKind::InvalidInput.into());
-                }
-            }
-        }
-
-        Ok(witnesses.into())
-    }
-
-    /// Returns `(select_until, difference_amount)`
-    /// - `select_until`: It is the number of the unspent transactions to take from beginning of given unspent
-    ///   transactions to build valid transaction
-    /// - `difference_amount`: Amount to return back to sender's wallet
-    fn transaction_estimate(
-        &self,
-        outputs: &[TxOut],
-        attributes: &TxAttributes,
-        unspent_transactions: &UnspentTransactions,
-    ) -> Result<(usize, Coin)> {
-        let mut fee = Fee::new(Coin::zero());
-        let (mut tx_aux, mut selected_until, mut difference_amount) =
-            self.transaction_estimate_with_fee(outputs, attributes, unspent_transactions, fee)?;
-        let mut new_fee = self
-            .fee_algorithm
-            .calculate_for_txaux(&tx_aux)
-            .context(ErrorKind::BalanceAdditionError)?;
-
-        while fee < new_fee {
-            fee = new_fee;
-            let (new_tx_aux, new_selected_until, new_difference_amount) =
-                self.transaction_estimate_with_fee(outputs, attributes, unspent_transactions, fee)?;
-
-            tx_aux = new_tx_aux;
-            selected_until = new_selected_until;
-            difference_amount = new_difference_amount;
-
-            new_fee = self
-                .fee_algorithm
-                .calculate_for_txaux(&tx_aux)
-                .context(ErrorKind::BalanceAdditionError)?;
-        }
-
-        Ok((selected_until, difference_amount))
-    }
-
-    /// Returns `(dummy_transaction, select_until, difference_amount)`
-    /// - `dummy_transaction`: Transaction with dummy values used for fee calculation
-    /// - `select_until`: It is the number of the unspent transactions to take from beginning of given unspent
-    ///   transactions to build valid transaction
-    /// - `difference_amount`: Amount to return back to sender's wallet
-    fn transaction_estimate_with_fee(
-        &self,
-        outputs: &[TxOut],
-        attributes: &TxAttributes,
-        unspent_transactions: &UnspentTransactions,
-        fee: Fee,
-    ) -> Result<(TxAux, usize, Coin)> {
-        let amount_to_transfer = self.amount_to_transfer(&outputs, fee)?;
-
-        let (selected_until, difference_amount) =
-            self.select_transactions(unspent_transactions, amount_to_transfer)?;
-
-        let inputs = unspent_transactions[..selected_until]
-            .iter()
-            .map(|(input, _)| input.clone())
-            .collect::<Vec<TxoPointer>>();
-
-        let transaction_estimate = if Coin::zero() == difference_amount {
-            Tx {
-                inputs,
-                outputs: outputs.to_vec(),
-                attributes: attributes.clone(),
-            }
-        } else {
-            let mut outputs = outputs.to_vec();
-            outputs.push(TxOut {
-                address: ExtendedAddr::BasicRedeem(RedeemAddress([
-                    0x0e, 0x7c, 0x04, 0x51, 0x10, 0xb8, 0xdb, 0xf2, 0x97, 0x65, 0x04, 0x73, 0x80,
-                    0x89, 0x89, 0x19, 0xc5, 0xcb, 0x56, 0xf4,
-                ])),
-                value: Coin::zero(),
-                valid_from: None,
-            });
-
-            Tx {
-                inputs,
-                outputs,
-                attributes: attributes.clone(),
-            }
-        };
-
-        let witness_estimate = self.witness_estimate(selected_until);
-
-        let tx_aux = TxAux::TransferTx(transaction_estimate, witness_estimate);
-
-        Ok((tx_aux, selected_until, difference_amount))
-    }
-
-    /// Returns dummy witnesses
-    fn witness_estimate(&self, num_inputs: usize) -> TxWitness {
-        vec![
-            TxInWitness::BasicRedeem(
-                EcdsaSignature::from_compact(&[0; 64], RecoveryId::from_i32(0).unwrap()).unwrap(),
-            );
-            num_inputs
-        ]
-        .into()
-    }
-
-    /// Builds final transaction
-    fn build_from_estimate<W: WalletClient>(
-        &self,
-        name: &str,
-        passphrase: &SecUtf8,
-        mut transaction: Tx,
-        difference_amount: Coin,
-        wallet_client: &W,
-    ) -> Result<TxAux> {
-        if Coin::zero() != difference_amount {
-            let new_address = wallet_client.new_redeem_address(name, passphrase)?;
-            transaction
-                .outputs
-                .push(TxOut::new(new_address, difference_amount));
-        }
-
-        let witnesses = self.witnesses(name, passphrase, wallet_client, &transaction)?;
-
-        Ok(TxAux::TransferTx(transaction, witnesses))
     }
 }
 
-impl<F> TransactionBuilder for DefaultTransactionBuilder<F>
+impl<S, F> TransactionBuilder for DefaultTransactionBuilder<S, F>
 where
+    S: Signer,
     F: FeeAlgorithm,
 {
-    fn build<W: WalletClient>(
+    fn build(
         &self,
         name: &str,
         passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
-        wallet_client: &W,
+        unspent_transactions: UnspentTransactions,
+        return_address: ExtendedAddr,
     ) -> Result<TxAux> {
-        let operations = &[
-            Operation::Filter(Filter::OnlyRedeemAddresses),
-            Operation::Sort(Sorter::HighestValueFirst),
-        ];
-        let mut unspent_transactions = wallet_client.unspent_transactions(name, passphrase)?;
-        unspent_transactions.apply_all(operations);
+        let mut fees = Coin::zero();
 
-        let (select_until, difference_amount) =
-            self.transaction_estimate(&outputs, &attributes, &unspent_transactions)?;
+        loop {
+            let (selected_unspent_transactions, difference_amount) =
+                unspent_transactions.select(fees)?;
 
-        unspent_transactions.truncate(select_until);
+            let transaction = build_transaction(
+                &selected_unspent_transactions,
+                outputs.clone(),
+                attributes.clone(),
+                difference_amount,
+                return_address.clone(),
+            );
 
-        let transaction = Tx {
-            inputs: unspent_transactions
-                .unwrap()
-                .into_iter()
-                .map(|(input, _)| input)
-                .collect(),
-            outputs,
-            attributes,
-        };
+            let witness = self.signer.sign(
+                name,
+                passphrase,
+                transaction.id(),
+                selected_unspent_transactions,
+            )?;
 
-        self.build_from_estimate(
-            name,
-            passphrase,
-            transaction,
-            difference_amount,
-            wallet_client,
-        )
+            let tx_aux = TxAux::TransferTx(transaction, witness);
+
+            let new_fees = self
+                .fee_algorithm
+                .calculate_for_txaux(&tx_aux)
+                .context(ErrorKind::BalanceAdditionError)?
+                .to_coin();
+
+            if new_fees > fees {
+                fees = new_fees;
+            } else {
+                return Ok(tx_aux);
+            }
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use std::str::FromStr;
-
-    use chain_core::common::{Proof, H256};
-    use chain_core::init::address::RedeemAddress;
-    use chain_core::init::coin::sum_coins;
-    use chain_core::tx::data::address::ExtendedAddr;
-    use chain_core::tx::data::TxId;
-    use chain_core::tx::fee::{LinearFee, Milli};
-    use chain_core::tx::witness::tree::RawPubkey;
-    use client_common::balance::TransactionChange;
-
-    use crate::{PrivateKey, PublicKey};
-
-    struct MockWalletClient {
-        txid_0: TxId,
-        txid_1: TxId,
-        txid_2: TxId,
-        private_key_0: PrivateKey,
-        private_key_1: PrivateKey,
-        private_key_2: PrivateKey,
-        public_key_0: PublicKey,
-        public_key_1: PublicKey,
-        public_key_2: PublicKey,
-        addr_0: ExtendedAddr,
-        addr_1: ExtendedAddr,
-        addr_2: ExtendedAddr,
-    }
-
-    impl MockWalletClient {
-        fn assert_fee(&self, fee: Fee, transaction: Tx) {
-            let input_amounts = transaction
-                .inputs
+fn build_transaction(
+    selected_unspent_transactions: &SelectedUnspentTransactions,
+    mut outputs: Vec<TxOut>,
+    attributes: TxAttributes,
+    difference_amount: Coin,
+    return_address: ExtendedAddr,
+) -> Tx {
+    if difference_amount == Coin::zero() {
+        Tx {
+            inputs: selected_unspent_transactions
                 .iter()
-                .map(|input| self.output(&input.id, input.index))
-                .collect::<Result<Vec<TxOut>>>()
-                .unwrap()
-                .into_iter()
-                .map(|input| input.value)
-                .collect::<Vec<Coin>>();
-
-            let input_amount = sum_coins(input_amounts.into_iter()).unwrap();
-
-            let output_amounts = transaction
-                .outputs
-                .into_iter()
-                .map(|output| output.value)
-                .collect::<Vec<Coin>>();
-
-            let output_amount = sum_coins(output_amounts.into_iter()).unwrap();
-
-            assert!(fee.to_coin() <= (input_amount - output_amount).unwrap());
+                .map(|(input, _)| input.clone())
+                .collect(),
+            outputs: outputs.clone(),
+            attributes: attributes.clone(),
         }
-    }
+    } else {
+        outputs.push(TxOut::new(return_address.clone(), difference_amount));
 
-    impl Default for MockWalletClient {
-        fn default() -> Self {
-            let private_key_0 = PrivateKey::deserialize_from(&[
-                197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138, 33, 159,
-                188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 194,
-            ])
-            .unwrap();
-            let private_key_1 = PrivateKey::deserialize_from(&[
-                197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138, 33, 159,
-                188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 195,
-            ])
-            .unwrap();
-            let private_key_2 = PrivateKey::deserialize_from(&[
-                197, 83, 160, 54, 4, 35, 93, 248, 252, 209, 79, 198, 209, 229, 177, 138, 33, 159,
-                188, 198, 233, 62, 255, 207, 207, 118, 142, 41, 119, 167, 78, 196,
-            ])
-            .unwrap();
-
-            let public_key_0 = PublicKey::from(&private_key_0);
-            let public_key_1 = PublicKey::from(&private_key_1);
-            let public_key_2 = PublicKey::from(&private_key_2);
-
-            let addr_0 = ExtendedAddr::BasicRedeem(RedeemAddress::from(&public_key_0));
-            let addr_1 = ExtendedAddr::BasicRedeem(RedeemAddress::from(&public_key_1));
-            let addr_2 = ExtendedAddr::BasicRedeem(RedeemAddress::from(&public_key_2));
-
-            Self {
-                txid_0: [0u8; 32],
-                txid_1: [1u8; 32],
-                txid_2: [2u8; 32],
-                private_key_0,
-                private_key_1,
-                private_key_2,
-                public_key_0,
-                public_key_1,
-                public_key_2,
-                addr_0,
-                addr_1,
-                addr_2,
-            }
+        Tx {
+            inputs: selected_unspent_transactions
+                .iter()
+                .map(|(input, _)| input.clone())
+                .collect(),
+            outputs,
+            attributes,
         }
-    }
-
-    impl WalletClient for MockWalletClient {
-        fn wallets(&self) -> Result<Vec<String>> {
-            unreachable!()
-        }
-
-        fn new_wallet(&self, _: &str, _: &SecUtf8) -> Result<()> {
-            unreachable!()
-        }
-
-        fn public_keys(&self, _: &str, _: &SecUtf8) -> Result<Vec<PublicKey>> {
-            unreachable!()
-        }
-
-        fn root_hashes(&self, _: &str, _: &SecUtf8) -> Result<Vec<H256>> {
-            unreachable!()
-        }
-
-        fn redeem_addresses(&self, _: &str, _: &SecUtf8) -> Result<Vec<ExtendedAddr>> {
-            unreachable!()
-        }
-
-        fn tree_addresses(&self, _: &str, _: &SecUtf8) -> Result<Vec<ExtendedAddr>> {
-            unreachable!()
-        }
-
-        fn addresses(&self, _: &str, _: &SecUtf8) -> Result<Vec<ExtendedAddr>> {
-            unreachable!()
-        }
-
-        fn find(
-            &self,
-            _: &str,
-            _: &SecUtf8,
-            address: &ExtendedAddr,
-        ) -> Result<Option<Either<PublicKey, H256>>> {
-            if address == &self.addr_0 {
-                Ok(Some(Either::Left(self.public_key_0.clone())))
-            } else if address == &self.addr_1 {
-                Ok(Some(Either::Left(self.public_key_1.clone())))
-            } else {
-                Ok(Some(Either::Left(self.public_key_2.clone())))
-            }
-        }
-
-        fn private_key(&self, _: &SecUtf8, public_key: &PublicKey) -> Result<Option<PrivateKey>> {
-            if public_key == &self.public_key_0 {
-                Ok(Some(self.private_key_0.clone()))
-            } else if public_key == &self.public_key_1 {
-                Ok(Some(self.private_key_1.clone()))
-            } else {
-                Ok(Some(self.private_key_2.clone()))
-            }
-        }
-
-        fn new_public_key(&self, _: &str, _: &SecUtf8) -> Result<PublicKey> {
-            unreachable!()
-        }
-
-        fn new_redeem_address(&self, _: &str, _: &SecUtf8) -> Result<ExtendedAddr> {
-            Ok(ExtendedAddr::BasicRedeem(
-                RedeemAddress::from_str("1fdf22497167a793ca794963ad6c95e6ffa0baba").unwrap(),
-            ))
-        }
-
-        fn new_tree_address(
-            &self,
-            _: &str,
-            _: &SecUtf8,
-            _: Vec<PublicKey>,
-            _: usize,
-            _: usize,
-        ) -> Result<ExtendedAddr> {
-            unreachable!()
-        }
-
-        fn generate_proof(
-            &self,
-            _: &str,
-            _: &SecUtf8,
-            _: &ExtendedAddr,
-            _: Vec<PublicKey>,
-        ) -> Result<Proof<RawPubkey>> {
-            unreachable!()
-        }
-
-        fn required_cosigners(&self, _: &str, _: &SecUtf8, _: &H256) -> Result<usize> {
-            unreachable!()
-        }
-
-        fn balance(&self, _: &str, _: &SecUtf8) -> Result<Coin> {
-            unreachable!()
-        }
-
-        fn history(&self, _: &str, _: &SecUtf8) -> Result<Vec<TransactionChange>> {
-            unreachable!()
-        }
-
-        fn unspent_transactions(&self, _: &str, _: &SecUtf8) -> Result<UnspentTransactions> {
-            Ok(UnspentTransactions::new(vec![
-                (
-                    TxoPointer {
-                        id: self.txid_0,
-                        index: 0,
-                    },
-                    TxOut {
-                        address: self.addr_0.clone(),
-                        value: Coin::new(200).unwrap(),
-                        valid_from: None,
-                    },
-                ),
-                (
-                    TxoPointer {
-                        id: self.txid_1,
-                        index: 0,
-                    },
-                    TxOut {
-                        address: self.addr_1.clone(),
-                        value: Coin::new(217).unwrap(),
-                        valid_from: None,
-                    },
-                ),
-                (
-                    TxoPointer {
-                        id: self.txid_2,
-                        index: 0,
-                    },
-                    TxOut {
-                        address: self.addr_2.clone(),
-                        value: Coin::new(100).unwrap(),
-                        valid_from: None,
-                    },
-                ),
-            ]))
-        }
-
-        fn output(&self, id: &TxId, _: usize) -> Result<TxOut> {
-            if &self.txid_0 == id {
-                Ok(TxOut {
-                    address: self.addr_0.clone(),
-                    value: Coin::new(200).unwrap(),
-                    valid_from: None,
-                })
-            } else if &self.txid_1 == id {
-                Ok(TxOut {
-                    address: self.addr_1.clone(),
-                    value: Coin::new(217).unwrap(),
-                    valid_from: None,
-                })
-            } else {
-                Ok(TxOut {
-                    address: self.addr_2.clone(),
-                    value: Coin::new(100).unwrap(),
-                    valid_from: None,
-                })
-            }
-        }
-
-        fn create_and_broadcast_transaction(
-            &self,
-            _: &str,
-            _: &SecUtf8,
-            _: Vec<TxOut>,
-            _: TxAttributes,
-        ) -> Result<()> {
-            unreachable!()
-        }
-
-        fn sync(&self) -> Result<()> {
-            unreachable!()
-        }
-
-        fn sync_all(&self) -> Result<()> {
-            unreachable!()
-        }
-    }
-
-    #[test]
-    fn check_with_exact_fee_match() {
-        let fee_algorithm = LinearFee::new(Milli::new(1, 1), Milli::new(1, 1));
-        let transaction_builder = DefaultTransactionBuilder::new(fee_algorithm);
-
-        let wallet_client = MockWalletClient::default();
-
-        let tx_aux = transaction_builder
-            .build(
-                "name",
-                &SecUtf8::from("passphrase"),
-                vec![TxOut {
-                    address: ExtendedAddr::BasicRedeem(
-                        RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20b4")
-                            .unwrap(),
-                    ),
-                    value: Coin::new(40).unwrap(),
-                    valid_from: None,
-                }],
-                TxAttributes::new(171),
-                &wallet_client,
-            )
-            .expect("Unable to build transaction");
-
-        println!("{:?}", tx_aux);
-
-        let fee = fee_algorithm.calculate_for_txaux(&tx_aux).unwrap();
-
-        match tx_aux {
-            TxAux::TransferTx(tx, _) => {
-                assert_eq!(1, tx.outputs.len());
-                wallet_client.assert_fee(fee, tx);
-            }
-            _ => unreachable!(
-                "MUST_TODO: client-core transaction builder doesn't do account/staking-related TX"
-            ),
-        }
-    }
-
-    #[test]
-    fn check_with_fee() {
-        let fee_algorithm = LinearFee::new(Milli::new(1, 1), Milli::new(1, 1));
-        let transaction_builder = DefaultTransactionBuilder::new(fee_algorithm);
-
-        let wallet_client = MockWalletClient::default();
-
-        let tx_aux = transaction_builder
-            .build(
-                "name",
-                &SecUtf8::from("passphrase"),
-                vec![TxOut {
-                    address: ExtendedAddr::BasicRedeem(
-                        RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20b4")
-                            .unwrap(),
-                    ),
-                    value: Coin::new(30).unwrap(),
-                    valid_from: None,
-                }],
-                TxAttributes::new(171),
-                &wallet_client,
-            )
-            .expect("Unable to build transaction");
-
-        let fee = fee_algorithm.calculate_for_txaux(&tx_aux).unwrap();
-
-        match tx_aux {
-            TxAux::TransferTx(tx, _) => {
-                assert_eq!(2, tx.outputs.len());
-                wallet_client.assert_fee(fee, tx);
-            }
-            _ => unreachable!(
-                "MUST_TODO: client-core transaction builder doesn't do account/staking-related TX"
-            ),
-        }
-    }
-
-    #[test]
-    fn check_insufficient_balance_with_fee() {
-        let fee_algorithm = LinearFee::new(Milli::new(1, 1), Milli::new(1, 1));
-        let transaction_builder = DefaultTransactionBuilder::new(fee_algorithm);
-
-        let wallet_client = MockWalletClient::default();
-
-        let tx_aux = transaction_builder.build(
-            "name",
-            &SecUtf8::from("passphrase"),
-            vec![TxOut {
-                address: ExtendedAddr::BasicRedeem(
-                    RedeemAddress::from_str("790661a2fd9da3fee53caab80859ecae125a20b4").unwrap(),
-                ),
-                value: Coin::new(400).unwrap(),
-                valid_from: None,
-            }],
-            TxAttributes::new(171),
-            &wallet_client,
-        );
-
-        assert!(tx_aux.is_err());
-        assert_eq!(ErrorKind::InsufficientBalance, tx_aux.unwrap_err().kind());
     }
 }

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -1,7 +1,7 @@
 use failure::ResultExt;
 use secstr::SecUtf8;
 
-use chain_core::init::coin::Coin;
+use chain_core::init::coin::{sum_coins, Coin};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
@@ -13,6 +13,18 @@ use client_common::{ErrorKind, Result};
 use crate::{SelectedUnspentTransactions, Signer, TransactionBuilder, UnspentTransactions};
 
 /// Default implementation of `TransactionBuilder`
+///
+/// # Algorithm
+///
+/// 1. Calculate `output_value`: Sum of all the output values.
+/// 2. Initialize `fees = 0`.
+/// 3. Select unspent transactions with `fees + output_value`.
+/// 4. Build transaction with selected unspent transactions (also add an extra output for change amount).
+/// 5. Sign transaction with private keys corresponding to selected unspent transactions.
+/// 6. Calculate `new_fees`.
+/// 7. If `new_fees > fees`, then change `fees = new_fees` and goto step 3, otherwise return signed transaction.
+///
+/// TODO: Create a `DummySigner` which signs a transaction with dummy values for fees calculation.
 #[derive(Debug)]
 pub struct DefaultTransactionBuilder<S, F>
 where
@@ -51,11 +63,13 @@ where
         unspent_transactions: UnspentTransactions,
         return_address: ExtendedAddr,
     ) -> Result<TxAux> {
+        let output_value = sum_coins(outputs.iter().map(|output| output.value))
+            .context(ErrorKind::BalanceAdditionError)?;
         let mut fees = Coin::zero();
 
         loop {
-            let (selected_unspent_transactions, difference_amount) =
-                unspent_transactions.select(fees)?;
+            let (selected_unspent_transactions, difference_amount) = unspent_transactions
+                .select((output_value + fees).context(ErrorKind::BalanceAdditionError)?)?;
 
             let transaction = build_transaction(
                 &selected_unspent_transactions,
@@ -96,25 +110,156 @@ fn build_transaction(
     difference_amount: Coin,
     return_address: ExtendedAddr,
 ) -> Tx {
-    if difference_amount == Coin::zero() {
-        Tx {
-            inputs: selected_unspent_transactions
-                .iter()
-                .map(|(input, _)| input.clone())
-                .collect(),
-            outputs: outputs.clone(),
-            attributes: attributes.clone(),
-        }
-    } else {
+    if difference_amount != Coin::zero() {
         outputs.push(TxOut::new(return_address.clone(), difference_amount));
+    }
 
-        Tx {
-            inputs: selected_unspent_transactions
-                .iter()
-                .map(|(input, _)| input.clone())
-                .collect(),
-            outputs,
-            attributes,
+    Tx {
+        inputs: selected_unspent_transactions
+            .iter()
+            .map(|(input, _)| input.clone())
+            .collect(),
+        outputs,
+        attributes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chain_core::tx::data::input::TxoPointer;
+    use chain_core::tx::fee::{LinearFee, Milli};
+    use client_common::storage::MemoryStorage;
+
+    use crate::signer::DefaultSigner;
+    use crate::unspent_transactions::{Operation, Sorter};
+    use crate::wallet::{DefaultWalletClient, WalletClient};
+
+    #[test]
+    fn check_transaction_building_flow() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+
+        let storage = MemoryStorage::default();
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage.clone())
+            .build()
+            .unwrap();
+
+        wallet_client.new_wallet(name, passphrase).unwrap();
+
+        let public_keys = vec![
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+            wallet_client.new_public_key(name, passphrase).unwrap(),
+        ];
+
+        let addresses = vec![
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+            wallet_client
+                .new_tree_address(
+                    name,
+                    passphrase,
+                    public_keys.clone(),
+                    public_keys[0].clone(),
+                    1,
+                    3,
+                )
+                .unwrap(),
+        ];
+
+        let mut unspent_transactions = UnspentTransactions::new(vec![
+            (
+                TxoPointer::new([0; 32], 0),
+                TxOut::new(addresses[0].clone(), Coin::new(500).unwrap()),
+            ),
+            (
+                TxoPointer::new([1; 32], 0),
+                TxOut::new(addresses[1].clone(), Coin::new(1000).unwrap()),
+            ),
+            (
+                TxoPointer::new([2; 32], 0),
+                TxOut::new(addresses[2].clone(), Coin::new(750).unwrap()),
+            ),
+            (
+                TxoPointer::new([3; 32], 0),
+                TxOut::new(addresses[3].clone(), Coin::new(1250).unwrap()),
+            ),
+        ]);
+        unspent_transactions.apply_all(&[Operation::Sort(Sorter::HighestValueFirst)]);
+
+        let return_address = wallet_client.new_redeem_address(name, passphrase).unwrap();
+
+        let signer = DefaultSigner::new(storage);
+        let fee_algorithm = LinearFee::new(Milli::new(1, 1), Milli::new(1, 1));
+
+        let transaction_builder = DefaultTransactionBuilder::new(signer, fee_algorithm);
+
+        let outputs = vec![TxOut::new(
+            wallet_client.new_redeem_address(name, passphrase).unwrap(),
+            Coin::new(1000).unwrap(),
+        )];
+        let attributes = TxAttributes::new(171);
+
+        let tx_aux = transaction_builder
+            .build(
+                name,
+                passphrase,
+                outputs,
+                attributes,
+                unspent_transactions.clone(),
+                return_address,
+            )
+            .unwrap();
+
+        let fee = fee_algorithm
+            .calculate_for_txaux(&tx_aux)
+            .unwrap()
+            .to_coin();
+
+        match tx_aux {
+            TxAux::TransferTx(transaction, witness) => {
+                let output_value =
+                    sum_coins(transaction.outputs.iter().map(|output| output.value)).unwrap();
+
+                let input_value = sum_coins(transaction.inputs.iter().map(|input| {
+                    if input.id == [3; 32] {
+                        unspent_transactions[0].1.value
+                    } else if input.id == [1; 32] {
+                        unspent_transactions[1].1.value
+                    } else if input.id == [2; 32] {
+                        unspent_transactions[2].1.value
+                    } else {
+                        unspent_transactions[0].1.value
+                    }
+                }))
+                .unwrap();
+
+                assert!((output_value + fee).unwrap() <= input_value);
+
+                for (i, input) in transaction.inputs.iter().enumerate() {
+                    let address = if input.id == [3; 32] {
+                        unspent_transactions[0].1.address.clone()
+                    } else if input.id == [1; 32] {
+                        unspent_transactions[1].1.address.clone()
+                    } else if input.id == [2; 32] {
+                        unspent_transactions[2].1.address.clone()
+                    } else {
+                        unspent_transactions[0].1.address.clone()
+                    };
+
+                    assert!(witness[i]
+                        .verify_tx_address(&transaction.id(), &address)
+                        .is_ok(),)
+                }
+            }
+            _ => {
+                // TODO: Transaction builder doesn't do account/staking related transactions
+                unreachable!()
+            }
         }
     }
 }

--- a/client-core/src/transaction_builder/unauthorized_transaction_builder.rs
+++ b/client-core/src/transaction_builder/unauthorized_transaction_builder.rs
@@ -1,24 +1,26 @@
 use secstr::SecUtf8;
 
+use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
 use client_common::{ErrorKind, Result};
 
-use crate::{TransactionBuilder, WalletClient};
+use crate::{TransactionBuilder, UnspentTransactions};
 
-/// `TransactionBuilder` which returns `PermissionDenied` error for each function call.
+/// Default implementation of `TransactionBuilder`
 #[derive(Debug, Default, Clone, Copy)]
 pub struct UnauthorizedTransactionBuilder;
 
 impl TransactionBuilder for UnauthorizedTransactionBuilder {
-    fn build<W: WalletClient>(
+    fn build(
         &self,
-        _name: &str,
-        _passphrase: &SecUtf8,
-        _outputs: Vec<TxOut>,
-        _attributes: TxAttributes,
-        _wallet_client: &W,
+        _: &str,
+        _: &SecUtf8,
+        _: Vec<TxOut>,
+        _: TxAttributes,
+        _: UnspentTransactions,
+        _: ExtendedAddr,
     ) -> Result<TxAux> {
         Err(ErrorKind::PermissionDenied.into())
     }

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -4,10 +4,8 @@ use std::ops::{Deref, DerefMut};
 use failure::ResultExt;
 
 use chain_core::init::coin::Coin;
-use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
-use chain_core::tx::data::Tx;
 use client_common::{ErrorKind, Result};
 
 /// An iterator over unspent transactions

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -121,17 +121,6 @@ impl UnspentTransactions {
     }
 }
 
-impl<'a> SelectedUnspentTransactions<'a> {
-    /// Builds a transaction from current selected unspent transactions
-    pub fn to_transaction(&self, outputs: Vec<TxOut>, attributes: TxAttributes) -> Tx {
-        Tx {
-            inputs: self.iter().map(|(input, _)| input.clone()).collect(),
-            outputs,
-            attributes,
-        }
-    }
-}
-
 /// Builder for unspent transactions
 enum Builder {
     Normal(Vec<(TxoPointer, TxOut)>),

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -27,7 +27,7 @@ use client_common::{ErrorKind, Result};
 /// // Apply operations
 /// unspent_transactions.apply_all(operations);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct UnspentTransactions {
     inner: Vec<(TxoPointer, TxOut)>,
 }
@@ -113,6 +113,11 @@ impl UnspentTransactions {
         }
 
         Err(ErrorKind::InsufficientBalance.into())
+    }
+
+    /// Selects all unspent transactions
+    pub fn select_all(&self) -> SelectedUnspentTransactions {
+        SelectedUnspentTransactions { inner: &self.inner }
     }
 }
 

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -18,8 +18,7 @@ use chain_core::tx::TxAux;
 use client_common::balance::TransactionChange;
 use client_common::Result;
 
-use crate::unspent_transactions::Operation;
-use crate::{PrivateKey, PublicKey, UnspentTransactions};
+use crate::{InputSelectionStrategy, PrivateKey, PublicKey, UnspentTransactions};
 
 /// Interface for a generic wallet
 pub trait WalletClient: Send + Sync {
@@ -123,7 +122,7 @@ pub trait WalletClient: Send + Sync {
     /// - `passphrase`: Passphrase of wallet
     /// - `outputs`: Transaction outputs
     /// - `attributes`: Transaction attributes,
-    /// - `operations`: Operations to apply on unspent transactions before selecting
+    /// - `input_selection_strategy`: Strategy to use while selecting unspent transactions
     /// - `return_address`: Address to which change amount will get returned
     fn create_transaction(
         &self,
@@ -131,7 +130,7 @@ pub trait WalletClient: Send + Sync {
         passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
-        operations: &[Operation],
+        input_selection_strategy: Option<InputSelectionStrategy>,
         return_address: ExtendedAddr,
     ) -> Result<TxAux>;
 

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -234,19 +234,6 @@ where
         self.index.output(id, index)
     }
 
-    // fn create_and_broadcast_transaction(
-    //     &self,
-    //     name: &str,
-    //     passphrase: &SecUtf8,
-    //     outputs: Vec<TxOut>,
-    //     attributes: TxAttributes,
-    // ) -> Result<()> {
-    //     let tx_aux = self
-    //         .transaction_builder
-    //         .build(name, passphrase, outputs, attributes, self)?;
-
-    //     self.index.broadcast_transaction(&tx_aux.encode())
-    // }
     fn create_transaction(
         &self,
         name: &str,

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -12,6 +12,7 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::TxId;
 use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::TxAux;
 use client_common::balance::TransactionChange;
 use client_common::storage::UnauthorizedStorage;
 use client_common::{Error, ErrorKind, Result, Storage};
@@ -19,6 +20,7 @@ use client_index::index::{Index, UnauthorizedIndex};
 
 use crate::service::*;
 use crate::transaction_builder::UnauthorizedTransactionBuilder;
+use crate::unspent_transactions::Operation;
 use crate::{
     MultiSigWalletClient, PrivateKey, PublicKey, TransactionBuilder, UnspentTransactions,
     WalletClient,
@@ -139,15 +141,16 @@ where
         name: &str,
         passphrase: &SecUtf8,
         public_keys: Vec<PublicKey>,
+        self_public_key: PublicKey,
         m: usize,
         n: usize,
     ) -> Result<ExtendedAddr> {
         // To verify if the passphrase is correct or not
         self.tree_addresses(name, passphrase)?;
 
-        let root_hash = self
-            .root_hash_service
-            .new_root_hash(public_keys, m, n, passphrase)?;
+        let root_hash =
+            self.root_hash_service
+                .new_root_hash(public_keys, self_public_key, m, n, passphrase)?;
 
         self.wallet_service
             .add_root_hash(name, passphrase, root_hash)?;
@@ -231,17 +234,42 @@ where
         self.index.output(id, index)
     }
 
-    fn create_and_broadcast_transaction(
+    // fn create_and_broadcast_transaction(
+    //     &self,
+    //     name: &str,
+    //     passphrase: &SecUtf8,
+    //     outputs: Vec<TxOut>,
+    //     attributes: TxAttributes,
+    // ) -> Result<()> {
+    //     let tx_aux = self
+    //         .transaction_builder
+    //         .build(name, passphrase, outputs, attributes, self)?;
+
+    //     self.index.broadcast_transaction(&tx_aux.encode())
+    // }
+    fn create_transaction(
         &self,
         name: &str,
         passphrase: &SecUtf8,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
-    ) -> Result<()> {
-        let tx_aux = self
-            .transaction_builder
-            .build(name, passphrase, outputs, attributes, self)?;
+        operations: &[Operation],
+        return_address: ExtendedAddr,
+    ) -> Result<TxAux> {
+        let mut unspent_transactions = self.unspent_transactions(name, passphrase)?;
+        unspent_transactions.apply_all(operations);
 
+        self.transaction_builder.build(
+            name,
+            passphrase,
+            outputs,
+            attributes,
+            unspent_transactions,
+            return_address,
+        )
+    }
+
+    fn broadcast_transaction(&self, tx_aux: &TxAux) -> Result<()> {
         self.index.broadcast_transaction(&tx_aux.encode())
     }
 
@@ -470,21 +498,18 @@ mod tests {
 
     use chrono::DateTime;
 
-    use chain_core::init::coin::{Coin, CoinError};
-    use chain_core::tx::data::address::ExtendedAddr;
-    use chain_core::tx::data::attribute::TxAttributes;
+    use chain_core::init::coin::CoinError;
     use chain_core::tx::data::input::TxoPointer;
-    use chain_core::tx::data::output::TxOut;
-    use chain_core::tx::data::{Tx, TxId};
+    use chain_core::tx::data::Tx;
     use chain_core::tx::fee::{Fee, FeeAlgorithm};
     use chain_core::tx::witness::TxInWitness;
-    use chain_core::tx::{TransactionId, TxAux};
-    use client_common::balance::{BalanceChange, TransactionChange};
+    use chain_core::tx::TransactionId;
+    use client_common::balance::BalanceChange;
     use client_common::storage::MemoryStorage;
-    use client_common::Result;
-    use client_index::Index;
 
+    use crate::signer::DefaultSigner;
     use crate::transaction_builder::DefaultTransactionBuilder;
+    use crate::unspent_transactions::{Filter, Sorter};
 
     #[derive(Debug)]
     pub struct MockIndex {
@@ -845,15 +870,20 @@ mod tests {
         assert!(wallet.sync().is_ok());
         assert!(wallet.sync_all().is_ok());
 
+        let signer = DefaultSigner::new(storage.clone());
+
         let wallet = DefaultWalletClient::builder()
             .with_wallet(storage)
             .with_transaction_read(wallet.index)
-            .with_transaction_write(DefaultTransactionBuilder::new(ZeroFeeAlgorithm::default()))
+            .with_transaction_write(DefaultTransactionBuilder::new(
+                signer,
+                ZeroFeeAlgorithm::default(),
+            ))
             .build()
             .unwrap();
 
-        assert!(wallet
-            .create_and_broadcast_transaction(
+        let transaction = wallet
+            .create_transaction(
                 "wallet_2",
                 &SecUtf8::from("passphrase"),
                 vec![TxOut {
@@ -862,8 +892,15 @@ mod tests {
                     valid_from: None,
                 }],
                 TxAttributes::new(171),
+                &[
+                    Operation::Filter(Filter::OnlyRedeemAddresses),
+                    Operation::Sort(Sorter::HighestValueFirst),
+                ],
+                addr_1.clone(),
             )
-            .is_ok());
+            .unwrap();
+
+        assert!(wallet.broadcast_transaction(&transaction).is_ok());
 
         assert_eq!(
             Coin::new(0).unwrap(),
@@ -906,8 +943,8 @@ mod tests {
                 .len()
         );
 
-        assert!(wallet
-            .create_and_broadcast_transaction(
+        let transaction = wallet
+            .create_transaction(
                 "wallet_3",
                 &SecUtf8::from("passphrase"),
                 vec![TxOut {
@@ -916,13 +953,20 @@ mod tests {
                     valid_from: None,
                 }],
                 TxAttributes::new(171),
+                &[
+                    Operation::Filter(Filter::OnlyRedeemAddresses),
+                    Operation::Sort(Sorter::HighestValueFirst),
+                ],
+                addr_1.clone(),
             )
-            .is_ok());
+            .unwrap();
+
+        assert!(wallet.broadcast_transaction(&transaction).is_ok());
 
         assert_eq!(
             ErrorKind::InsufficientBalance,
             wallet
-                .create_and_broadcast_transaction(
+                .create_transaction(
                     "wallet_2",
                     &SecUtf8::from("passphrase"),
                     vec![TxOut {
@@ -931,6 +975,11 @@ mod tests {
                         valid_from: None,
                     }],
                     TxAttributes::new(171),
+                    &[
+                        Operation::Filter(Filter::OnlyRedeemAddresses),
+                        Operation::Sort(Sorter::HighestValueFirst),
+                    ],
+                    addr_1.clone()
                 )
                 .unwrap_err()
                 .kind()
@@ -1029,11 +1078,18 @@ mod tests {
         assert_eq!(
             ErrorKind::PermissionDenied,
             wallet
-                .create_and_broadcast_transaction(
+                .create_transaction(
                     "name",
                     &SecUtf8::from("passphrase"),
                     Vec::new(),
-                    TxAttributes::new(171)
+                    TxAttributes::new(171),
+                    &[
+                        Operation::Filter(Filter::OnlyRedeemAddresses),
+                        Operation::Sort(Sorter::HighestValueFirst),
+                    ],
+                    ExtendedAddr::BasicRedeem(RedeemAddress::from(&PublicKey::from(
+                        &PrivateKey::new().unwrap()
+                    )))
                 )
                 .unwrap_err()
                 .kind()
@@ -1052,8 +1108,11 @@ mod tests {
 
     #[test]
     fn invalid_wallet_building() {
-        let builder = DefaultWalletClient::builder()
-            .with_transaction_write(DefaultTransactionBuilder::new(ZeroFeeAlgorithm::default()));
+        let storage = MemoryStorage::default();
+        let signer = DefaultSigner::new(storage);
+        let builder = DefaultWalletClient::builder().with_transaction_write(
+            DefaultTransactionBuilder::new(signer, ZeroFeeAlgorithm::default()),
+        );
 
         assert_eq!(ErrorKind::InvalidInput, builder.build().unwrap_err().kind());
     }
@@ -1090,7 +1149,14 @@ mod tests {
         ];
 
         let tree_address = wallet
-            .new_tree_address(name, &passphrase, public_keys.clone(), 2, 3)
+            .new_tree_address(
+                name,
+                &passphrase,
+                public_keys.clone(),
+                public_keys[0].clone(),
+                2,
+                3,
+            )
             .unwrap();
 
         assert_eq!(1, wallet.tree_addresses(name, &passphrase).unwrap().len());
@@ -1134,7 +1200,14 @@ mod tests {
         ];
 
         let multi_sig_address = wallet
-            .new_tree_address(name, passphrase, public_keys.clone(), 2, 3)
+            .new_tree_address(
+                name,
+                passphrase,
+                public_keys.clone(),
+                public_keys[0].clone(),
+                2,
+                3,
+            )
             .unwrap();
 
         let transaction = Tx::new();
@@ -1239,7 +1312,14 @@ mod tests {
         ];
 
         let tree_address = wallet
-            .new_tree_address(name, passphrase, public_keys.clone(), 1, 3)
+            .new_tree_address(
+                name,
+                passphrase,
+                public_keys.clone(),
+                public_keys[0].clone(),
+                1,
+                3,
+            )
             .unwrap();
 
         let transaction = Tx::new();

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use client_common::error::{Error, ErrorKind, Result};
 use client_common::storage::SledStorage;
 use client_common::tendermint::{Client, RpcClient};
+use client_core::signer::DefaultSigner;
 use client_core::transaction_builder::DefaultTransactionBuilder;
 use client_core::wallet::DefaultWalletClient;
 use client_index::index::DefaultIndex;
@@ -38,8 +39,9 @@ impl Server {
     pub(crate) fn start(&self) -> Result<()> {
         let storage = SledStorage::new(&self.storage_dir)?;
         let tendermint_client = RpcClient::new(&self.tendermint_url);
+        let signer = DefaultSigner::new(storage.clone());
         let transaction_builder =
-            DefaultTransactionBuilder::new(tendermint_client.genesis()?.fee_policy());
+            DefaultTransactionBuilder::new(signer, tendermint_client.genesis()?.fee_policy());
         let index = DefaultIndex::new(storage.clone(), tendermint_client);
         let wallet_client = DefaultWalletClient::builder()
             .with_wallet(storage)

--- a/client-rpc/src/wallet_rpc.rs
+++ b/client-rpc/src/wallet_rpc.rs
@@ -10,7 +10,6 @@ use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use client_common::balance::TransactionChange;
-use client_core::unspent_transactions::{Filter, Operation, Sorter};
 use client_core::wallet::WalletClient;
 
 use crate::server::{rpc_error_from_string, to_rpc_error};
@@ -130,10 +129,6 @@ where
             .client
             .new_redeem_address(&request.name, &request.passphrase)
             .map_err(to_rpc_error)?;
-        let operations = &[
-            Operation::Filter(Filter::OnlyRedeemAddresses),
-            Operation::Sort(Sorter::HighestValueFirst),
-        ];
 
         let transaction = self
             .client
@@ -142,7 +137,7 @@ where
                 &request.passphrase,
                 vec![tx_out],
                 tx_attributes,
-                operations,
+                None,
                 return_address,
             )
             .map_err(to_rpc_error)?;


### PR DESCRIPTION
**Solution**: 
- Added support for 1-of-n schnorr signatures in transaction builder.
- Divided transaction builder into three components:
  - `Signer`: For transaction signing
  - `UnspentTransactions`: For UTXO selection
  - `TransactionBuilder`: For building transaction
- There is also a slight change in algorithm used for creating transactions:
  - We now no longer have a `DummySigner` which signs a transaction with dummy values for calculating fees. (I'll have to give more thought on implementing a `DummySigner` because 1-of-n signatures consist of a schnorr signature and a merkle proof which can be of variable size. So, we cannot deterministically estimate the size and structure of a 1-of-n signature)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crypto-com/chain/134)
<!-- Reviewable:end -->
