### PR TITLE
Problem: no private TX support (CRO-181)

### DIFF
--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -6,24 +6,30 @@ use abci::*;
 use bit_vec::BitVec;
 use chain_core::common::MerkleTree;
 use chain_core::compute_app_hash;
-use chain_core::tx::data::Tx;
+use chain_core::tx::data::input::{TxoIndex, TxoPointer};
 use chain_core::tx::data::TxId;
-use chain_core::tx::TransactionId;
+use chain_core::tx::PlainTxAux;
 use chain_core::tx::TxAux;
 use chain_tx_validation::TxWithOutputs;
 use integer_encoding::VarInt;
 use kvdb::{DBTransaction, KeyValueDB};
-use parity_codec::Encode;
+use parity_codec::{Decode, Encode};
 use std::sync::Arc;
 
 /// Given a db and a DB transaction, it will go through TX inputs and mark them as spent
 /// in the TX_META storage and it will create a new entry for TX in TX_META with all outputs marked as unspent.
-pub fn update_utxos_commit(tx: &Tx, db: Arc<dyn KeyValueDB>, dbtx: &mut DBTransaction) {
-    spend_utxos(&tx.inputs, db, dbtx);
+pub fn update_utxos_commit(
+    inputs: &[TxoPointer],
+    no_of_outputs: TxoIndex,
+    txid: TxId,
+    db: Arc<dyn KeyValueDB>,
+    dbtx: &mut DBTransaction,
+) {
+    spend_utxos(inputs, db, dbtx);
     dbtx.put(
         COL_TX_META,
-        &tx.id(),
-        &BitVec::from_elem(tx.outputs.len(), false).to_bytes(),
+        &txid,
+        &BitVec::from_elem(no_of_outputs as usize, false).to_bytes(),
     );
 }
 
@@ -44,14 +50,29 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             for txaux in self.delivered_txs.iter() {
                 let txid: TxId = txaux.tx_id();
                 match &txaux {
-                    TxAux::TransferTx(tx, witness) => {
-                        inittx.put(
-                            COL_BODIES,
-                            &txid[..],
-                            &TxWithOutputs::Transfer(tx.clone()).encode(),
+                    TxAux::TransferTx {
+                        inputs,
+                        no_of_outputs,
+                        txpayload,
+                        ..
+                    } => {
+                        // FIXME: temporary hack / this shouldn't be here
+                        let plain_tx = PlainTxAux::decode(&mut txpayload.as_slice());
+                        if let Some(PlainTxAux::TransferTx(tx, witness)) = plain_tx {
+                            inittx.put(
+                                COL_BODIES,
+                                &txid[..],
+                                &TxWithOutputs::Transfer(tx.clone()).encode(),
+                            );
+                            inittx.put(COL_WITNESS, &txid[..], &witness.encode());
+                        }
+                        update_utxos_commit(
+                            &inputs,
+                            *no_of_outputs,
+                            txid,
+                            self.storage.db.clone(),
+                            &mut inittx,
                         );
-                        inittx.put(COL_WITNESS, &txid[..], &witness.encode());
-                        update_utxos_commit(&tx, self.storage.db.clone(), &mut inittx);
                     }
                     TxAux::DepositStakeTx(tx, witness) => {
                         inittx.put(COL_BODIES, &txid[..], &tx.encode());

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -18,8 +18,9 @@ use chain_core::common::TendermintEventType;
 use chain_core::state::account::StakedState;
 use chain_core::state::tendermint::TendermintVotePower;
 use chain_core::tx::data::input::TxoPointer;
-use chain_core::tx::TxAux;
+use chain_core::tx::{PlainTxAux, TxAux};
 use kvdb::{DBTransaction, KeyValueDB};
+use parity_codec::Decode;
 use protobuf::RepeatedField;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -134,10 +135,10 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
         if let (0, Some((txaux, fee_acc))) = (resp.code, mtxaux) {
             let mut inittx = self.storage.db.transaction();
             let (next_account_root, maccount) = match &txaux {
-                TxAux::TransferTx(tx, _) => {
+                TxAux::TransferTx { inputs, .. } => {
                     // here the original idea was "conservative" that it "spent" utxos here
                     // but it didn't create utxos for this TX (they are created in commit)
-                    spend_utxos(&tx.inputs, self.storage.db.clone(), &mut inittx);
+                    spend_utxos(&inputs, self.storage.db.clone(), &mut inittx);
                     (self.uncommitted_account_root_hash, None)
                 }
                 TxAux::DepositStakeTx(tx, _) => {
@@ -224,17 +225,26 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
         let mut resp = ResponseEndBlock::new();
         let mut add_bloom = false;
         let mut bloom = Bloom::default();
-        let empty = vec![];
         for txaux in self.delivered_txs.iter() {
-            let views = match txaux {
-                TxAux::TransferTx(tx, _) => &tx.attributes.allowed_view,
-                TxAux::WithdrawUnbondedStakeTx(tx, _) => &tx.attributes.allowed_view,
-                _ => &empty,
+            match txaux {
+                TxAux::TransferTx { txpayload, .. } => {
+                    // FIXME: temporary hack / this shouldn't be here
+                    let plain_tx = PlainTxAux::decode(&mut txpayload.as_slice());
+                    if let Some(PlainTxAux::TransferTx(tx, _)) = plain_tx {
+                        for view in tx.attributes.allowed_view.iter() {
+                            add_bloom = true;
+                            bloom.accrue(Input::Raw(&view.view_key.serialize()[..]));
+                        }
+                    }
+                }
+                TxAux::WithdrawUnbondedStakeTx(tx, _) => {
+                    for view in tx.attributes.allowed_view.iter() {
+                        add_bloom = true;
+                        bloom.accrue(Input::Raw(&view.view_key.serialize()[..]));
+                    }
+                }
+                _ => {}
             };
-            for view in views.iter() {
-                add_bloom = true;
-                bloom.accrue(Input::Raw(&view.view_key.serialize()[..]));
-            }
         }
         if add_bloom {
             // TODO: explore alternatives, e.g. https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki

--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 ///! TODO: feature-guard when workspaces can be built with --features flag: https://github.com/rust-lang/cargo/issues/5015
 use super::*;
+use chain_core::tx::PlainTxAux;
 use chain_core::tx::TxAux;
 use chain_tx_validation::{verify_transfer, ChainInfo};
 
@@ -25,23 +26,30 @@ impl EnclaveProxy for MockClient {
                 }
             }
             EnclaveRequest::VerifyTx {
-                tx: TxAux::TransferTx(maintx, witness),
+                tx: TxAux::TransferTx { txpayload, .. },
                 inputs,
                 min_fee_computed,
                 previous_block_time,
                 unbonding_period,
             } => {
-                let info = ChainInfo {
-                    min_fee_computed,
-                    chain_hex_id: self.chain_hex_id,
-                    previous_block_time,
-                    unbonding_period,
-                };
-                let result = verify_transfer(&maintx, &witness, info, inputs);
-                if let Ok(fee) = result {
-                    EnclaveResponse::VerifyTx(Ok(fee))
-                } else {
-                    EnclaveResponse::VerifyTx(Err(()))
+                // FIXME
+                let plain_tx = PlainTxAux::decode(&mut txpayload.as_slice());
+                match plain_tx {
+                    Some(PlainTxAux::TransferTx(maintx, witness)) => {
+                        let info = ChainInfo {
+                            min_fee_computed,
+                            chain_hex_id: self.chain_hex_id,
+                            previous_block_time,
+                            unbonding_period,
+                        };
+                        let result = verify_transfer(&maintx, &witness, info, inputs);
+                        if let Ok(fee) = result {
+                            EnclaveResponse::VerifyTx(Ok(fee))
+                        } else {
+                            EnclaveResponse::VerifyTx(Err(()))
+                        }
+                    }
+                    _ => EnclaveResponse::UnsupportedTxType,
                 }
             }
             _ => EnclaveResponse::UnsupportedTxType,

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -90,10 +90,10 @@ pub fn verify<T: EnclaveProxy>(
     accounts: &AccountStorage,
 ) -> Result<(Fee, Option<StakedState>), Error> {
     let paid_fee = match txaux {
-        TxAux::TransferTx(maintx, _) => {
+        TxAux::TransferTx { inputs, .. } => {
             // TODO: the input lookup would probably later be done on the enclave side (as it'll store the sealed TX data)
             // so one will only check and send TX IDs
-            let input_transactions = check_spent_input_lookup(&maintx.inputs, db)?;
+            let input_transactions = check_spent_input_lookup(&inputs, db)?;
             let response = tx_validator.process_request(EnclaveRequest::VerifyTx {
                 tx: txaux.clone(),
                 inputs: input_transactions,

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -156,13 +156,17 @@ pub mod tests {
         DepositBondTx, StakedStateOpWitness, UnbondTx, WithdrawUnbondedTx,
     };
     use chain_core::tx::data::{
-        address::ExtendedAddr, attribute::TxAttributes, input::TxoPointer, output::TxOut,
+        address::ExtendedAddr,
+        attribute::TxAttributes,
+        input::{TxoIndex, TxoPointer},
+        output::TxOut,
     };
     use chain_core::tx::data::{Tx, TxId};
     use chain_core::tx::fee::FeeAlgorithm;
     use chain_core::tx::fee::{LinearFee, Milli};
     use chain_core::tx::witness::tree::RawPubkey;
     use chain_core::tx::witness::{TxInWitness, TxWitness};
+    use chain_core::tx::PlainTxAux;
     use chain_tx_validation::{verify_transfer, TxWithOutputs};
     use kvdb_memorydb::create;
     use parity_codec::Encode;
@@ -266,7 +270,8 @@ pub mod tests {
         timelocked: bool,
     ) -> (
         Arc<dyn KeyValueDB>,
-        TxAux,
+        // TxAux,
+        PlainTxAux,
         Tx,
         TxWitness,
         MerkleTree<RawPubkey>,
@@ -284,7 +289,7 @@ pub mod tests {
 
         let witness: Vec<TxInWitness> =
             vec![get_tx_witness(secp, &tx.id(), &secret_key, &merkle_tree)];
-        let txaux = TxAux::new(tx.clone(), witness.clone().into());
+        let txaux = PlainTxAux::new(tx.clone(), witness.clone().into());
         (
             db,
             txaux,
@@ -699,7 +704,14 @@ pub mod tests {
 
     #[test]
     fn existing_utxo_input_tx_should_verify() {
-        let (db, txaux, _, _, _, _, accounts) = prepare_app_valid_transfer_tx(false);
+        let (db, plain_txaux, tx, _, _, _, accounts) = prepare_app_valid_transfer_tx(false);
+        let txaux = TxAux::TransferTx {
+            txid: tx.id(),
+            inputs: tx.inputs,
+            no_of_outputs: tx.outputs.len() as TxoIndex,
+            nonce: [0; 12],
+            txpayload: plain_txaux.encode(),
+        };
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
@@ -915,10 +927,33 @@ pub mod tests {
         }
     }
 
+    fn replace_tx_payload(txaux: TxAux, plain_tx: PlainTxAux) -> TxAux {
+        if let (TxAux::TransferTx { nonce, .. }, PlainTxAux::TransferTx(tx, _)) =
+            (txaux, plain_tx.clone())
+        {
+            TxAux::TransferTx {
+                txid: tx.id(),
+                inputs: tx.inputs.clone(),
+                no_of_outputs: tx.outputs.len() as TxoIndex,
+                nonce,
+                txpayload: plain_tx.encode(),
+            }
+        } else {
+            unreachable!()
+        }
+    }
+
     #[test]
     fn test_transfer_verify_fail() {
-        let (db, txaux, tx, witness, merkle_tree, secret_key, accounts) =
+        let (db, plain_txaux, tx, witness, merkle_tree, secret_key, accounts) =
             prepare_app_valid_transfer_tx(false);
+        let txaux = TxAux::TransferTx {
+            txid: tx.id(),
+            inputs: tx.inputs.clone(),
+            no_of_outputs: tx.outputs.len() as TxoIndex,
+            nonce: [0; 12],
+            txpayload: plain_txaux.encode(),
+        };
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
@@ -949,7 +984,8 @@ pub mod tests {
         {
             let mut tx = tx.clone();
             tx.inputs.clear();
-            let txaux = TxAux::TransferTx(tx, witness.clone());
+            let txaux =
+                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -966,7 +1002,8 @@ pub mod tests {
             tx.outputs.clear();
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::NoOutputs);
-            let txaux = TxAux::TransferTx(tx, witness.clone());
+            let txaux =
+                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -984,7 +1021,8 @@ pub mod tests {
             tx.inputs.push(inp);
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::DuplicateInputs);
-            let txaux = TxAux::TransferTx(tx, witness.clone());
+            let txaux =
+                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1001,7 +1039,8 @@ pub mod tests {
             tx.outputs[0].value = Coin::zero();
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::ZeroCoin);
-            let txaux = TxAux::TransferTx(tx, witness.clone());
+            let txaux =
+                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1019,7 +1058,8 @@ pub mod tests {
             witness.push(wp);
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::UnexpectedWitnesses);
-            let txaux = TxAux::TransferTx(tx.clone(), witness);
+            let txaux =
+                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx.clone(), witness));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1032,7 +1072,10 @@ pub mod tests {
         }
         // MissingWitnesses
         {
-            let txaux = TxAux::TransferTx(tx.clone(), vec![].into());
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx.clone(), vec![].into()),
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1058,7 +1101,7 @@ pub mod tests {
                 &result,
                 Error::InvalidSum(CoinError::OutOfBound(Coin::max().into())),
             );
-            let txaux = TxAux::TransferTx(tx, witness);
+            let txaux = replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1126,7 +1169,8 @@ pub mod tests {
                 &result,
                 Error::EcdsaCrypto(secp256k1::Error::InvalidPublicKey),
             );
-            let txaux = TxAux::TransferTx(tx.clone(), witness);
+            let txaux =
+                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx.clone(), witness));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1158,7 +1202,7 @@ pub mod tests {
             witness[0] = get_tx_witness(Secp256k1::new(), &tx.id(), &secret_key, &merkle_tree);
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::InputOutputDoNotMatch);
-            let txaux = TxAux::TransferTx(tx, witness);
+            let txaux = replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness));
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1171,7 +1215,15 @@ pub mod tests {
         }
         // OutputInTimelock
         {
-            let (db, txaux, tx, witness, _, _, accounts) = prepare_app_valid_transfer_tx(true);
+            let (db, plain_txaux, tx, witness, _, _, accounts) =
+                prepare_app_valid_transfer_tx(true);
+            let txaux = TxAux::TransferTx {
+                txid: tx.id(),
+                inputs: tx.inputs.clone(),
+                no_of_outputs: tx.outputs.len() as TxoIndex,
+                nonce: [0; 12],
+                txpayload: plain_txaux.encode(),
+            };
             let addr = get_address(&Secp256k1::new(), &secret_key).0;
             let input_tx = get_old_tx(addr, true);
             let result = verify_transfer(

--- a/chain-core/src/tx/data/input.rs
+++ b/chain-core/src/tx/data/input.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::tx::data::TxId;
 
+// TODO: u16 and Vec size check in Decode implementation
+pub type TxoIndex = u64;
+
 /// Structure used for addressing a specific output of a transaction
 /// built from a TxId (hash of the tx) and the offset in the outputs of this
 /// transaction.
@@ -14,7 +17,7 @@ use crate::tx::data::TxId;
 pub struct TxoPointer {
     pub id: TxId,
     // TODO: u16 and Vec size check in Decode implementation
-    pub index: u64,
+    pub index: TxoIndex,
 }
 
 impl fmt::Display for TxoPointer {
@@ -28,7 +31,7 @@ impl TxoPointer {
     pub fn new(id: TxId, index: usize) -> Self {
         TxoPointer {
             id,
-            index: index as u64,
+            index: index as TxoIndex,
         }
     }
 }

--- a/chain-core/src/tx/fee/mod.rs
+++ b/chain-core/src/tx/fee/mod.rs
@@ -175,7 +175,10 @@ impl FeeAlgorithm for LinearFee {
     }
 
     fn calculate_for_txaux(&self, txaux: &TxAux) -> Result<Fee, CoinError> {
-        self.estimate(txaux.encode().len())
+        match txaux {
+            TxAux::TransferTx { txpayload, .. } => self.estimate(txpayload.len()),
+            _ => self.estimate(txaux.encode().len()),
+        }
     }
 }
 

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -13,12 +13,41 @@ use self::data::Tx;
 use self::witness::TxWitness;
 use crate::state::account::{DepositBondTx, StakedStateOpWitness, UnbondTx, WithdrawUnbondedTx};
 use crate::tx::data::{txid_hash, TxId};
+use data::input::{TxoIndex, TxoPointer};
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+/// FIXME: other TX to be moved here (when support added in enclave etc.)
+pub enum PlainTxAux {
+    /// normal value transfer Tx with the vector of witnesses
+    TransferTx(Tx, TxWitness),
+}
+
+impl PlainTxAux {
+    /// creates a new Tx with a vector of witnesses (mainly for testing/tools)
+    pub fn new(tx: Tx, witness: TxWitness) -> Self {
+        PlainTxAux::TransferTx(tx, witness)
+    }
+}
+
+impl fmt::Display for PlainTxAux {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PlainTxAux::TransferTx(tx, witness) => display_tx_witness(f, tx, witness),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 pub enum TxAux {
     /// normal value transfer Tx with the vector of witnesses
-    TransferTx(Tx, TxWitness),
+    TransferTx {
+        txid: TxId,
+        inputs: Vec<TxoPointer>,
+        no_of_outputs: TxoIndex,
+        nonce: [u8; 12],
+        txpayload: Vec<u8>,
+    },
     /// Tx "spends" utxos to be deposited as bonded stake in an account (witnesses as in transfer)
     DepositStakeTx(DepositBondTx, TxWitness),
     /// Tx that modifies account state -- moves some bonded stake into unbonded (witness for account)
@@ -35,15 +64,10 @@ pub trait TransactionId: Encode {
 }
 
 impl TxAux {
-    /// creates a new Tx with a vector of witnesses (mainly for testing/tools)
-    pub fn new(tx: Tx, witness: TxWitness) -> Self {
-        TxAux::TransferTx(tx, witness)
-    }
-
     /// retrieves a TX ID (currently blake2s(scale_codec_bytes(tx)))
     pub fn tx_id(&self) -> TxId {
         match self {
-            TxAux::TransferTx(tx, _) => tx.id(),
+            TxAux::TransferTx { txid, .. } => *txid,
             TxAux::DepositStakeTx(tx, _) => tx.id(),
             TxAux::UnbondStakeTx(tx, _) => tx.id(),
             TxAux::WithdrawUnbondedStakeTx(tx, _) => tx.id(),
@@ -63,7 +87,10 @@ fn display_tx_witness<T: fmt::Display, W: fmt::Debug>(
 impl fmt::Display for TxAux {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TxAux::TransferTx(tx, witness) => display_tx_witness(f, tx, witness),
+            TxAux::TransferTx { txid, inputs, .. } => {
+                writeln!(f, "Transfer Tx id:\n{}", hex::encode(&txid[..]))?;
+                writeln!(f, "tx inputs: {:?}\n", inputs)
+            }
             TxAux::DepositStakeTx(tx, witness) => display_tx_witness(f, tx, witness),
             TxAux::UnbondStakeTx(tx, witness) => display_tx_witness(f, tx, witness),
             TxAux::WithdrawUnbondedStakeTx(tx, witness) => display_tx_witness(f, tx, witness),
@@ -114,11 +141,10 @@ pub mod tests {
             schnorr_sign(&secp, &msg, &sk1).0,
             merkle.generate_proof(raw_public_keys[0].clone()).unwrap(),
         );
-        assert_eq!(tx.id(), tx.id());
-        let txa = TxAux::TransferTx(tx, vec![w1].into());
+        let txa = PlainTxAux::TransferTx(tx, vec![w1].into());
         let mut encoded: Vec<u8> = txa.encode();
         let mut data: &[u8] = encoded.as_mut();
-        let decoded = TxAux::decode(&mut data).expect("decode tx aux");
+        let decoded = PlainTxAux::decode(&mut data).expect("decode tx aux");
         assert_eq!(txa, decoded);
     }
 }

--- a/client-common/src/tendermint/types/block.rs
+++ b/client-common/src/tendermint/types/block.rs
@@ -77,7 +77,15 @@ mod tests {
 
     #[test]
     fn check_transactions() {
-        let transaction = encode(&TxAux::TransferTx(Tx::new(), vec![].into()).encode());
+        let transaction = encode(
+            &TxAux::TransferTx {
+                txid: [0u8; 32],
+                inputs: vec![],
+                nonce: [0u8; 12],
+                txpayload: vec![],
+            }
+            .encode(),
+        );
 
         let block = Block {
             block: BlockInner {

--- a/client-common/src/tendermint/types/block.rs
+++ b/client-common/src/tendermint/types/block.rs
@@ -73,14 +73,13 @@ mod tests {
     use base64::encode;
     use parity_codec::Encode;
 
-    use chain_core::tx::data::Tx;
-
     #[test]
     fn check_transactions() {
         let transaction = encode(
             &TxAux::TransferTx {
                 txid: [0u8; 32],
                 inputs: vec![],
+                no_of_outputs: 0,
                 nonce: [0u8; 12],
                 txpayload: vec![],
             }

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -4,11 +4,14 @@ use secstr::SecUtf8;
 use chain_core::init::coin::{sum_coins, Coin};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::input::TxoIndex;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::Tx;
 use chain_core::tx::fee::FeeAlgorithm;
+use chain_core::tx::PlainTxAux;
 use chain_core::tx::{TransactionId, TxAux};
 use client_common::{ErrorKind, Result};
+use parity_codec::Encode;
 
 use crate::{SelectedUnspentTransactions, Signer, TransactionBuilder, UnspentTransactions};
 
@@ -86,8 +89,15 @@ where
                 selected_unspent_transactions,
             )?;
 
-            let tx_aux = TxAux::TransferTx(transaction, witness);
-
+            let plain_tx_aux = PlainTxAux::TransferTx(transaction.clone(), witness);
+            // FIXME: dummy enc for length (multiple of 16 bytes)
+            let tx_aux = TxAux::TransferTx {
+                txid: transaction.id(),
+                inputs: transaction.inputs.clone(),
+                no_of_outputs: transaction.outputs.len() as TxoIndex,
+                nonce: [0u8; 12],
+                txpayload: plain_tx_aux.encode(),
+            };
             let new_fees = self
                 .fee_algorithm
                 .calculate_for_txaux(&tx_aux)

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -6,7 +6,7 @@ use chain_core::state::account::{DepositBondTx, WithdrawUnbondedTx};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
-use chain_core::tx::data::{Tx, TxId};
+use chain_core::tx::data::TxId;
 use chain_core::tx::TransactionId;
 use chain_core::tx::TxAux;
 use client_common::balance::{BalanceChange, TransactionChange};
@@ -69,12 +69,8 @@ where
         time: DateTime<Utc>,
     ) -> Result<()> {
         match transaction {
-            TxAux::TransferTx(transfer_transaction, _) => {
-                self.handle_transfer_transaction(&transfer_transaction, height, time)?;
-                self.transaction_service.set(
-                    &transfer_transaction.id(),
-                    &Transaction::TransferTransaction(transfer_transaction),
-                )
+            TxAux::TransferTx {txid: _, inputs: _, no_of_outputs: _, nonce: _, txpayload: _} => {
+                unimplemented!("FIXME: indexing should be rethought, as it'll first check the filter and query (block data would be obfuscated)")
             }
             TxAux::DepositStakeTx(deposit_bond_transaction, _) => {
                 self.handle_deposit_stake_transaction(&deposit_bond_transaction, height, time)?;
@@ -99,25 +95,6 @@ where
                 )
             }
         }
-    }
-
-    fn handle_transfer_transaction(
-        &self,
-        transaction: &Tx,
-        height: u64,
-        time: DateTime<Utc>,
-    ) -> Result<()> {
-        let transaction_id = transaction.id();
-
-        for input in transaction.inputs.iter() {
-            self.handle_transaction_input(transaction_id, input, height, time)?;
-        }
-
-        for (i, output) in transaction.outputs.iter().enumerate() {
-            self.handle_transaction_output(transaction_id, output, i, height, time)?;
-        }
-
-        Ok(())
     }
 
     fn handle_deposit_stake_transaction(

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 chain-tx-validation = { path = "../chain-tx-validation" }
-parity-codec = { version = "4.1.1" }
+parity-codec = { version = "4.1.1", features = ["derive"] }

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -2,8 +2,11 @@
 
 use chain_core::common::Timespec;
 use chain_core::init::coin::Coin;
-use chain_core::tx::{fee::Fee, TxAux};
+use chain_core::tx::data::Tx;
+use chain_core::tx::data::TxId;
+use chain_core::tx::{fee::Fee, PlainTxAux, TxAux};
 use chain_tx_validation::TxWithOutputs;
+
 use parity_codec::{Decode, Encode, Input, Output};
 
 /// requests sent from chain-abci app to enclave wrapper server
@@ -150,3 +153,36 @@ impl Decode for EnclaveResponse {
 
 /// ZMQ flags to be used in the socket connection
 pub const FLAGS: i32 = 0;
+
+/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
+#[derive(Encode, Decode)]
+pub struct EncryptionRequest {
+    pub tx: PlainTxAux,
+}
+
+/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
+#[derive(Encode, Decode)]
+pub struct EncryptionResponse {
+    pub tx: TxAux,
+}
+
+/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
+/// TODO: limit txs size + no of view keys in each TX?
+#[derive(Encode, Decode)]
+pub struct DecryptionRequestBody {
+    pub txs: Vec<TxId>,
+}
+
+/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
+#[derive(Encode, Decode)]
+pub struct DecryptionRequest {
+    pub body: DecryptionRequestBody,
+    /// ecdsa on the body in compact form?
+    pub view_key_sig: [u8; 64],
+}
+
+/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
+#[derive(Encode, Decode)]
+pub struct DecryptionResponse {
+    pub txs: Vec<Tx>,
+}


### PR DESCRIPTION
Solution: added "plain" TX data type and moved transfer TX there
* changed downstream with stubs and temporary mocks
* added mock querying data types

--
some more context:
* this breaks the client functionality, as the client won't be able to decode Tx data straight out of Tendermint blocks (it's still possible to decode in the current implementation, as the txpayload isn't obfuscated, but soon-ish, it won't be) => I guess I'll tag master before merging this PR
* as the enclave part will require a lot of additional work to facilitate encrypting/decrypting, I've added temporary TM query paths that would help with developing the client workflow (client adds view keys in TX, syncs up block header filters, uses filters to collect TXIDs...) before it's usable