### PR TITLE
Problem: (CRO-132) No way to create transactions to withdraw unbonded amount from account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "client-network"
+version = "0.1.0"
+dependencies = [
+ "chain-core 0.1.0",
+ "client-common 0.1.0",
+ "client-core 0.1.0",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "client-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "client-common",
     "client-core",
     "client-index",
+    "client-network",
     "client-rpc",
     "dev-utils",
 ]

--- a/client-core/src/key/private_key.rs
+++ b/client-core/src/key/private_key.rs
@@ -2,10 +2,9 @@ use failure::ResultExt;
 use parity_codec::{Decode, Encode, Input, Output};
 use rand::rngs::OsRng;
 use secp256k1::schnorrsig::{schnorr_sign, SchnorrSignature};
-use secp256k1::{Message, PublicKey as SecpPublicKey, SecretKey};
+use secp256k1::{Message, PublicKey as SecpPublicKey, RecoverableSignature, SecretKey};
 use zeroize::Zeroize;
 
-use chain_core::tx::witness::TxInWitness;
 use client_common::{ErrorKind, Result};
 
 use crate::{PublicKey, SECP};
@@ -37,11 +36,11 @@ impl PrivateKey {
     }
 
     /// Signs a message with current private key
-    pub fn sign<T: AsRef<[u8]>>(&self, bytes: T) -> Result<TxInWitness> {
+    pub fn sign<T: AsRef<[u8]>>(&self, bytes: T) -> Result<RecoverableSignature> {
         let message =
             Message::from_slice(bytes.as_ref()).context(ErrorKind::DeserializationError)?;
         let signature = SECP.with(|secp| secp.sign_recoverable(&message, &self.0));
-        Ok(TxInWitness::BasicRedeem(signature))
+        Ok(signature)
     }
 
     /// Signs a message with current private key (uses schnorr signature algorithm)

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -49,6 +49,44 @@ where
         Ok(())
     }
 
