### PR TITLE
Problem: latest chain-core doesn't compile in tx-enclave

### DIFF
--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::Vec;
+
 /// Transaction internal structure
 pub mod data;
 /// Transaction fee calculation


### PR DESCRIPTION
Solution: added an explicit Vec import in tx module