### PR TITLE
Problem: non-consolidated transaction validation code (CRO-175)

### DIFF
--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -1,6 +1,5 @@
 use super::ChainNodeApp;
 use crate::app::spend_utxos;
-use crate::storage::tx::TxWithOutputs;
 use crate::storage::*;
 use abci::*;
 use bit_vec::BitVec;
@@ -10,6 +9,7 @@ use chain_core::tx::data::Tx;
 use chain_core::tx::data::TxId;
 use chain_core::tx::TransactionId;
 use chain_core::tx::TxAux;
+use chain_tx_validation::TxWithOutputs;
 use integer_encoding::VarInt;
 use kvdb::{DBTransaction, KeyValueDB};
 use parity_codec::Encode;

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -80,7 +80,7 @@ impl ChainNodeApp {
                         previous_block_time: state.block_time,
                         unbonding_period: state.unbonding_period,
                     },
-                    self.uncommitted_account_root_hash,
+                    &self.uncommitted_account_root_hash,
                     self.storage.db.clone(),
                     &self.accounts,
                 );

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -1,9 +1,10 @@
 use super::ChainNodeApp;
-use crate::storage::tx::{verify, ChainInfo};
+use crate::storage::tx::verify;
 use abci::*;
 use chain_core::state::account::StakedState;
 use chain_core::tx::fee::{Fee, FeeAlgorithm};
 use chain_core::tx::TxAux;
+use chain_tx_validation::ChainInfo;
 use parity_codec::Decode;
 
 /// Wrapper to astract over CheckTx and DeliverTx requests
@@ -77,9 +78,9 @@ impl ChainNodeApp {
                         min_fee_computed: min_fee,
                         chain_hex_id: self.chain_hex_id,
                         previous_block_time: state.block_time,
-                        last_account_root_hash: self.uncommitted_account_root_hash,
                         unbonding_period: state.unbonding_period,
                     },
+                    self.uncommitted_account_root_hash,
                     self.storage.db.clone(),
                     &self.accounts,
                 );

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -2,156 +2,54 @@ use crate::storage::account::AccountStorage;
 use crate::storage::account::AccountWrapper;
 use crate::storage::{COL_BODIES, COL_TX_META};
 use bit_vec::BitVec;
-use chain_core::common::Timespec;
-use chain_core::init::coin::{Coin, CoinError};
-use chain_core::state::account::{
-    to_stake_key, DepositBondTx, StakedState, StakedStateAddress, StakedStateOpWitness, UnbondTx,
-    WithdrawUnbondedTx,
-};
+use chain_core::state::account::{to_stake_key, StakedState, StakedStateAddress};
 use chain_core::tx::data::input::TxoPointer;
-use chain_core::tx::data::output::TxOut;
-use chain_core::tx::data::TxId;
 use chain_core::tx::fee::Fee;
-use chain_core::tx::witness::TxWitness;
 use chain_core::tx::TransactionId;
-use chain_core::tx::{data::Tx, TxAux};
-use chain_tx_validation::witness::{verify_tx_address, verify_tx_recover_address};
+use chain_core::tx::TxAux;
+use chain_tx_validation::{
+    verify_bonded_deposit, verify_transfer, verify_unbonded_withdraw, verify_unbonding,
+    witness::verify_tx_recover_address, ChainInfo, Error, TxWithOutputs,
+};
 use kvdb::KeyValueDB;
-use parity_codec::{Decode, Encode};
-use secp256k1;
+use parity_codec::Decode;
 use starling::constants::KEY_LEN;
-use std::collections::BTreeSet;
 use std::sync::Arc;
-use std::{fmt, io};
 
+/// key type for looking up accounts/staked states in the merkle tree storage
 pub type StarlingFixedKey = [u8; KEY_LEN];
 