+    /// Finds public key corresponding to given redeem address
+    pub fn find_public_key(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        redeem_address: &RedeemAddress,
+    ) -> Result<Option<PublicKey>> {
+        let public_keys = self.public_keys(name, passphrase)?;
+
+        for public_key in public_keys {
+            let known_address = RedeemAddress::from(&public_key);
+
+            if known_address == *redeem_address {
+                return Ok(Some(public_key));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Checks if root hash exists in current wallet and returns root hash if exists
+    pub fn find_root_hash(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        root_hash: &H256,
+    ) -> Result<Option<H256>> {
+        let root_hashes = self.root_hashes(name, passphrase)?;
+
+        for known_hash in root_hashes {
+            if known_hash == *root_hash {
+                return Ok(Some(known_hash));
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Finds an address in wallet and returns corresponding public key or root hash
     pub fn find(
         &self,
@@ -157,44 +195,6 @@ where
     /// Clears all storage
     pub fn clear(&self) -> Result<()> {
         self.storage.clear(KEYSPACE)
-    }
-
-    /// Finds public key corresponding to given redeem address
-    fn find_public_key(
-        &self,
-        name: &str,
-        passphrase: &SecUtf8,
-        redeem_address: &RedeemAddress,
-    ) -> Result<Option<PublicKey>> {
-        let public_keys = self.public_keys(name, passphrase)?;
-
-        for public_key in public_keys {
-            let known_address = RedeemAddress::from(&public_key);
-
-            if known_address == *redeem_address {
-                return Ok(Some(public_key));
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Checks if root hash exists in current wallet and returns root hash if exists
-    fn find_root_hash(
-        &self,
-        name: &str,
-        passphrase: &SecUtf8,
-        root_hash: &H256,
-    ) -> Result<Option<H256>> {
-        let root_hashes = self.root_hashes(name, passphrase)?;
-
-        for known_hash in root_hashes {
-            if known_hash == *root_hash {
-                return Ok(Some(known_hash));
-            }
-        }
-
-        Ok(None)
     }
 }
 

--- a/client-core/src/signer/default_signer.rs
+++ b/client-core/src/signer/default_signer.rs
@@ -65,7 +65,7 @@ where
             .private_key(&public_key, passphrase)?
             .ok_or_else(|| Error::from(ErrorKind::PrivateKeyNotFound))?;
 
-        private_key.sign(&message)
+        private_key.sign(&message).map(TxInWitness::BasicRedeem)
     }
 
     /// Schnorr signs message with private key corresponding to `self_public_key` in given 1-of-n root hash

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -8,6 +8,7 @@ use secp256k1::schnorrsig::SchnorrSignature;
 use secstr::SecUtf8;
 
 use chain_core::common::{Proof, H256};
+use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
@@ -42,6 +43,22 @@ pub trait WalletClient: Send + Sync {
 
     /// Retrieves all addresses corresponding to given wallet
     fn addresses(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<ExtendedAddr>>;
+
+    /// Finds public key corresponding to given redeem address
+    fn find_public_key(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        redeem_address: &RedeemAddress,
+    ) -> Result<Option<PublicKey>>;
+
+    /// Checks if root hash exists in current wallet and returns root hash if exists
+    fn find_root_hash(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        root_hash: &H256,
+    ) -> Result<Option<H256>>;
 
     /// Finds an address in wallet and returns corresponding public key or root hash
     fn find(

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -105,6 +105,26 @@ where
         self.wallet_service.addresses(name, passphrase)
     }
 
+    fn find_public_key(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        redeem_address: &RedeemAddress,
+    ) -> Result<Option<PublicKey>> {
+        self.wallet_service
+            .find_public_key(name, passphrase, redeem_address)
+    }
+
+    fn find_root_hash(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        root_hash: &H256,
+    ) -> Result<Option<H256>> {
+        self.wallet_service
+            .find_root_hash(name, passphrase, root_hash)
+    }
+
     fn find(
         &self,
         name: &str,

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "client-network"
+version = "0.1.0"
+authors = ["Devashish Dixit <devashish@crypto.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chain-core = { path = "../chain-core" }
+client-common = { path = "../client-common" }
+client-core = { path = "../client-core" }
+secstr = "0.3.2"

--- a/client-network/src/lib.rs
+++ b/client-network/src/lib.rs
@@ -1,0 +1,12 @@
+#![deny(missing_docs, unsafe_code, unstable_features)]
+//! Crypto.com Chain currently has two realms:
+//!
+//! - Payments
+//! - Network Operations
+//!
+//! This crate provides and easy to use client for performing network operations on Crypto.com Chain. Payments, on the
+//! other hand, are handled by `WalletClient` in `chain-core` crate.
+pub mod network_ops;
+
+#[doc(inline)]
+pub use self::network_ops::NetworkOpsClient;

--- a/client-network/src/lib.rs
+++ b/client-network/src/lib.rs
@@ -5,7 +5,7 @@
 //! - Network Operations
 //!
 //! This crate provides and easy to use client for performing network operations on Crypto.com Chain. Payments, on the
-//! other hand, are handled by `WalletClient` in `chain-core` crate.
+//! other hand, are handled by `WalletClient` in `client-core` crate.
 pub mod network_ops;
 
 #[doc(inline)]

--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -1,0 +1,27 @@
+//! Network operations on Crypto.com Chain
+mod default_network_ops_client;
+
+pub use self::default_network_ops_client::DefaultNetworkOpsClient;
+
+use secstr::SecUtf8;
+
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::output::TxOut;
+use chain_core::tx::TxAux;
+use client_common::Result;
+
+/// Interface for performing network operations on Crypto.com Chain
+pub trait NetworkOpsClient {
+    /// Creates a new transaction for withdrawing unbonded stake from an account
+    fn create_withdraw_unbonded_stake_transaction(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        from_address: &ExtendedAddr,
+        outputs: Vec<TxOut>,
+        attributes: TxAttributes,
+    ) -> Result<TxAux>;
+
+    // TODO: Add `create_deposit_bonded_stake_transaction()`, `create_unbond_stake_transaction()` and `get_account_details()` functions
+}

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -50,7 +50,7 @@ where
 
                 let public_key = self
                     .wallet_client
-                    .find_public_key(name, passphrase, &redeem_address)?
+                    .find_public_key(name, passphrase, redeem_address)?
                     .ok_or_else(|| Error::from(ErrorKind::AddressNotFound))?;
 
                 let private_key = self

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -1,0 +1,213 @@
+use secstr::SecUtf8;
+
+use chain_core::state::account::{AccountOpWitness, WithdrawUnbondedTx};
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::output::TxOut;
+use chain_core::tx::{TransactionId, TxAux};
+use client_common::{Error, ErrorKind, Result};
+use client_core::WalletClient;
+
+use crate::NetworkOpsClient;
+
+/// Default implementation of `NetworkOpsClient`
+pub struct DefaultNetworkOpsClient<'a, W>
+where
+    W: WalletClient,
+{
+    wallet_client: &'a W,
+}
+
+impl<'a, W> DefaultNetworkOpsClient<'a, W>
+where
+    W: WalletClient,
+{
+    /// Creates a new instance of `DefaultNetworkOpsClient`
+    pub fn new(wallet_client: &'a W) -> Self {
+        Self { wallet_client }
+    }
+}
+
+impl<'a, W> NetworkOpsClient for DefaultNetworkOpsClient<'a, W>
+where
+    W: WalletClient,
+{
+    fn create_withdraw_unbonded_stake_transaction(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        from_address: &ExtendedAddr,
+        outputs: Vec<TxOut>,
+        attributes: TxAttributes,
+    ) -> Result<TxAux> {
+        match from_address {
+            ExtendedAddr::BasicRedeem(ref redeem_address) => {
+                let transaction = WithdrawUnbondedTx {
+                    nonce: 0,
+                    outputs,
+                    attributes,
+                };
+
+                let public_key = self
+                    .wallet_client
+                    .find_public_key(name, passphrase, &redeem_address)?
+                    .ok_or_else(|| Error::from(ErrorKind::AddressNotFound))?;
+
+                let private_key = self
+                    .wallet_client
+                    .private_key(passphrase, &public_key)?
+                    .ok_or_else(|| Error::from(ErrorKind::PrivateKeyNotFound))?;
+
+                let signature = private_key
+                    .sign(transaction.id())
+                    .map(AccountOpWitness::new)?;
+
+                Ok(TxAux::WithdrawUnbondedStakeTx(transaction, signature))
+            }
+            ExtendedAddr::OrTree(_) => Err(ErrorKind::InvalidInput.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chain_core::init::address::RedeemAddress;
+    use client_common::storage::MemoryStorage;
+    use client_core::wallet::DefaultWalletClient;
+    use client_core::{PrivateKey, PublicKey};
+
+    #[test]
+    fn check_withdraw_unbonded_stake_transaction() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+
+        let storage = MemoryStorage::default();
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage)
+            .build()
+            .unwrap();
+        let network_ops_client = DefaultNetworkOpsClient::new(&wallet_client);
+
+        wallet_client.new_wallet(name, passphrase).unwrap();
+
+        let from_address = wallet_client.new_redeem_address(name, passphrase).unwrap();
+
+        let transaction = network_ops_client
+            .create_withdraw_unbonded_stake_transaction(
+                name,
+                passphrase,
+                &from_address,
+                Vec::new(),
+                TxAttributes::new(171),
+            )
+            .unwrap();
+
+        match transaction {
+            TxAux::WithdrawUnbondedStakeTx(transaction, witness) => {
+                let id = transaction.id();
+                let account_address = witness
+                    .verify_tx_recover_address(&id)
+                    .expect("Unable to verify transaction");
+
+                match from_address {
+                    ExtendedAddr::BasicRedeem(redeem_address) => {
+                        assert_eq!(account_address, redeem_address)
+                    }
+                    ExtendedAddr::OrTree(_) => unreachable!("Address cannot be of tree type"),
+                }
+            }
+            _ => unreachable!(
+                "`create_withdraw_unbonded_stake_transaction()` created invalid transaction type"
+            ),
+        }
+    }
+
+    #[test]
+    fn check_withdraw_unbonded_stake_transaction_address_not_found() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+
+        let storage = MemoryStorage::default();
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage)
+            .build()
+            .unwrap();
+        let network_ops_client = DefaultNetworkOpsClient::new(&wallet_client);
+
+        wallet_client.new_wallet(name, passphrase).unwrap();
+
+        assert_eq!(
+            ErrorKind::AddressNotFound,
+            network_ops_client
+                .create_withdraw_unbonded_stake_transaction(
+                    name,
+                    passphrase,
+                    &ExtendedAddr::BasicRedeem(RedeemAddress::from(&PublicKey::from(
+                        &PrivateKey::new().unwrap(),
+                    ))),
+                    Vec::new(),
+                    TxAttributes::new(171),
+                )
+                .unwrap_err()
+                .kind()
+        );
+    }
+
+    #[test]
+    fn check_withdraw_unbonded_stake_transaction_wallet_not_found() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+
+        let storage = MemoryStorage::default();
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage)
+            .build()
+            .unwrap();
+        let network_ops_client = DefaultNetworkOpsClient::new(&wallet_client);
+
+        assert_eq!(
+            ErrorKind::WalletNotFound,
+            network_ops_client
+                .create_withdraw_unbonded_stake_transaction(
+                    name,
+                    passphrase,
+                    &ExtendedAddr::BasicRedeem(RedeemAddress::from(&PublicKey::from(
+                        &PrivateKey::new().unwrap(),
+                    ))),
+                    Vec::new(),
+                    TxAttributes::new(171),
+                )
+                .unwrap_err()
+                .kind()
+        );
+    }
+
+    #[test]
+    fn check_withdraw_unbonded_stake_transaction_invalid_address_type() {
+        let name = "name";
+        let passphrase = &SecUtf8::from("passphrase");
+
+        let storage = MemoryStorage::default();
+        let wallet_client = DefaultWalletClient::builder()
+            .with_wallet(storage)
+            .build()
+            .unwrap();
+        let network_ops_client = DefaultNetworkOpsClient::new(&wallet_client);
+
+        assert_eq!(
+            ErrorKind::InvalidInput,
+            network_ops_client
+                .create_withdraw_unbonded_stake_transaction(
+                    name,
+                    passphrase,
+                    &ExtendedAddr::OrTree([0; 32]),
+                    Vec::new(),
+                    TxAttributes::new(171),
+                )
+                .unwrap_err()
+                .kind()
+        );
+    }
+}


### PR DESCRIPTION
**Solution**: 
- Created `NetworkOpsClient` with a default implementation to create and sign transaction to withdraw unbonded amount.
- In future, all the functions related to network operations on Chain will be added to `NetworkOpsClient`.

NOTE: Currently, I've hard-coded value of nonce to be zero. This will change in future once we have a way to query nonce value from Chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crypto-com/chain/142)
<!-- Reviewable:end -->
