### PR TITLE
Problem: (CRO-199) BlockResults RPC call in client is not compatible with Tendermint 0.32

### DIFF
--- a/client-common/src/tendermint/types/block_results.rs
+++ b/client-common/src/tendermint/types/block_results.rs
@@ -82,9 +82,12 @@ mod tests {
             height: "2".to_owned(),
             results: Results {
                 deliver_tx: Some(vec![DeliverTx {
-                    tags: vec![Tag {
-                        key: "dHhpZA==".to_owned(),
-                        value: "kOzcmhZgAAaw5roBdqDNniwRjjKNe+foJEiDAOObTDQ=".to_owned(),
+                    events: vec![Event {
+                        event_type: TendermintEventType::ValidTransactions.to_string(),
+                        attributes: vec![Attribute {
+                            key: "dHhpZA==".to_owned(),
+                            value: "kOzcmhZgAAaw5roBdqDNniwRjjKNe+foJEiDAOObTDQ=".to_owned(),
+                        }],
                     }],
                 }]),
             },
@@ -98,9 +101,12 @@ mod tests {
             height: "2".to_owned(),
             results: Results {
                 deliver_tx: Some(vec![DeliverTx {
-                    tags: vec![Tag {
-                        key: "dHhpZA==".to_owned(),
-                        value: "kOzcmhZgAAaw5riwRjjKNe+foJEiDAOObTDQ=".to_owned(),
+                    events: vec![Event {
+                        event_type: TendermintEventType::ValidTransactions.to_string(),
+                        attributes: vec![Attribute {
+                            key: "dHhpZA==".to_owned(),
+                            value: "kOzcmhZgAAaw5riwRjjKNe+foJEiDAOObTDQ=".to_owned(),
+                        }],
                     }],
                 }]),
             },

--- a/client-common/src/tendermint/types/block_results.rs
+++ b/client-common/src/tendermint/types/block_results.rs
@@ -5,8 +5,10 @@ use base64::decode;
 use failure::ResultExt;
 use serde::Deserialize;
 
-use crate::{ErrorKind, Result};
+use chain_core::common::TendermintEventType;
 use chain_core::tx::data::TxId;
+
+use crate::{ErrorKind, Result};
 
 #[derive(Debug, Deserialize)]
 pub struct BlockResults {
@@ -16,17 +18,23 @@ pub struct BlockResults {
 
 #[derive(Debug, Deserialize)]
 pub struct Results {
-    #[serde(rename = "DeliverTx")]
     pub deliver_tx: Option<Vec<DeliverTx>>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct DeliverTx {
-    pub tags: Vec<Tag>,
+    pub events: Vec<Event>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Tag {
+pub struct Event {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub attributes: Vec<Attribute>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Attribute {
     pub key: String,
     pub value: String,
 }
@@ -40,17 +48,21 @@ impl BlockResults {
                 let mut transactions: HashSet<TxId> = HashSet::with_capacity(deliver_tx.len());
 
                 for transaction in deliver_tx.iter() {
-                    for tag in transaction.tags.iter() {
-                        let decoded =
-                            decode(&tag.value).context(ErrorKind::DeserializationError)?;
-                        if 32 != decoded.len() {
-                            return Err(ErrorKind::DeserializationError.into());
+                    for event in transaction.events.iter() {
+                        if event.event_type == TendermintEventType::ValidTransactions.to_string() {
+                            for attribute in event.attributes.iter() {
+                                let decoded = decode(&attribute.value)
+                                    .context(ErrorKind::DeserializationError)?;
+                                if 32 != decoded.len() {
+                                    return Err(ErrorKind::DeserializationError.into());
+                                }
+
+                                let mut id: [u8; 32] = [0; 32];
+                                id.copy_from_slice(&decoded);
+
+                                transactions.insert(id);
+                            }
                         }
-
-                        let mut id: [u8; 32] = [0; 32];
-                        id.copy_from_slice(&decoded);
-
-                        transactions.insert(id);
                     }
                 }
 

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -312,6 +312,7 @@ mod tests {
     use parity_codec::Encode;
     use secp256k1::recovery::{RecoverableSignature, RecoveryId};
 
+    use chain_core::common::TendermintEventType;
     use chain_core::init::coin::Coin;
     use chain_core::state::account::StakedStateOpWitness;
     use chain_core::tx::data::address::ExtendedAddr;
@@ -432,9 +433,14 @@ mod tests {
                     height: "1".to_owned(),
                     results: Results {
                         deliver_tx: Some(vec![DeliverTx {
-                            tags: vec![Tag {
-                                key: "dHhpZA==".to_owned(),
-                                value: base64::encode(&self.transaction(1).unwrap().tx_id()[..]),
+                            events: vec![Event {
+                                event_type: TendermintEventType::ValidTransactions.to_string(),
+                                attributes: vec![Attribute {
+                                    key: "dHhpZA==".to_owned(),
+                                    value: base64::encode(
+                                        &self.transaction(1).unwrap().tx_id()[..],
+                                    ),
+                                }],
                             }],
                         }]),
                     },
@@ -444,9 +450,14 @@ mod tests {
                     height: "2".to_owned(),
                     results: Results {
                         deliver_tx: Some(vec![DeliverTx {
-                            tags: vec![Tag {
-                                key: "dHhpZA==".to_owned(),
-                                value: base64::encode(&self.transaction(2).unwrap().tx_id()[..]),
+                            events: vec![Event {
+                                event_type: TendermintEventType::ValidTransactions.to_string(),
+                                attributes: vec![Attribute {
+                                    key: "dHhpZA==".to_owned(),
+                                    value: base64::encode(
+                                        &self.transaction(2).unwrap().tx_id()[..],
+                                    ),
+                                }],
                             }],
                         }]),
                     },


### PR DESCRIPTION
Solution: Changed block_results RPC call to match new structure in Tendermint 0.32