-/// All possible TX validation errors
-#[derive(Debug)]
-pub enum Error {
-    WrongChainHexId,
-    NoInputs,
-    NoOutputs,
-    DuplicateInputs,
-    ZeroCoin,
-    InvalidSum(CoinError),
-    UnexpectedWitnesses,
-    MissingWitnesses,
-    InvalidInput,
-    InputSpent,
-    InputOutputDoNotMatch,
-    OutputInTimelock,
-    EcdsaCrypto(secp256k1::Error),
-    IoError(io::Error),
-    AccountLookupError(starling::traits::Exception),
-    AccountNotFound,
-    AccountNotUnbonded,
-    AccountWithdrawOutputNotLocked,
-    AccountIncorrectNonce,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::Error::*;
-        match self {
-            WrongChainHexId => write!(f, "chain hex ID does not match"),
-            DuplicateInputs => write!(f, "duplicated inputs"),
-            UnexpectedWitnesses => write!(f, "transaction has more witnesses than inputs"),
-            MissingWitnesses => write!(f, "transaction has more inputs than witnesses"),
-            NoInputs => write!(f, "transaction has no inputs"),
-            NoOutputs => write!(f, "transaction has no outputs"),
-            ZeroCoin => write!(f, "output with no credited value"),
-            InvalidSum(ref err) => write!(f, "input or output sum error: {}", err),
-            InvalidInput => write!(f, "transaction spends an invalid input"),
-            InputSpent => write!(f, "transaction spends an input that was already spent"),
-            InputOutputDoNotMatch => write!(
-                f,
-                "transaction input output coin (plus fee) sums don't match"
-            ),
-            OutputInTimelock => write!(f, "output transaction is in timelock"),
-            EcdsaCrypto(ref err) => write!(f, "ECDSA crypto error: {}", err),
-            IoError(ref err) => write!(f, "IO error: {}", err),
-            AccountLookupError(ref err) => write!(f, "Account lookup error: {}", err),
-            AccountNotFound => write!(f, "account not found"),
-            AccountNotUnbonded => write!(f, "account not unbonded for withdrawal"),
-            AccountWithdrawOutputNotLocked => write!(
-                f,
-                "account withdrawal outputs not time-locked to unbonded_from"
-            ),
-            AccountIncorrectNonce => write!(f, "incorrect transaction count for account operation"),
-        }
+/// checks that the account can be retrieved from the trie storage
+pub fn get_account(
+    account_address: &StakedStateAddress,
+    last_root: &StarlingFixedKey,
+    accounts: &AccountStorage,
+) -> Result<StakedState, Error> {
+    let account_key = to_stake_key(account_address);
+    let items = accounts.get(last_root, &mut [&account_key]);
+    if let Err(e) = items {
+        return Err(Error::IoError(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            e,
+        )));
+    }
+    let account = items.unwrap()[&account_key].clone();
+    match account {
+        None => Err(Error::AccountNotFound),
+        Some(AccountWrapper(a)) => Ok(a),
     }
 }
 
