### PR TITLE
Problem: tx-validation doesn't compile in enclaves (CRO-189 / CRO-182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,8 +288,8 @@ dependencies = [
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -557,6 +557,11 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,7 +678,7 @@ dependencies = [
  "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2271,10 +2276,10 @@ dependencies = [
 
 [[package]]
 name = "tiny-keccak"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2729,6 +2734,7 @@ dependencies = [
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
+"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum csv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9044e25afb0924b5a5fc5511689b0918629e85d68ea591e5e87fbf1e85ea1b3b"
 "checksum csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5cdef62f37e6ffe7d1f07a381bc0db32b7a3ff1cac0de56cb0d81e71f53d65"
@@ -2921,7 +2927,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dbbdebb0b801c7fa4260b6b9ac5a15980276d7d7bcc2dc2959a7c4dc8b426a1a"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2ffcf4bcfc641413fa0f1427bf8f91dfc78f56a6559cbf50e04837ae442a87"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -7,11 +7,11 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["sha3", "serde"]
+default = ["serde"]
 
 [dependencies]
 digest = "0.8"
-sha3 = { version = "0.8", optional = true }
+tiny-keccak = { version = "1.5.0", default-features = false, features = ["keccak"] }
 hex = "0.3"
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["recovery", "endomorphism", "serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/chain-core/src/init/address.rs
+++ b/chain-core/src/init/address.rs
@@ -17,25 +17,23 @@ use std::str::FromStr;
 use std::{fmt, ops};
 
 use hex;
-#[cfg(feature = "sha3")]
 use secp256k1::key::PublicKey;
 #[cfg(feature = "serde")]
 use serde::de::Error;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "sha3")]
-use sha3::Keccak256;
+use tiny_keccak::Keccak;
 
-#[cfg(feature = "sha3")]
-use crate::common::{hash256, H256};
+use crate::common::{H256, HASH_SIZE_256};
 
 /// Keccak-256 crypto hash length in bytes
 pub const KECCAK256_BYTES: usize = 32;
 
 /// Calculate Keccak-256 crypto hash
-#[cfg(feature = "sha3")]
 pub fn keccak256(data: &[u8]) -> H256 {
-    hash256::<Keccak256>(data)
+    let mut output = [0u8; HASH_SIZE_256];
+    Keccak::keccak256(data, &mut output);
+    output
 }
 
 /// Convert a slice into array
@@ -145,7 +143,6 @@ impl ops::Deref for RedeemAddress {
     }
 }
 
-#[cfg(feature = "sha3")]
 impl From<&PublicKey> for RedeemAddress {
     fn from(pk: &PublicKey) -> Self {
         let hash = keccak256(&pk.serialize_uncompressed()[1..]);

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -1,9 +1,20 @@
+#![cfg_attr(all(feature = "mesalock_sgx", not(target_env = "sgx")), no_std)]
+#![cfg_attr(
+    all(target_env = "sgx", target_vendor = "mesalock"),
+    feature(rustc_private)
+)]
 #![deny(missing_docs, unsafe_code, unstable_features)]
 //! This crate contains functionality for transaction validation. It's currently tested in chain-abci. (TODO: move tests)
 //! WARNING: all validation is pure functions / without DB access => it assumes double-spending BitVec is checked in chain-abci
 
 /// transaction witness verification
 pub mod witness;
+
+#[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+use std::prelude::v1::Vec;
 
 use chain_core::common::Timespec;
 use chain_core::init::coin::{Coin, CoinError};


### PR DESCRIPTION
Solution: extra attribute configs + converted the address in chain core to use tiny-keccak rather than sha3 crate (as the former compiles out-of-the-box in sgx env)