### PR TITLE
Problem: (CRO-197) Latest ABCI (for tendermint 0.32) doesn't compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abci"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -247,7 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "chain-abci"
 version = "0.0.1"
 dependencies = [
- "abci 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abci 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2689,7 +2689,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum abci 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5341ad5ddbc3618739548cd55b3503752daef44755f4d63d2f9c78059a55f870"
+"checksum abci 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2801852eafa0d2e44684f8fb5a6abf7455af04137cd35c4e81d1dd766eedf238"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-abci = "0.5.4"
+abci = "0.6"
 chain-core = { path = "../chain-core" }
 chain-tx-validation = { path = "../chain-tx-validation" }
 log = "0.4.0"

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -196,7 +196,10 @@ impl abci::Application for ChainNodeApp {
             kvpair.key = Vec::from(&b"txid"[..]);
             // TODO: "Keys and values in tags must be UTF-8 encoded strings" ?
             kvpair.value = Vec::from(&txaux.tx_id()[..]);
-            resp.tags.push(kvpair);
+            let mut event = Event::new();
+            event.field_type = "delivered_txs".to_string();
+            event.attributes.push(kvpair);
+            resp.events.push(event);
             self.delivered_txs.push(txaux);
             let rewards_pool = &mut self
                 .last_state
@@ -237,7 +240,10 @@ impl abci::Application for ChainNodeApp {
             kvpair.key = Vec::from(&b"ethbloom"[..]);
             // TODO: "Keys and values in tags must be UTF-8 encoded strings" ?
             kvpair.value = Vec::from(&bloom.data()[..]);
-            resp.tags.push(kvpair);
+            let mut event = Event::new();
+            event.field_type = "end_block".to_string();
+            event.attributes.push(kvpair);
+            resp.events.push(event);
         }
         // TODO: skipchain-based validator changes?
         if !self.power_changed_in_block.is_empty() {

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -13,6 +13,7 @@ use crate::storage::account::AccountWrapper;
 use crate::storage::tx::StarlingFixedKey;
 use crate::storage::COL_TX_META;
 use bit_vec::BitVec;
+use chain_core::common::TendermintEventType;
 use chain_core::state::account::StakedState;
 use chain_core::state::tendermint::TendermintVotePower;
 use chain_core::tx::data::input::TxoPointer;
@@ -197,7 +198,7 @@ impl abci::Application for ChainNodeApp {
             // TODO: "Keys and values in tags must be UTF-8 encoded strings" ?
             kvpair.value = Vec::from(&txaux.tx_id()[..]);
             let mut event = Event::new();
-            event.field_type = "delivered_txs".to_string();
+            event.field_type = TendermintEventType::ValidTransactions.to_string();
             event.attributes.push(kvpair);
             resp.events.push(event);
             self.delivered_txs.push(txaux);
@@ -241,7 +242,7 @@ impl abci::Application for ChainNodeApp {
             // TODO: "Keys and values in tags must be UTF-8 encoded strings" ?
             kvpair.value = Vec::from(&bloom.data()[..]);
             let mut event = Event::new();
-            event.field_type = "end_block".to_string();
+            event.field_type = TendermintEventType::BlockFilter.to_string();
             event.attributes.push(kvpair);
             resp.events.push(event);
         }

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -430,7 +430,7 @@ fn deliver_tx_should_reject_empty_tx() {
     let cresp = app.deliver_tx(&creq);
     assert_ne!(0, cresp.code);
     assert_eq!(0, app.delivered_txs.len());
-    assert_eq!(0, cresp.tags.len());
+    assert_eq!(0, cresp.events.len());
 }
 
 #[test]
@@ -448,7 +448,7 @@ fn deliver_tx_should_reject_invalid_tx() {
     let cresp = app.deliver_tx(&creq);
     assert_ne!(0, cresp.code);
     assert_eq!(0, app.delivered_txs.len());
-    assert_eq!(0, cresp.tags.len());
+    assert_eq!(0, cresp.events.len());
 }
 
 fn deliver_valid_tx() -> (
@@ -477,8 +477,9 @@ fn deliver_tx_should_add_valid_tx() {
     let (app, tx, _, cresp) = deliver_valid_tx();
     assert_eq!(0, cresp.code);
     assert_eq!(1, app.delivered_txs.len());
-    assert_eq!(1, cresp.tags.len());
-    assert_eq!(&tx.id()[..], &cresp.tags[0].value[..]);
+    assert_eq!(1, cresp.events.len());
+    assert_eq!(1, cresp.events[0].attributes.len());
+    assert_eq!(&tx.id()[..], &cresp.events[0].attributes[0].value[..]);
 }
 
 #[test]
@@ -528,7 +529,7 @@ fn endblock_should_change_block_height() {
         10,
         i64::from(app.last_state.as_ref().unwrap().last_block_height)
     );
-    assert_eq!(0, cresp.tags.len());
+    assert_eq!(0, cresp.events.len());
 }
 
 #[test]
@@ -553,9 +554,10 @@ fn valid_commit_should_persist() {
     let mut endreq = RequestEndBlock::default();
     endreq.set_height(10);
     let cresp = app.end_block(&endreq);
-    assert_eq!(1, cresp.tags.len());
+    assert_eq!(1, cresp.events.len());
+    assert_eq!(1, cresp.events[0].attributes.len());
     assert_eq!(1, app.delivered_txs.len());
-    let bloom = Bloom::from(&cresp.tags[0].value[..]);
+    let bloom = Bloom::from(&cresp.events[0].attributes[0].value[..]);
     assert!(bloom.contains_input(Input::Raw(
         &tx.attributes.allowed_view[0].view_key.serialize()
     )));

--- a/chain-core/src/common/mod.rs
+++ b/chain-core/src/common/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use digest::Digest;
 
 /// Generic merkle tree
@@ -23,3 +25,19 @@ pub type Timespec = i64;
 pub type H256 = [u8; HASH_SIZE_256];
 pub type H264 = [u8; HASH_SIZE_256 + 1];
 pub type H512 = [u8; HASH_SIZE_256 * 2];
+
+/// Types of tendermint events created during `deliver_tx` / `end_block`
+#[derive(Debug, Clone, Copy)]
+pub enum TendermintEventType {
+    ValidTransactions,
+    BlockFilter,
+}
+
+impl fmt::Display for TendermintEventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TendermintEventType::ValidTransactions => write!(f, "valid_txs"),
+            TendermintEventType::BlockFilter => write!(f, "block_filter"),
+        }
+    }
+}


### PR DESCRIPTION
Solution: Changed abci version to 0.6 and made all necessary changes.

- tendermint 0.32 also involves changes in the response structure of `/block_results` RPC call which will be fixed as a part of separate PR.