-/// External information needed for TX validation
-#[derive(Clone, Copy)]
-pub struct ChainInfo {
-    pub min_fee_computed: Fee,
-    pub chain_hex_id: u8,
-    pub previous_block_time: Timespec,
-    pub last_account_root_hash: StarlingFixedKey,
-    pub unbonding_period: u32,
-}
-
-fn check_attributes(tx_chain_hex_id: u8, extra_info: &ChainInfo) -> Result<(), Error> {
-    // TODO: check other attributes?
-    // check that chain IDs match
-    if extra_info.chain_hex_id != tx_chain_hex_id {
-        return Err(Error::WrongChainHexId);
-    }
-    Ok(())
-}
-
-fn check_inputs_basic(inputs: &[TxoPointer], witness: &TxWitness) -> Result<(), Error> {
+fn check_spent_input_lookup(
+    inputs: &[TxoPointer],
+    db: Arc<dyn KeyValueDB>,
+) -> Result<Vec<TxWithOutputs>, Error> {
     // check that there are inputs
     if inputs.is_empty() {
         return Err(Error::NoInputs);
     }
-
-    // check that there are no duplicate inputs
-    let mut inputs_s = BTreeSet::new();
-    if !inputs.iter().all(|x| inputs_s.insert(x)) {
-        return Err(Error::DuplicateInputs);
-    }
-
-    // verify transaction witnesses
-    if inputs.len() < witness.len() {
-        return Err(Error::UnexpectedWitnesses);
-    }
-
-    if inputs.len() > witness.len() {
-        return Err(Error::MissingWitnesses);
-    }
-
-    Ok(())
-}
-
-#[derive(Encode, Decode)]
-pub enum TxWithOutputs {
-    Transfer(Tx),
-    StakeWithdraw(WithdrawUnbondedTx),
-}
-
-impl TxWithOutputs {
-    pub fn outputs(&self) -> &[TxOut] {
-        match self {
-            TxWithOutputs::Transfer(tx) => &tx.outputs,
-            TxWithOutputs::StakeWithdraw(tx) => &tx.outputs,
-        }
-    }
-}
-
-fn check_inputs_lookup(
-    main_txid: &TxId,
-    inputs: &[TxoPointer],
-    witness: &TxWitness,
-    extra_info: &ChainInfo,
-    db: Arc<dyn KeyValueDB>,
-) -> Result<Coin, Error> {
-    let mut incoins = Coin::zero();
-    // verify that txids of inputs correspond to the owner/signer
-    // and it'd check they are not spent
-    for (txin, in_witness) in inputs.iter().zip(witness.iter()) {
+    let mut result = Vec::with_capacity(inputs.len());
+    for txin in inputs.iter() {
         let txo = db.get(COL_TX_META, &txin.id[..]);
         match txo {
             Ok(Some(v)) => {
@@ -166,27 +64,7 @@ fn check_inputs_lookup(
                 let txdata = db.get(COL_BODIES, &txin.id[..]).unwrap().unwrap().to_vec();
                 // only TxWithOutputs should have an entry in COL_TX_META
                 let tx = TxWithOutputs::decode(&mut txdata.as_slice()).unwrap();
-                let outputs = tx.outputs();
-                if input_index >= outputs.len() {
-                    return Err(Error::InvalidInput);
-                }
-                let txout = &outputs[input_index];
-                if let Some(valid_from) = &txout.valid_from {
-                    if *valid_from > extra_info.previous_block_time {
-                        return Err(Error::OutputInTimelock);
-                    }
-                }
-
-                let wv = verify_tx_address(&in_witness, main_txid, &txout.address);
-                if let Err(e) = wv {
-                    return Err(Error::EcdsaCrypto(e));
-                }
-                let sum = incoins + txout.value;
-                if let Err(e) = sum {
-                    return Err(Error::InvalidSum(e));
-                } else {
-                    incoins = sum.unwrap();
-                }
+                result.push(tx);
             }
             Ok(None) => {
                 return Err(Error::InvalidInput);
@@ -196,196 +74,7 @@ fn check_inputs_lookup(
             }
         }
     }
-    Ok(incoins)
-}
-
-fn check_outputs_basic(outputs: &[TxOut]) -> Result<(), Error> {
-    // check that there are outputs
-    if outputs.is_empty() {
-        return Err(Error::NoOutputs);
-    }
-
-    // check that all outputs have a non-zero amount
-    if !outputs.iter().all(|x| x.value > Coin::zero()) {
-        return Err(Error::ZeroCoin);
-    }
-
-    // Note: we don't need to check against MAX_COIN because Coin's
-    // constructor should already do it.
-
-    // TODO: check address attributes?
-    Ok(())
-}
-
-fn check_input_output_sums(
-    incoins: Coin,
-    outcoins: Coin,
-    extra_info: &ChainInfo,
-) -> Result<Fee, Error> {
-    // check sum(input amounts) >= sum(output amounts) + minimum fee
-    let min_fee: Coin = extra_info.min_fee_computed.to_coin();
-    let total_outsum = outcoins + min_fee;
-    if let Err(coin_err) = total_outsum {
-        return Err(Error::InvalidSum(coin_err));
-    }
-    if incoins < total_outsum.unwrap() {
-        return Err(Error::InputOutputDoNotMatch);
-    }
-    let fee_paid = (incoins - outcoins).unwrap();
-    Ok(Fee::new(fee_paid))
-}
-
-/// checks TransferTx -- TODO: this will be moved to an enclave
-/// TODO: when more address/sigs available, check Redeem addresses are never in outputs?
-fn verify_transfer(
-    maintx: &Tx,
-    witness: &TxWitness,
-    extra_info: ChainInfo,
-    db: Arc<dyn KeyValueDB>,
-) -> Result<Fee, Error> {
-    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
-    check_inputs_basic(&maintx.inputs, witness)?;
-    check_outputs_basic(&maintx.outputs)?;
-    let incoins = check_inputs_lookup(&maintx.id(), &maintx.inputs, witness, &extra_info, db)?;
-    let outcoins = maintx.get_output_total();
-    if let Err(coin_err) = outcoins {
-        return Err(Error::InvalidSum(coin_err));
-    }
-    check_input_output_sums(incoins, outcoins.unwrap(), &extra_info)
-}
-
-fn verify_bonded_deposit(
-    maintx: &DepositBondTx,
-    witness: &TxWitness,
-    extra_info: ChainInfo,
-    db: Arc<dyn KeyValueDB>,
-    accounts: &AccountStorage,
-) -> Result<(Fee, Option<StakedState>), Error> {
-    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
-    check_inputs_basic(&maintx.inputs, witness)?;
-    let incoins = check_inputs_lookup(&maintx.id(), &maintx.inputs, witness, &extra_info, db)?;
-    if incoins <= extra_info.min_fee_computed.to_coin() {
-        return Err(Error::InputOutputDoNotMatch);
-    }
-    let deposit_amount = (incoins - extra_info.min_fee_computed.to_coin()).expect("init");
-    // TODO: check account not jailed etc.?
-    let maccount = get_account(
-        &maintx.to_staked_account,
-        &extra_info.last_account_root_hash,
-        accounts,
-    );
-    let account = match maccount {
-        Ok(mut a) => {
-            a.deposit(deposit_amount);
-            Ok(a)
-        }
-        Err(Error::AccountNotFound) => Ok(StakedState::new_init(
-            deposit_amount,
-            extra_info.previous_block_time,
-            maintx.to_staked_account,
-            true,
-        )),
-        e => e,
-    };
-    Ok((extra_info.min_fee_computed, Some(account?)))
-}
-
-/// checks that the account can be retrieved from the trie storage
-pub fn get_account(
-    account_address: &StakedStateAddress,
-    last_root: &StarlingFixedKey,
-    accounts: &AccountStorage,
-) -> Result<StakedState, Error> {
-    let account_key = to_stake_key(account_address);
-    let items = accounts.get(last_root, &mut [&account_key]);
-    if let Err(e) = items {
-        return Err(Error::AccountLookupError(e));
-    }
-    let account = items.unwrap()[&account_key].clone();
-    match account {
-        None => Err(Error::AccountNotFound),
-        Some(AccountWrapper(a)) => Ok(a),
-    }
-}
-
-fn verify_unbonding(
-    maintx: &UnbondTx,
-    witness: &StakedStateOpWitness,
-    extra_info: ChainInfo,
-    accounts: &AccountStorage,
-) -> Result<(Fee, Option<StakedState>), Error> {
-    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
-    let account_address = verify_tx_recover_address(&witness, &maintx.id());
-    if let Err(e) = account_address {
-        return Err(Error::EcdsaCrypto(e));
-    }
-    let mut account = get_account(
-        &account_address.unwrap(),
-        &extra_info.last_account_root_hash,
-        accounts,
-    )?;
-    // checks that account transaction count matches to the one in transaction
-    if maintx.nonce != account.nonce {
-        return Err(Error::AccountIncorrectNonce);
-    }
-    // check that a non-zero amount is being unbound
-    if maintx.value == Coin::zero() {
-        return Err(Error::ZeroCoin);
-    }
-    check_input_output_sums(account.bonded, maintx.value, &extra_info)?;
-    account.unbond(
-        maintx.value,
-        extra_info.min_fee_computed.to_coin(),
-        extra_info.previous_block_time + i64::from(extra_info.unbonding_period),
-    );
-    // only pay the minimal fee from the bonded amount if correct; the rest remains in bonded
-    Ok((extra_info.min_fee_computed, Some(account)))
-}
-
-fn verify_unbonded_withdraw(
-    maintx: &WithdrawUnbondedTx,
-    witness: &StakedStateOpWitness,
-    extra_info: ChainInfo,
-    accounts: &AccountStorage,
-) -> Result<(Fee, Option<StakedState>), Error> {
-    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
-    check_outputs_basic(&maintx.outputs)?;
-    let account_address = verify_tx_recover_address(&witness, &maintx.id());
-    if let Err(e) = account_address {
-        return Err(Error::EcdsaCrypto(e));
-    }
-    let mut account = get_account(
-        &account_address.unwrap(),
-        &extra_info.last_account_root_hash,
-        accounts,
-    )?;
-    // checks that account transaction count matches to the one in transaction
-    if maintx.nonce != account.nonce {
-        return Err(Error::AccountIncorrectNonce);
-    }
-    // checks that account can withdraw to outputs
-    if account.unbonded_from > extra_info.previous_block_time {
-        return Err(Error::AccountNotUnbonded);
-    }
-    // checks that there is something to wihdraw
-    if account.unbonded == Coin::zero() {
-        return Err(Error::ZeroCoin);
-    }
-    // checks that outputs are locked to the unbonded time
-    if !maintx
-        .outputs
-        .iter()
-        .all(|x| x.valid_from == Some(account.unbonded_from))
-    {
-        return Err(Error::AccountWithdrawOutputNotLocked);
-    }
-    let outcoins = maintx.get_output_total();
-    if let Err(coin_err) = outcoins {
-        return Err(Error::InvalidSum(coin_err));
-    }
-    let fee = check_input_output_sums(account.unbonded, outcoins.unwrap(), &extra_info)?;
-    account.withdraw();
-    Ok((fee, Some(account)))
+    Ok(result)
 }
 
 /// Checks TX against the current DB and returns an `Error` if something fails.
@@ -393,21 +82,49 @@ fn verify_unbonded_withdraw(
 pub fn verify(
     txaux: &TxAux,
     extra_info: ChainInfo,
+    last_account_root_hash: StarlingFixedKey,
     db: Arc<dyn KeyValueDB>,
     accounts: &AccountStorage,
 ) -> Result<(Fee, Option<StakedState>), Error> {
     let paid_fee = match txaux {
         TxAux::TransferTx(maintx, witness) => {
-            (verify_transfer(maintx, witness, extra_info, db)?, None)
+            let input_transactions = check_spent_input_lookup(&maintx.inputs, db)?;
+            (
+                verify_transfer(maintx, witness, extra_info, input_transactions)?,
+                None,
+            )
         }
         TxAux::DepositStakeTx(maintx, witness) => {
-            verify_bonded_deposit(maintx, witness, extra_info, db, accounts)?
+            let maccount =
+                get_account(&maintx.to_staked_account, &last_account_root_hash, accounts);
+            let account = match maccount {
+                Ok(a) => Some(a),
+                Err(Error::AccountNotFound) => None,
+                Err(e) => {
+                    return Err(e);
+                }
+            };
+            let input_transactions = check_spent_input_lookup(&maintx.inputs, db)?;
+
+            verify_bonded_deposit(maintx, witness, extra_info, input_transactions, account)?
         }
         TxAux::UnbondStakeTx(maintx, witness) => {
-            verify_unbonding(maintx, witness, extra_info, accounts)?
+            let account_address = verify_tx_recover_address(&witness, &maintx.id());
+            if let Err(e) = account_address {
+                return Err(Error::EcdsaCrypto(e));
+            }
+            let account =
+                get_account(&account_address.unwrap(), &last_account_root_hash, accounts)?;
+            verify_unbonding(maintx, extra_info, account)?
         }
         TxAux::WithdrawUnbondedStakeTx(maintx, witness) => {
-            verify_unbonded_withdraw(maintx, witness, extra_info, accounts)?
+            let account_address = verify_tx_recover_address(&witness, &maintx.id());
+            if let Err(e) = account_address {
+                return Err(Error::EcdsaCrypto(e));
+            }
+            let account =
+                get_account(&account_address.unwrap(), &last_account_root_hash, accounts)?;
+            verify_unbonded_withdraw(maintx, extra_info, account)?
         }
     };
     Ok(paid_fee)

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -5,7 +5,6 @@ use chain_abci::app::*;
 use chain_abci::storage::account::AccountStorage;
 use chain_abci::storage::account::AccountWrapper;
 use chain_abci::storage::tx::StarlingFixedKey;
-use chain_abci::storage::tx::TxWithOutputs;
 use chain_abci::storage::*;
 use chain_core::common::{MerkleTree, Proof, H256, HASH_SIZE_256};
 use chain_core::compute_app_hash;
@@ -35,6 +34,7 @@ use chain_core::tx::{
     witness::{TxInWitness, TxWitness},
     TxAux,
 };
+use chain_tx_validation::TxWithOutputs;
 use ethbloom::{Bloom, Input};
 use hex::decode;
 use kvdb::KeyValueDB;

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -9,6 +9,4 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a1e70e1f0bb65d3a97f100f79d99c85395d897f8", features = ["recovery", "endomorphism"] }
-
-[dev-dependencies]
-parity-codec = { version = "4.0.0" }
+parity-codec = { features = ["derive"], version = "4.0.0" }

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -1,2 +1,374 @@
+#![deny(missing_docs, unsafe_code, unstable_features)]
+//! This crate contains functionality for transaction validation. It's currently tested in chain-abci. (TODO: move tests)
+//! WARNING: all validation is pure functions / without DB access => it assumes double-spending BitVec is checked in chain-abci
+
 /// transaction witness verification
 pub mod witness;
+
+use chain_core::common::Timespec;
+use chain_core::init::coin::{Coin, CoinError};
+use chain_core::state::account::{DepositBondTx, StakedState, UnbondTx, WithdrawUnbondedTx};
+use chain_core::tx::data::input::TxoPointer;
+use chain_core::tx::data::output::TxOut;
+use chain_core::tx::data::Tx;
+use chain_core::tx::data::TxId;
+use chain_core::tx::fee::Fee;
+use chain_core::tx::witness::TxWitness;
+use chain_core::tx::TransactionId;
+use parity_codec::{Decode, Encode};
+use secp256k1;
+use std::collections::BTreeSet;
+use std::{fmt, io};
+use witness::verify_tx_address;
+
+/// All possible TX validation errors
+#[derive(Debug)]
+pub enum Error {
+    /// chain hex ID does not match
+    WrongChainHexId,
+    /// transaction has no inputs
+    NoInputs,
+    /// transaction has no outputs
+    NoOutputs,
+    /// transaction has duplicated inputs
+    DuplicateInputs,
+    /// output with no credited value
+    ZeroCoin,
+    /// input or output summation error
+    InvalidSum(CoinError),
+    /// transaction has more witnesses than inputs
+    UnexpectedWitnesses,
+    /// transaction has more inputs than witnesses
+    MissingWitnesses,
+    /// transaction spends an invalid input
+    InvalidInput,
+    /// transaction spends an input that was already spent
+    InputSpent,
+    /// transaction input output coin (plus fee) sums don't match
+    InputOutputDoNotMatch,
+    /// output transaction is in timelock that hasn't passed
+    OutputInTimelock,
+    /// cryptographic library error
+    EcdsaCrypto(secp256k1::Error),
+    /// DB read error
+    IoError(io::Error),
+    /// staked state not found
+    AccountNotFound,
+    /// staked state not unbounded
+    AccountNotUnbonded,
+    /// outputs created out of a staked state are not time-locked to unbonding period
+    AccountWithdrawOutputNotLocked,
+    /// incorrect nonce supplied in staked state operation
+    AccountIncorrectNonce,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::Error::*;
+        match self {
+            WrongChainHexId => write!(f, "chain hex ID does not match"),
+            DuplicateInputs => write!(f, "duplicated inputs"),
+            UnexpectedWitnesses => write!(f, "transaction has more witnesses than inputs"),
+            MissingWitnesses => write!(f, "transaction has more inputs than witnesses"),
+            NoInputs => write!(f, "transaction has no inputs"),
+            NoOutputs => write!(f, "transaction has no outputs"),
+            ZeroCoin => write!(f, "output with no credited value"),
+            InvalidSum(ref err) => write!(f, "input or output sum error: {}", err),
+            InvalidInput => write!(f, "transaction spends an invalid input"),
+            InputSpent => write!(f, "transaction spends an input that was already spent"),
+            InputOutputDoNotMatch => write!(
+                f,
+                "transaction input output coin (plus fee) sums don't match"
+            ),
+            OutputInTimelock => write!(f, "output transaction is in timelock"),
+            EcdsaCrypto(ref err) => write!(f, "ECDSA crypto error: {}", err),
+            IoError(ref err) => write!(f, "IO error: {}", err),
+            AccountNotFound => write!(f, "account not found"),
+            AccountNotUnbonded => write!(f, "account not unbonded for withdrawal"),
+            AccountWithdrawOutputNotLocked => write!(
+                f,
+                "account withdrawal outputs not time-locked to unbonded_from"
+            ),
+            AccountIncorrectNonce => write!(f, "incorrect transaction count for account operation"),
+        }
+    }
+}
+
+/// External information needed for TX validation
+#[derive(Clone, Copy)]
+pub struct ChainInfo {
+    /// minimal fee computed for the transaction
+    pub min_fee_computed: Fee,
+    /// network hexamedical ID
+    pub chain_hex_id: u8,
+    /// time in the previous committed block
+    pub previous_block_time: Timespec,
+    /// how much time is required to wait until stake state's unbonded amount can be withdrawn
+    pub unbonding_period: u32,
+}
+
+fn check_attributes(tx_chain_hex_id: u8, extra_info: &ChainInfo) -> Result<(), Error> {
+    // TODO: check other attributes?
+    // check that chain IDs match
+    if extra_info.chain_hex_id != tx_chain_hex_id {
+        return Err(Error::WrongChainHexId);
+    }
+    Ok(())
+}
+
+fn check_inputs_basic(inputs: &[TxoPointer], witness: &TxWitness) -> Result<(), Error> {
+    // check that there are inputs
+    if inputs.is_empty() {
+        return Err(Error::NoInputs);
+    }
+
+    // check that there are no duplicate inputs
+    let mut inputs_s = BTreeSet::new();
+    if !inputs.iter().all(|x| inputs_s.insert(x)) {
+        return Err(Error::DuplicateInputs);
+    }
+
+    // verify transaction witnesses
+    if inputs.len() < witness.len() {
+        return Err(Error::UnexpectedWitnesses);
+    }
+
+    if inputs.len() > witness.len() {
+        return Err(Error::MissingWitnesses);
+    }
+
+    Ok(())
+}
+
+/// wrapper around transactions with outputs
+#[derive(Encode, Decode)]
+pub enum TxWithOutputs {
+    /// normal transfer
+    Transfer(Tx),
+    /// withdrawing unbonded amount from a staked state
+    StakeWithdraw(WithdrawUnbondedTx),
+}
+
+impl TxWithOutputs {
+    /// returns the particular transaction type's outputs
+    pub fn outputs(&self) -> &[TxOut] {
+        match self {
+            TxWithOutputs::Transfer(tx) => &tx.outputs,
+            TxWithOutputs::StakeWithdraw(tx) => &tx.outputs,
+        }
+    }
+
+    /// returns the particular transaction type's id (currently blake2s_hash(SCALE-encoded tx))
+    pub fn id(&self) -> TxId {
+        match self {
+            TxWithOutputs::Transfer(tx) => tx.id(),
+            TxWithOutputs::StakeWithdraw(tx) => tx.id(),
+        }
+    }
+}
+
+fn check_inputs(
+    main_txid: &TxId,
+    inputs: &[TxoPointer],
+    witness: &TxWitness,
+    extra_info: &ChainInfo,
+    transaction_inputs: Vec<TxWithOutputs>,
+) -> Result<Coin, Error> {
+    let mut incoins = Coin::zero();
+    // verify that txids of inputs correspond to the owner/signer
+    // and it'd check they are not spent
+    // TODO: zip3 / itertools?
+    for (txin, (tx, in_witness)) in inputs
+        .iter()
+        .zip(transaction_inputs.iter().zip(witness.iter()))
+    {
+        if txin.id != tx.id() {
+            return Err(Error::InvalidInput);
+        }
+        let input_index = txin.index as usize;
+        let outputs = tx.outputs();
+        if input_index >= outputs.len() {
+            return Err(Error::InvalidInput);
+        }
+        let txout = &outputs[input_index];
+        if let Some(valid_from) = &txout.valid_from {
+            if *valid_from > extra_info.previous_block_time {
+                return Err(Error::OutputInTimelock);
+            }
+        }
+        let wv = verify_tx_address(&in_witness, main_txid, &txout.address);
+        if let Err(e) = wv {
+            return Err(Error::EcdsaCrypto(e));
+        }
+        let sum = incoins + txout.value;
+        if let Err(e) = sum {
+            return Err(Error::InvalidSum(e));
+        } else {
+            incoins = sum.unwrap();
+        }
+    }
+    Ok(incoins)
+}
+
+fn check_outputs_basic(outputs: &[TxOut]) -> Result<(), Error> {
+    // check that there are outputs
+    if outputs.is_empty() {
+        return Err(Error::NoOutputs);
+    }
+
+    // check that all outputs have a non-zero amount
+    if !outputs.iter().all(|x| x.value > Coin::zero()) {
+        return Err(Error::ZeroCoin);
+    }
+
+    // Note: we don't need to check against MAX_COIN because Coin's
+    // constructor should already do it.
+
+    // TODO: check address attributes?
+    Ok(())
+}
+
+fn check_input_output_sums(
+    incoins: Coin,
+    outcoins: Coin,
+    extra_info: &ChainInfo,
+) -> Result<Fee, Error> {
+    // check sum(input amounts) >= sum(output amounts) + minimum fee
+    let min_fee: Coin = extra_info.min_fee_computed.to_coin();
+    let total_outsum = outcoins + min_fee;
+    if let Err(coin_err) = total_outsum {
+        return Err(Error::InvalidSum(coin_err));
+    }
+    if incoins < total_outsum.unwrap() {
+        return Err(Error::InputOutputDoNotMatch);
+    }
+    let fee_paid = (incoins - outcoins).unwrap();
+    Ok(Fee::new(fee_paid))
+}
+
+/// checks TransferTx -- TODO: this will be moved to an enclave
+/// WARNING: it assumes double-spending BitVec of inputs is checked in chain-abci
+pub fn verify_transfer(
+    maintx: &Tx,
+    witness: &TxWitness,
+    extra_info: ChainInfo,
+    transaction_inputs: Vec<TxWithOutputs>,
+) -> Result<Fee, Error> {
+    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
+    check_inputs_basic(&maintx.inputs, witness)?;
+    check_outputs_basic(&maintx.outputs)?;
+    let incoins = check_inputs(
+        &maintx.id(),
+        &maintx.inputs,
+        witness,
+        &extra_info,
+        transaction_inputs,
+    )?;
+    let outcoins = maintx.get_output_total();
+    if let Err(coin_err) = outcoins {
+        return Err(Error::InvalidSum(coin_err));
+    }
+    check_input_output_sums(incoins, outcoins.unwrap(), &extra_info)
+}
+
+/// checks depositing to a staked state -- TODO: this will be moved to an enclave
+/// WARNING: it assumes double-spending BitVec of inputs is checked in chain-abci
+pub fn verify_bonded_deposit(
+    maintx: &DepositBondTx,
+    witness: &TxWitness,
+    extra_info: ChainInfo,
+    transaction_inputs: Vec<TxWithOutputs>,
+    maccount: Option<StakedState>,
+) -> Result<(Fee, Option<StakedState>), Error> {
+    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
+    check_inputs_basic(&maintx.inputs, witness)?;
+    let incoins = check_inputs(
+        &maintx.id(),
+        &maintx.inputs,
+        witness,
+        &extra_info,
+        transaction_inputs,
+    )?;
+    if incoins <= extra_info.min_fee_computed.to_coin() {
+        return Err(Error::InputOutputDoNotMatch);
+    }
+    let deposit_amount = (incoins - extra_info.min_fee_computed.to_coin()).expect("init");
+    let account = match maccount {
+        Some(mut a) => {
+            a.deposit(deposit_amount);
+            Some(a)
+        }
+        None => Some(StakedState::new_init(
+            deposit_amount,
+            extra_info.previous_block_time,
+            maintx.to_staked_account,
+            true,
+        )),
+    };
+    Ok((extra_info.min_fee_computed, account))
+}
+
+/// checks moving some amount from bonded to unbonded in staked states
+/// NOTE: witness is assumed to be checked in chain-abci
+pub fn verify_unbonding(
+    maintx: &UnbondTx,
+    extra_info: ChainInfo,
+    mut account: StakedState,
+) -> Result<(Fee, Option<StakedState>), Error> {
+    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
+
+    // checks that account transaction count matches to the one in transaction
+    if maintx.nonce != account.nonce {
+        return Err(Error::AccountIncorrectNonce);
+    }
+    // check that a non-zero amount is being unbound
+    if maintx.value == Coin::zero() {
+        return Err(Error::ZeroCoin);
+    }
+    check_input_output_sums(account.bonded, maintx.value, &extra_info)?;
+    account.unbond(
+        maintx.value,
+        extra_info.min_fee_computed.to_coin(),
+        extra_info.previous_block_time + i64::from(extra_info.unbonding_period),
+    );
+    // only pay the minimal fee from the bonded amount if correct; the rest remains in bonded
+    Ok((extra_info.min_fee_computed, Some(account)))
+}
+
+/// checks wihdrawing from a staked state -- TODO: this will be moved to an enclave
+/// NOTE: witness is assumed to be checked in chain-abci
+pub fn verify_unbonded_withdraw(
+    maintx: &WithdrawUnbondedTx,
+    extra_info: ChainInfo,
+    mut account: StakedState,
+) -> Result<(Fee, Option<StakedState>), Error> {
+    check_attributes(maintx.attributes.chain_hex_id, &extra_info)?;
+    check_outputs_basic(&maintx.outputs)?;
+    // checks that account transaction count matches to the one in transaction
+    if maintx.nonce != account.nonce {
+        return Err(Error::AccountIncorrectNonce);
+    }
+    // checks that account can withdraw to outputs
+    if account.unbonded_from > extra_info.previous_block_time {
+        return Err(Error::AccountNotUnbonded);
+    }
+    // checks that there is something to wihdraw
+    if account.unbonded == Coin::zero() {
+        return Err(Error::ZeroCoin);
+    }
+    // checks that outputs are locked to the unbonded time
+    if !maintx
+        .outputs
+        .iter()
+        .all(|x| x.valid_from == Some(account.unbonded_from))
+    {
+        return Err(Error::AccountWithdrawOutputNotLocked);
+    }
+    let outcoins = maintx.get_output_total();
+    if let Err(coin_err) = outcoins {
+        return Err(Error::InvalidSum(coin_err));
+    }
+    let fee = check_input_output_sums(account.unbonded, outcoins.unwrap(), &extra_info)?;
+    account.withdraw();
+    Ok((fee, Some(account)))
+}


### PR DESCRIPTION
Solution: moved the remaining tx validation code from chain-abci to the dedicated crate and fixed tests.
note that the dedicated crate tries to be as self-contained as possible, so it doesn't do I/O and all inputs are explicitly provided to it -- for account/stakedstate-based operations, it assumes witness / signature was checked during the account lookup; for utxo-based operations, it assumes inputs were checked not to be spent in abci app