### PR TITLE
Problem: chain-core is not sgx-friendly (CRO-188 / CRO-182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
  "parity-codec 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -276,7 +276,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -289,7 +289,7 @@ version = "0.1.0"
 dependencies = [
  "chain-core 0.1.0",
  "parity-codec 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c)",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -387,7 +387,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c)",
 ]
 
 [[package]]
@@ -1847,7 +1847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "secp256k1zkp"
 version = "0.13.0"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8#a1e70e1f0bb65d3a97f100f79d99c85395d897f8"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c#aa4f8e08253e7278c20122b9268c970d6f03d44c"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2729,7 +2729,7 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-"checksum secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=a1e70e1f0bb65d3a97f100f79d99c85395d897f8)" = "<none>"
+"checksum secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=aa4f8e08253e7278c20122b9268c970d6f03d44c)" = "<none>"
 "checksum secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb003d53cef244a97516226b01155057c7fa6eb52914933c32f6c98a84182188"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.3"
 protobuf = "2.6.0"
 integer-encoding = "1.0.7"
 clap = { features = ["yaml"], version = "2.33.0" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a1e70e1f0bb65d3a97f100f79d99c85395d897f8", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "aa4f8e08253e7278c20122b9268c970d6f03d44c", features = ["recovery", "endomorphism"] }
 blake2 = "0.8"
 ethbloom = "0.5.0"
 parity-codec = { features = ["derive"], version = "4.1.0" }

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -6,12 +6,15 @@ description = "Library with core types and serialization for the use in external
 readme = "../README.md"
 edition = "2018"
 
+[features]
+default = ["sha3", "serde"]
+
 [dependencies]
 digest = "0.8"
-sha3 = "0.8"
+sha3 = { version = "0.8", optional = true }
 hex = "0.3"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a1e70e1f0bb65d3a97f100f79d99c85395d897f8", features = ["serde", "recovery", "endomorphism"] }
-serde = { version = "1.0", features = ["derive"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "aa4f8e08253e7278c20122b9268c970d6f03d44c", features = ["recovery", "endomorphism", "serde"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = "0.8"
 serde_json = "1.0"
 parity-codec = { features = ["derive"], version = "4.1.0" }

--- a/chain-core/src/common/merkle_tree.rs
+++ b/chain-core/src/common/merkle_tree.rs
@@ -1,3 +1,4 @@
+use std::prelude::v1::{Box, Vec};
 use std::vec::IntoIter;
 
 use blake2::Blake2s;

--- a/chain-core/src/init/coin.rs
+++ b/chain-core/src/init/coin.rs
@@ -8,13 +8,16 @@ use crate::state::tendermint::TendermintVotePower;
 use parity_codec::{Decode, Encode, Input};
 
 use crate::state::tendermint::TENDERMINT_MAX_VOTE_POWER;
+#[cfg(feature = "serde")]
 use serde::de::{Deserialize, Deserializer, Error, Visitor};
+#[cfg(feature = "serde")]
 use serde::Serialize;
 use static_assertions::const_assert;
 use std::convert::TryFrom;
 use std::{fmt, mem, ops, result, slice};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Encode)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Encode)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Coin(u64);
 
 /// error type relating to `Coin` operations
@@ -180,6 +183,7 @@ impl From<u32> for Coin {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Coin {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -1,6 +1,7 @@
-use std::fmt;
-
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::prelude::v1::{String, Vec};
 
 use crate::common::Timespec;
 use crate::init::address::RedeemAddress;
@@ -13,7 +14,8 @@ use crate::state::RewardsPoolState;
 use crate::tx::fee::LinearFee;
 use std::collections::{BTreeMap, HashSet};
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InitNetworkParameters {
     // Initial fee setting
     // -- TODO: perhaps change to be against T: FeeAlgorithm
@@ -25,7 +27,8 @@ pub struct InitNetworkParameters {
     pub unbonding_period: u32,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AccountType {
     // vanilla -- redeemable
     ExternallyOwnedAccount,
@@ -33,12 +36,14 @@ pub enum AccountType {
     Contract,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ValidatorKeyType {
     Ed25519,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InitialValidator {
     // account with the required staked amount
     pub staking_account_address: RedeemAddress,
@@ -50,7 +55,8 @@ pub struct InitialValidator {
 
 /// Initial configuration ("app_state" in genesis.json of Tendermint config)
 /// TODO: reward/treasury config, extra validator config...
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InitConfig {
     // Redeem mapping of ERC20 snapshot: Eth address => (CRO tokens, AccountType)
     pub distribution: BTreeMap<RedeemAddress, (Coin, AccountType)>,

--- a/chain-core/src/lib.rs
+++ b/chain-core/src/lib.rs
@@ -1,3 +1,15 @@
+#![cfg_attr(all(feature = "mesalock_sgx", not(target_env = "sgx")), no_std)]
+#![cfg_attr(
+    all(target_env = "sgx", target_vendor = "mesalock"),
+    feature(rustc_private)
+)]
+
+#[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+use std::prelude::v1::Vec;
+
 /// Miscellaneous definitions and generic merkle tree
 pub mod common;
 /// Types mainly related to InitChain command in ABCI

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -9,10 +9,12 @@ use crate::tx::witness::{tree::RawSignature, EcdsaSignature};
 use crate::tx::TransactionId;
 use blake2::Blake2s;
 use parity_codec::{Decode, Encode, Input, Output};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::prelude::v1::Vec;
 // TODO: switch to normal signatures + explicit public key
 use crate::init::address::ErrorAddress;
 use secp256k1::recovery::{RecoverableSignature, RecoveryId};
-use serde::{Deserialize, Serialize};
 use std::convert::{From, TryFrom};
 use std::fmt;
 
@@ -23,9 +25,8 @@ pub type Count = u64;
 pub type Nonce = u64;
 
 /// StakedState address type
-#[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StakedStateAddress {
     BasicRedeem(RedeemAddress),
 }
@@ -161,7 +162,8 @@ impl StakedState {
 }
 
 /// attributes in StakedState-related transactions
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StakedStateOpAttributes {
     pub chain_hex_id: u8,
     // TODO: Other attributes?
@@ -197,7 +199,8 @@ impl Decode for StakedStateOpAttributes {
 
 /// takes UTXOs inputs, deposits them in the specified StakedState's bonded amount - fee
 /// (updates StakedState's bonded + nonce)
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DepositBondTx {
     pub inputs: Vec<TxoPointer>,
     pub to_staked_account: StakedStateAddress,
@@ -232,7 +235,8 @@ impl fmt::Display for DepositBondTx {
 
 /// updates the StakedState (TODO: implicit from the witness?) by moving some of the bonded amount - fee into unbonded,
 /// and setting the unbonded_from to last_block_time+min_unbonding_time (network parameter)
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UnbondTx {
     pub value: Coin,
     pub nonce: Nonce,
@@ -260,7 +264,8 @@ impl fmt::Display for UnbondTx {
 
 /// takes the StakedState (TODO: implicit from the witness?) and creates UTXOs
 /// (update's StakedState's unbonded + nonce)
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WithdrawUnbondedTx {
     pub nonce: Nonce,
     pub outputs: Vec<TxOut>,
@@ -297,7 +302,8 @@ impl fmt::Display for WithdrawUnbondedTx {
 }
 
 /// A witness for StakedState operations
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StakedStateOpWitness {
     BasicRedeem(EcdsaSignature),
 }

--- a/chain-core/src/state/mod.rs
+++ b/chain-core/src/state/mod.rs
@@ -8,10 +8,12 @@ use crate::init::coin::Coin;
 use account::{Nonce, StakedStateAddress};
 use blake2::Blake2s;
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use tendermint::{BlockHeight, TendermintValidatorPubKey};
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RewardsPoolState {
     /// remaining amount in the pool
     pub remaining: Coin,
@@ -34,7 +36,8 @@ impl RewardsPoolState {
 }
 
 /// holds state about a node responsible for transaction validation / block signing and service node whitelist management
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CouncilNode {
     // account with the required staked amount
     pub staking_account_address: StakedStateAddress,

--- a/chain-core/src/state/tendermint.rs
+++ b/chain-core/src/state/tendermint.rs
@@ -1,6 +1,8 @@
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::prelude::v1::{String, ToString, Vec};
 
 /// Tendermint block height
 /// TODO: u64?
@@ -9,7 +11,8 @@ pub type BlockHeight = i64;
 /// The protobuf structure currently has "String" to denote the type / length
 /// and variable length byte array. In this internal representation,
 /// it's desirable to keep it restricted and compact. (TM should be encoding using the compressed form.)
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TendermintValidatorPubKey {
     Ed25519([u8; 32]),
     // there's PubKeySecp256k1, but https://tendermint.com/docs/spec/abci/apps.html#validator-updates

--- a/chain-core/src/tx/data/access.rs
+++ b/chain-core/src/tx/data/access.rs
@@ -1,12 +1,14 @@
 use parity_codec::{Decode, Encode, Input, Output};
 use secp256k1::key::PublicKey;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::tx::witness::tree::RawPubkey;
 
 /// What can be access in TX -- TODO: revisit when enforced by HW encryption / enclaves
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TxAccess {
     AllData,
     // TODO: u16 and Vec size check in Decode implementation
@@ -22,7 +24,8 @@ impl Default for TxAccess {
 }
 
 /// Specifies who can access what -- TODO: revisit when enforced by HW encryption / enclaves
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxAccessPolicy {
     pub view_key: PublicKey,
     pub access: TxAccess,

--- a/chain-core/src/tx/data/address.rs
+++ b/chain-core/src/tx/data/address.rs
@@ -1,4 +1,5 @@
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -12,7 +13,8 @@ type TreeRoot = H256;
 /// Currently, only Ethereum-style redeem address + MAST of Or operations (records the root).
 /// TODO: HD-addresses?
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ExtendedAddr {
     BasicRedeem(RedeemAddress),
     OrTree(TreeRoot),

--- a/chain-core/src/tx/data/attribute.rs
+++ b/chain-core/src/tx/data/attribute.rs
@@ -1,10 +1,13 @@
 use parity_codec::{Decode, Encode, Input, Output};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::prelude::v1::Vec;
 
 use crate::tx::data::access::TxAccessPolicy;
 
 /// Tx extra metadata, e.g. network ID
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxAttributes {
     pub chain_hex_id: u8,
     pub allowed_view: Vec<TxAccessPolicy>,

--- a/chain-core/src/tx/data/input.rs
+++ b/chain-core/src/tx/data/input.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::tx::data::TxId;
@@ -8,9 +9,8 @@ use crate::tx::data::TxId;
 /// Structure used for addressing a specific output of a transaction
 /// built from a TxId (hash of the tx) and the offset in the outputs of this
 /// transaction.
-#[derive(
-    Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode,
-)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxoPointer {
     pub id: TxId,
     // TODO: u16 and Vec size check in Decode implementation

--- a/chain-core/src/tx/data/mod.rs
+++ b/chain-core/src/tx/data/mod.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::Vec;
+
 /// For specifying access control to TX data
 pub mod access;
 /// Different address types (Redeem and Tree/MAST)
@@ -13,6 +15,7 @@ use std::fmt;
 
 use blake2::Blake2s;
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::{hash256, H256};
@@ -35,7 +38,8 @@ pub type TxId = H256;
 /// A Transaction containing tx inputs and tx outputs.
 /// TODO: max input/output size?
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tx {
     pub inputs: Vec<TxoPointer>,
     pub outputs: Vec<TxOut>,

--- a/chain-core/src/tx/data/output.rs
+++ b/chain-core/src/tx/data/output.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::Timespec;
@@ -9,7 +10,8 @@ use crate::tx::data::address::ExtendedAddr;
 
 /// Tx Output composed of an address and a coin value
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxOut {
     pub address: ExtendedAddr,
     pub value: Coin,

--- a/chain-core/src/tx/fee/mod.rs
+++ b/chain-core/src/tx/fee/mod.rs
@@ -6,9 +6,11 @@
 use crate::init::coin::{Coin, CoinError};
 use crate::tx::TxAux;
 use parity_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::num::ParseIntError;
 use std::ops::{Add, Mul};
+use std::prelude::v1::Vec;
 use std::str::FromStr;
 use std::{error, fmt};
 
@@ -30,8 +32,9 @@ impl Fee {
 /// TODO: overflow checks in Cargo?
 /// [profile.release]
 /// overflow-checks = true
-#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode)]
-#[serde(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, Encode, Decode)]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Milli(u64);
 impl Milli {
     /// takes the integer part and 4-digit fractional part
@@ -135,7 +138,8 @@ impl Mul for Milli {
 }
 
 /// Linear fee using the basic affine formula `COEFFICIENT * scale_bytes(txaux).len() + CONSTANT`
-#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode)]
+#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LinearFee {
     /// this is the minimal fee
     pub constant: Milli,

--- a/chain-core/src/tx/witness/mod.rs
+++ b/chain-core/src/tx/witness/mod.rs
@@ -2,6 +2,7 @@
 pub mod tree;
 
 use std::fmt;
+use std::prelude::v1::Vec;
 
 use parity_codec::{Decode, Encode, Input, Output};
 // TODO: switch to normal signatures + explicit public key

--- a/chain-core/src/tx/witness/tree.rs
+++ b/chain-core/src/tx/witness/tree.rs
@@ -9,12 +9,14 @@ use crate::common::{H264, H512};
 #[derive(Clone)]
 pub struct RawPubkey(H264);
 
+#[cfg(feature = "serde")]
 impl ::serde::Serialize for RawPubkey {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_bytes(&self.0)
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> ::serde::Deserialize<'de> for RawPubkey {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<RawPubkey, D::Error> {
         use ::serde::de::Error;

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 chain-core = { path = "../chain-core" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a1e70e1f0bb65d3a97f100f79d99c85395d897f8", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "aa4f8e08253e7278c20122b9268c970d6f03d44c", features = ["recovery", "endomorphism"] }
 parity-codec = { features = ["derive"], version = "4.1.0" }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 chain-core = { path = "../chain-core" }
 client-common = { path = "../client-common" }
 client-index = { path = "../client-index" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a1e70e1f0bb65d3a97f100f79d99c85395d897f8", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "aa4f8e08253e7278c20122b9268c970d6f03d44c", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 rand = "0.6"
 failure = "0.1"
 hex = "0.3"

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -14,7 +14,7 @@ jsonrpc = { version = "0.11", optional = true }
 base64 = "0.10"
 
 [dev-dependencies]
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "a1e70e1f0bb65d3a97f100f79d99c85395d897f8", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "aa4f8e08253e7278c20122b9268c970d6f03d44c", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
 
 [features]
 default = ["sled", "rpc"]


### PR DESCRIPTION
Solution: upgraded secp256k1 fork + feature-guarded a lot of it

NOTE: proper sgx-friendly version would also require a few changes in chain-core's Cargo.toml + would only work on nightly OR would need Xargo;
for that reason it's not done here -- the TX enclave repo will have a subtree of chain's repository with the SGX breaking changes