### PR TITLE
 Problem: deposit bonded and withdraw unbounded aren't done in enclaves (CRO-208)

### DIFF
--- a/chain-abci/src/app/query.rs
+++ b/chain-abci/src/app/query.rs
@@ -8,6 +8,7 @@ use chain_core::state::account::StakedStateAddress;
 use chain_core::tx::data::input::TxoIndex;
 use chain_core::tx::data::{txid_hash, TXID_HASH_ID};
 use chain_core::tx::TransactionId;
+use chain_core::tx::TxObfuscated;
 use chain_core::tx::{PlainTxAux, TxAux};
 use chain_tx_validation::TxWithOutputs;
 use enclave_protocol::{
@@ -61,23 +62,57 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             // FIXME: temporary mock
             "mockencrypt" => {
                 let request = EncryptionRequest::decode(&mut _req.data.as_slice());
-                if let Some(EncryptionRequest {
-                    tx: PlainTxAux::TransferTx(tx, witness),
-                }) = request
-                {
-                    let mock = EncryptionResponse {
-                        tx: TxAux::TransferTx {
-                            txid: tx.id(),
-                            inputs: tx.inputs.clone(),
-                            no_of_outputs: tx.outputs.len() as TxoIndex,
-                            nonce: [0u8; 12],
-                            txpayload: PlainTxAux::TransferTx(tx, witness).encode(),
-                        },
-                    };
-                    resp.value = mock.encode();
-                } else {
-                    resp.log += "invalid request";
-                    resp.code = 1;
+                match request {
+                    Some(EncryptionRequest::TransferTx(tx, witness)) => {
+                        let plain = PlainTxAux::TransferTx(tx.clone(), witness);
+                        let mock = EncryptionResponse {
+                            tx: TxAux::TransferTx {
+                                txid: tx.id(),
+                                inputs: tx.inputs.clone(),
+                                no_of_outputs: tx.outputs.len() as TxoIndex,
+                                payload: TxObfuscated {
+                                    key_from: 0,
+                                    nonce: [0u8; 12],
+                                    txpayload: plain.encode(),
+                                },
+                            },
+                        };
+                        resp.value = mock.encode();
+                    }
+                    Some(EncryptionRequest::DepositStake(maintx, witness)) => {
+                        let plain = PlainTxAux::DepositStakeTx(witness);
+                        let mock = EncryptionResponse {
+                            tx: TxAux::DepositStakeTx {
+                                tx: maintx,
+                                payload: TxObfuscated {
+                                    key_from: 0,
+                                    nonce: [0u8; 12],
+                                    txpayload: plain.encode(),
+                                },
+                            },
+                        };
+                        resp.value = mock.encode();
+                    }
+                    Some(EncryptionRequest::WithdrawStake(tx, _, witness)) => {
+                        let plain = PlainTxAux::WithdrawUnbondedStakeTx(tx.clone());
+                        let mock = EncryptionResponse {
+                            tx: TxAux::WithdrawUnbondedStakeTx {
+                                txid: tx.id(),
+                                no_of_outputs: tx.outputs.len() as TxoIndex,
+                                witness,
+                                payload: TxObfuscated {
+                                    key_from: 0,
+                                    nonce: [0u8; 12],
+                                    txpayload: plain.encode(),
+                                },
+                            },
+                        };
+                        resp.value = mock.encode();
+                    }
+                    _ => {
+                        resp.log += "invalid request";
+                        resp.code = 1;
+                    }
                 }
             }
             // FIXME: temporary mock

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -162,6 +162,7 @@ pub fn verify<T: EnclaveProxy>(
     Ok(paid_fee)
 }
 
+/// FIXME: probably move the tests to chain-tx-validation and keep here only the small parts related to abci (looking up accounts, checking double spends...)
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -186,7 +187,10 @@ pub mod tests {
     use chain_core::tx::witness::tree::RawPubkey;
     use chain_core::tx::witness::{TxInWitness, TxWitness};
     use chain_core::tx::PlainTxAux;
-    use chain_tx_validation::{verify_transfer, TxWithOutputs};
+    use chain_core::tx::TxObfuscated;
+    use chain_tx_validation::{
+        verify_bonded_deposit, verify_transfer, verify_unbonded_withdraw, TxWithOutputs,
+    };
     use kvdb_memorydb::create;
     use parity_codec::Encode;
     use secp256k1::schnorrsig::schnorr_sign;
@@ -289,8 +293,7 @@ pub mod tests {
         timelocked: bool,
     ) -> (
         Arc<dyn KeyValueDB>,
-        // TxAux,
-        PlainTxAux,
+        TxAux,
         Tx,
         TxWitness,
         MerkleTree<RawPubkey>,
@@ -308,7 +311,18 @@ pub mod tests {
 
         let witness: Vec<TxInWitness> =
             vec![get_tx_witness(secp, &tx.id(), &secret_key, &merkle_tree)];
-        let txaux = PlainTxAux::new(tx.clone(), witness.clone().into());
+        let plain_txaux = PlainTxAux::new(tx.clone(), witness.clone().into());
+        // TODO: mock enc
+        let txaux = TxAux::TransferTx {
+            txid: tx.id(),
+            inputs: tx.inputs.clone(),
+            no_of_outputs: tx.outputs.len() as TxoIndex,
+            payload: TxObfuscated {
+                key_from: 0,
+                nonce: [0; 12],
+                txpayload: plain_txaux.encode(),
+            },
+        };
         (
             db,
             txaux,
@@ -468,6 +482,7 @@ pub mod tests {
         TxAux,
         WithdrawUnbondedTx,
         StakedStateOpWitness,
+        StakedState,
         SecretKey,
         AccountStorage,
         StarlingFixedKey,
@@ -480,7 +495,7 @@ pub mod tests {
         let addr = RedeemAddress::from(&public_key);
         let account = StakedState::new(1, Coin::zero(), Coin::one(), unbonded_from, addr.into());
         let key = account.key();
-        let wrapped = AccountWrapper(account);
+        let wrapped = AccountWrapper(account.clone());
         let new_root = tree
             .insert(None, &mut [&key], &mut vec![&wrapped])
             .expect("insert");
@@ -497,13 +512,32 @@ pub mod tests {
 
         let tx = WithdrawUnbondedTx::new(1, outputs, TxAttributes::new(DEFAULT_CHAIN_ID));
         let witness = get_account_op_witness(secp, &tx.id(), &secret_key);
-        let txaux = TxAux::WithdrawUnbondedStakeTx(tx.clone(), witness.clone());
-        (txaux, tx.clone(), witness, secret_key, tree, new_root)
+        // TODO: mock enc
+        let txaux = TxAux::WithdrawUnbondedStakeTx {
+            txid: tx.id(),
+            no_of_outputs: tx.outputs.len() as TxoIndex,
+            witness: witness.clone(),
+            payload: TxObfuscated {
+                key_from: 0,
+                nonce: [0; 12],
+                txpayload: PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()).encode(),
+            },
+        };
+        (
+            txaux,
+            tx.clone(),
+            witness,
+            account,
+            secret_key,
+            tree,
+            new_root,
+        )
     }
 
     #[test]
     fn existing_account_withdraw_tx_should_verify() {
-        let (txaux, _, _, _, accounts, last_account_root_hash) = prepare_app_valid_withdraw_tx(0);
+        let (txaux, _, _, _, _, accounts, last_account_root_hash) =
+            prepare_app_valid_withdraw_tx(0);
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
@@ -526,7 +560,7 @@ pub mod tests {
     #[test]
     fn test_account_withdraw_verify_fail() {
         let db = create_db();
-        let (txaux, tx, _, secret_key, accounts, last_account_root_hash) =
+        let (txaux, tx, _, account, secret_key, accounts, last_account_root_hash) =
             prepare_app_valid_withdraw_tx(0);
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
@@ -549,6 +583,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(&result, Error::WrongChainHexId);
         }
         // NoOutputs
@@ -556,7 +592,12 @@ pub mod tests {
             let mut tx = tx.clone();
             tx.outputs.clear();
             let witness = get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key);
-            let txaux = TxAux::WithdrawUnbondedStakeTx(tx, witness);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()),
+                Some(witness),
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -565,6 +606,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(&result, Error::NoOutputs);
         }
         // ZeroCoin
@@ -572,7 +615,12 @@ pub mod tests {
             let mut tx = tx.clone();
             tx.outputs[0].value = Coin::zero();
             let witness = get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key);
-            let txaux = TxAux::WithdrawUnbondedStakeTx(tx, witness);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()),
+                Some(witness),
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -581,6 +629,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(&result, Error::ZeroCoin);
         }
         // InvalidSum
@@ -589,9 +639,12 @@ pub mod tests {
             tx.outputs[0].value = Coin::max();
             let outp = tx.outputs[0].clone();
             tx.outputs.push(outp);
-            let txaux = TxAux::WithdrawUnbondedStakeTx(
-                tx.clone(),
-                get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key),
+            let witness = get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()),
+                Some(witness),
+                None,
             );
             let result = verify(
                 &mock_bridge,
@@ -601,6 +654,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(
                 &result,
                 Error::InvalidSum(CoinError::OutOfBound(Coin::max().into())),
@@ -610,9 +665,12 @@ pub mod tests {
         {
             let mut tx = tx.clone();
             tx.outputs[0].value = (tx.outputs[0].value + Coin::one()).unwrap();
-            let txaux = TxAux::WithdrawUnbondedStakeTx(
-                tx.clone(),
-                get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key),
+            let witness = get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()),
+                Some(witness),
+                None,
             );
             let result = verify(
                 &mock_bridge,
@@ -622,6 +680,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(&result, Error::InputOutputDoNotMatch);
         }
         // AccountNotFound
@@ -640,9 +700,12 @@ pub mod tests {
         {
             let mut tx = tx.clone();
             tx.nonce = 0;
-            let txaux = TxAux::WithdrawUnbondedStakeTx(
-                tx.clone(),
-                get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key),
+            let witness = get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()),
+                Some(witness),
+                None,
             );
             let result = verify(
                 &mock_bridge,
@@ -652,15 +715,20 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(&result, Error::AccountIncorrectNonce);
         }
         // AccountWithdrawOutputNotLocked
         {
             let mut tx = tx.clone();
             tx.outputs[0].valid_from = None;
-            let txaux = TxAux::WithdrawUnbondedStakeTx(
-                tx.clone(),
-                get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key),
+            let witness = get_account_op_witness(Secp256k1::new(), &tx.id(), &secret_key);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()),
+                Some(witness),
+                None,
             );
             let result = verify(
                 &mock_bridge,
@@ -670,11 +738,13 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account.clone());
             expect_error(&result, Error::AccountWithdrawOutputNotLocked);
         }
         // AccountNotUnbonded
         {
-            let (txaux, _, _, _, accounts, last_account_root_hash) =
+            let (txaux, _, _, account, _, accounts, last_account_root_hash) =
                 prepare_app_valid_withdraw_tx(20);
             let result = verify(
                 &mock_bridge,
@@ -684,6 +754,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_unbonded_withdraw(&tx, extra_info, account);
             expect_error(&result, Error::AccountNotUnbonded);
         }
     }
@@ -695,6 +767,7 @@ pub mod tests {
         TxAux,
         DepositBondTx,
         TxWitness,
+        SecretKey,
         AccountStorage,
     ) {
         let (db, txp, _, merkle_tree, secret_key) = prepate_init_tx(timelocked);
@@ -709,12 +782,21 @@ pub mod tests {
 
         let witness: Vec<TxInWitness> =
             vec![get_tx_witness(secp, &tx.id(), &secret_key, &merkle_tree)];
-        let txaux = TxAux::DepositStakeTx(tx.clone(), witness.clone().into());
+        // TODO: mock enc
+        let txaux = TxAux::DepositStakeTx {
+            tx: tx.clone(),
+            payload: TxObfuscated {
+                key_from: 0,
+                nonce: [0u8; 12],
+                txpayload: PlainTxAux::DepositStakeTx(witness.clone().into()).encode(),
+            },
+        };
         (
             db,
             txaux,
             tx.clone(),
             witness.into(),
+            secret_key,
             AccountStorage::new(Storage::new_db(create_db()), 20).expect("account db"),
         )
     }
@@ -723,14 +805,7 @@ pub mod tests {
 
     #[test]
     fn existing_utxo_input_tx_should_verify() {
-        let (db, plain_txaux, tx, _, _, _, accounts) = prepare_app_valid_transfer_tx(false);
-        let txaux = TxAux::TransferTx {
-            txid: tx.id(),
-            inputs: tx.inputs,
-            no_of_outputs: tx.outputs.len() as TxoIndex,
-            nonce: [0; 12],
-            txpayload: plain_txaux.encode(),
-        };
+        let (db, txaux, _, _, _, _, accounts) = prepare_app_valid_transfer_tx(false);
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
@@ -750,7 +825,7 @@ pub mod tests {
             &accounts,
         );
         assert!(result.is_ok());
-        let (db, txaux, _, _, accounts) = prepare_app_valid_deposit_tx(false);
+        let (db, txaux, _, _, _, accounts) = prepare_app_valid_deposit_tx(false);
         let result = verify(
             &mock_bridge,
             &txaux,
@@ -775,7 +850,7 @@ pub mod tests {
 
     #[test]
     fn test_deposit_verify_fail() {
-        let (db, txaux, tx, witness, accounts) = prepare_app_valid_deposit_tx(false);
+        let (db, txaux, tx, witness, secret_key, accounts) = prepare_app_valid_deposit_tx(false);
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
@@ -798,13 +873,20 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_bonded_deposit(&tx, &witness, extra_info, vec![], None);
             expect_error(&result, Error::WrongChainHexId);
         }
         // NoInputs
         {
             let mut tx = tx.clone();
             tx.inputs.clear();
-            let txaux = TxAux::DepositStakeTx(tx, witness.clone());
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::DepositStakeTx(witness.clone()),
+                None,
+                Some(tx.clone()),
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -813,6 +895,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_bonded_deposit(&tx, &witness, extra_info, vec![], None);
             expect_error(&result, Error::NoInputs);
         }
         // DuplicateInputs
@@ -820,7 +904,12 @@ pub mod tests {
             let mut tx = tx.clone();
             let inp = tx.inputs[0].clone();
             tx.inputs.push(inp);
-            let txaux = TxAux::DepositStakeTx(tx, witness.clone());
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::DepositStakeTx(witness.clone()),
+                None,
+                Some(tx.clone()),
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -829,6 +918,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_bonded_deposit(&tx, &witness, extra_info, vec![], None);
             expect_error(&result, Error::DuplicateInputs);
         }
         // UnexpectedWitnesses
@@ -836,7 +927,12 @@ pub mod tests {
             let mut witness = witness.clone();
             let wp = witness[0].clone();
             witness.push(wp);
-            let txaux = TxAux::DepositStakeTx(tx.clone(), witness);
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::DepositStakeTx(witness.clone()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -845,11 +941,18 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_bonded_deposit(&tx, &witness, extra_info, vec![], None);
             expect_error(&result, Error::UnexpectedWitnesses);
         }
         // MissingWitnesses
         {
-            let txaux = TxAux::DepositStakeTx(tx.clone(), vec![].into());
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::DepositStakeTx(vec![].into()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -858,6 +961,8 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_bonded_deposit(&tx, &vec![].into(), extra_info, vec![], None);
             expect_error(&result, Error::MissingWitnesses);
         }
         // InputSpent
@@ -904,7 +1009,26 @@ pub mod tests {
                     .serialize(),
                 )]),
             );
-            let txaux = TxAux::DepositStakeTx(tx.clone(), witness);
+            let addr = get_address(&secp, &secret_key).0;
+            let input_tx = get_old_tx(addr, false);
+
+            let result = verify_bonded_deposit(
+                &tx,
+                &witness,
+                extra_info,
+                vec![TxWithOutputs::Transfer(input_tx)],
+                None,
+            );
+            expect_error(
+                &result,
+                Error::EcdsaCrypto(secp256k1::Error::InvalidPublicKey),
+            );
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::DepositStakeTx(witness.clone()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -913,10 +1037,7 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
-            expect_error(
-                &result,
-                Error::EcdsaCrypto(secp256k1::Error::InvalidPublicKey),
-            );
+            assert!(result.is_err());
         }
         // InvalidInput
         {
@@ -942,37 +1063,83 @@ pub mod tests {
                 db.clone(),
                 &accounts,
             );
+            assert!(result.is_err());
+            let result = verify_bonded_deposit(&tx, &witness, extra_info, vec![], None);
             expect_error(&result, Error::InputOutputDoNotMatch);
         }
     }
 
-    fn replace_tx_payload(txaux: TxAux, plain_tx: PlainTxAux) -> TxAux {
-        if let (TxAux::TransferTx { nonce, .. }, PlainTxAux::TransferTx(tx, _)) =
-            (txaux, plain_tx.clone())
-        {
-            TxAux::TransferTx {
+    fn replace_tx_payload(
+        txaux: TxAux,
+        plain_tx: PlainTxAux,
+        mwitness: Option<StakedStateOpWitness>,
+        mtx: Option<DepositBondTx>,
+    ) -> TxAux {
+        match (txaux, plain_tx.clone()) {
+            (
+                TxAux::TransferTx {
+                    payload:
+                        TxObfuscated {
+                            key_from, nonce, ..
+                        },
+                    ..
+                },
+                PlainTxAux::TransferTx(tx, _),
+            ) => TxAux::TransferTx {
                 txid: tx.id(),
                 inputs: tx.inputs.clone(),
                 no_of_outputs: tx.outputs.len() as TxoIndex,
-                nonce,
-                txpayload: plain_tx.encode(),
-            }
-        } else {
-            unreachable!()
+                payload: TxObfuscated {
+                    key_from,
+                    nonce,
+                    txpayload: plain_tx.encode(),
+                },
+            },
+            (
+                TxAux::DepositStakeTx {
+                    tx,
+                    payload:
+                        TxObfuscated {
+                            key_from, nonce, ..
+                        },
+                },
+                PlainTxAux::DepositStakeTx(_),
+            ) => TxAux::DepositStakeTx {
+                tx: if let Some(t) = mtx { t } else { tx },
+                payload: TxObfuscated {
+                    key_from,
+                    nonce,
+                    txpayload: plain_tx.encode(),
+                },
+            },
+            (
+                TxAux::WithdrawUnbondedStakeTx {
+                    witness,
+                    payload:
+                        TxObfuscated {
+                            key_from, nonce, ..
+                        },
+                    ..
+                },
+                PlainTxAux::WithdrawUnbondedStakeTx(tx),
+            ) => TxAux::WithdrawUnbondedStakeTx {
+                txid: tx.id(),
+                no_of_outputs: tx.outputs.len() as TxoIndex,
+                witness: if let Some(w) = mwitness { w } else { witness },
+                payload: TxObfuscated {
+                    key_from,
+                    nonce,
+                    txpayload: plain_tx.encode(),
+                },
+            },
+            _ => unreachable!(),
         }
     }
 
     #[test]
     fn test_transfer_verify_fail() {
-        let (db, plain_txaux, tx, witness, merkle_tree, secret_key, accounts) =
+        let (db, txaux, tx, witness, merkle_tree, secret_key, accounts) =
             prepare_app_valid_transfer_tx(false);
-        let txaux = TxAux::TransferTx {
-            txid: tx.id(),
-            inputs: tx.inputs.clone(),
-            no_of_outputs: tx.outputs.len() as TxoIndex,
-            nonce: [0; 12],
-            txpayload: plain_txaux.encode(),
-        };
         let extra_info = ChainInfo {
             min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
                 .calculate_for_txaux(&txaux)
@@ -1003,8 +1170,12 @@ pub mod tests {
         {
             let mut tx = tx.clone();
             tx.inputs.clear();
-            let txaux =
-                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx, witness.clone()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1021,8 +1192,12 @@ pub mod tests {
             tx.outputs.clear();
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::NoOutputs);
-            let txaux =
-                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx, witness.clone()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1040,8 +1215,12 @@ pub mod tests {
             tx.inputs.push(inp);
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::DuplicateInputs);
-            let txaux =
-                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx, witness.clone()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1058,8 +1237,12 @@ pub mod tests {
             tx.outputs[0].value = Coin::zero();
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::ZeroCoin);
-            let txaux =
-                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness.clone()));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx, witness.clone()),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1077,8 +1260,12 @@ pub mod tests {
             witness.push(wp);
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::UnexpectedWitnesses);
-            let txaux =
-                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx.clone(), witness));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx.clone(), witness),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1094,6 +1281,8 @@ pub mod tests {
             let txaux = replace_tx_payload(
                 txaux.clone(),
                 PlainTxAux::TransferTx(tx.clone(), vec![].into()),
+                None,
+                None,
             );
             let result = verify(
                 &mock_bridge,
@@ -1120,7 +1309,12 @@ pub mod tests {
                 &result,
                 Error::InvalidSum(CoinError::OutOfBound(Coin::max().into())),
             );
-            let txaux = replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx, witness),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1188,8 +1382,12 @@ pub mod tests {
                 &result,
                 Error::EcdsaCrypto(secp256k1::Error::InvalidPublicKey),
             );
-            let txaux =
-                replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx.clone(), witness));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx.clone(), witness),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1221,7 +1419,12 @@ pub mod tests {
             witness[0] = get_tx_witness(Secp256k1::new(), &tx.id(), &secret_key, &merkle_tree);
             let result = verify_transfer(&tx, &witness, extra_info, vec![]);
             expect_error(&result, Error::InputOutputDoNotMatch);
-            let txaux = replace_tx_payload(txaux.clone(), PlainTxAux::TransferTx(tx, witness));
+            let txaux = replace_tx_payload(
+                txaux.clone(),
+                PlainTxAux::TransferTx(tx, witness),
+                None,
+                None,
+            );
             let result = verify(
                 &mock_bridge,
                 &txaux,
@@ -1234,15 +1437,7 @@ pub mod tests {
         }
         // OutputInTimelock
         {
-            let (db, plain_txaux, tx, witness, _, _, accounts) =
-                prepare_app_valid_transfer_tx(true);
-            let txaux = TxAux::TransferTx {
-                txid: tx.id(),
-                inputs: tx.inputs.clone(),
-                no_of_outputs: tx.outputs.len() as TxoIndex,
-                nonce: [0; 12],
-                txpayload: plain_txaux.encode(),
-            };
+            let (db, txaux, tx, witness, _, _, accounts) = prepare_app_valid_transfer_tx(true);
             let addr = get_address(&Secp256k1::new(), &secret_key).0;
             let input_tx = get_old_tx(addr, true);
             let result = verify_transfer(

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -25,6 +25,7 @@ use chain_core::tx::witness::tree::RawPubkey;
 use chain_core::tx::witness::EcdsaSignature;
 use chain_core::tx::PlainTxAux;
 use chain_core::tx::TransactionId;
+use chain_core::tx::TxObfuscated;
 use chain_core::tx::{
     data::{
         access::{TxAccess, TxAccessPolicy},
@@ -376,7 +377,7 @@ fn check_tx_should_reject_invalid_tx() {
     assert_ne!(0, cresp.code);
 }
 
-fn prepare_app_valid_tx() -> (ChainNodeApp<MockClient>, TxAux) {
+fn prepare_app_valid_tx() -> (ChainNodeApp<MockClient>, TxAux, WithdrawUnbondedTx) {
     let secp = Secp256k1::new();
     let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
@@ -393,13 +394,23 @@ fn prepare_app_valid_tx() -> (ChainNodeApp<MockClient>, TxAux) {
     );
 
     let witness = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &tx.id(), &secret_key));
-    let txaux = TxAux::WithdrawUnbondedStakeTx(tx, witness);
-    (app, txaux)
+    // TODO: mock enc
+    let txaux = TxAux::WithdrawUnbondedStakeTx {
+        txid: tx.id(),
+        no_of_outputs: tx.outputs.len() as TxoIndex,
+        witness: witness.clone(),
+        payload: TxObfuscated {
+            key_from: 0,
+            nonce: [0; 12],
+            txpayload: PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()).encode(),
+        },
+    };
+    (app, txaux, tx)
 }
 
 #[test]
 fn check_tx_should_accept_valid_tx() {
-    let (mut app, txaux) = prepare_app_valid_tx();
+    let (mut app, txaux, _) = prepare_app_valid_tx();
     let mut creq = RequestCheckTx::default();
     creq.set_tx(txaux.encode());
     let cresp = app.check_tx(&creq);
@@ -467,7 +478,7 @@ fn deliver_valid_tx() -> (
     StakedStateOpWitness,
     ResponseDeliverTx,
 ) {
-    let (mut app, txaux) = prepare_app_valid_tx();
+    let (mut app, txaux, tx) = prepare_app_valid_tx();
     let rewards_pool_remaining_old = app.last_state.as_ref().unwrap().rewards_pool.remaining;
     assert_eq!(0, app.delivered_txs.len());
     begin_block(&mut app);
@@ -477,7 +488,7 @@ fn deliver_valid_tx() -> (
     let rewards_pool_remaining_new = app.last_state.as_ref().unwrap().rewards_pool.remaining;
     assert!(rewards_pool_remaining_new > rewards_pool_remaining_old);
     match txaux {
-        TxAux::WithdrawUnbondedStakeTx(tx, witness) => (app, tx, witness, cresp),
+        TxAux::WithdrawUnbondedStakeTx { witness, .. } => (app, tx, witness, cresp),
         _ => unreachable!("prepare_app_valid_tx should prepare stake withdrawal tx"),
     }
 }
@@ -791,7 +802,16 @@ fn all_valid_tx_types_should_commit() {
     );
     let txid = &tx0.id();
     let witness0 = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &txid, &secret_key));
-    let withdrawtx = TxAux::WithdrawUnbondedStakeTx(tx0, witness0);
+    let withdrawtx = TxAux::WithdrawUnbondedStakeTx {
+        txid: tx0.id(),
+        no_of_outputs: tx0.outputs.len() as TxoIndex,
+        witness: witness0,
+        payload: TxObfuscated {
+            key_from: 0,
+            nonce: [0u8; 12],
+            txpayload: PlainTxAux::WithdrawUnbondedStakeTx(tx0).encode(),
+        },
+    };
     {
         let account = get_account(&addr, &app);
         // TODO: more precise amount assertions
@@ -824,8 +844,11 @@ fn all_valid_tx_types_should_commit() {
         txid: tx1.id(),
         inputs: tx1.inputs.clone(),
         no_of_outputs: tx1.outputs.len() as TxoIndex,
-        nonce: [0; 12],
-        txpayload: plain_txaux.encode(),
+        payload: TxObfuscated {
+            key_from: 0,
+            nonce: [0u8; 12],
+            txpayload: plain_txaux.encode(),
+        },
     };
     {
         let spent_utxos = get_tx_meta(&txid, &app);
@@ -847,7 +870,14 @@ fn all_valid_tx_types_should_commit() {
             .unwrap(),
     )]
     .into();
-    let depositx = TxAux::DepositStakeTx(tx2, witness2);
+    let depositx = TxAux::DepositStakeTx {
+        tx: tx2,
+        payload: TxObfuscated {
+            key_from: 0,
+            nonce: [0u8; 12],
+            txpayload: PlainTxAux::DepositStakeTx(witness2).encode(),
+        },
+    };
     {
         let spent_utxos0 = get_tx_meta(&txid, &app);
         assert!(spent_utxos0[0] && !spent_utxos0[1]);

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -19,7 +19,7 @@ use crate::tx::data::{txid_hash, TxId};
 use data::input::{TxoIndex, TxoPointer};
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-/// FIXME: other TX to be moved here (when support added in enclave etc.)
+/// Plain transaction parts "visible" inside enclaves
 pub enum PlainTxAux {
     /// both private; normal value transfer Tx with the vector of witnesses
     TransferTx(Tx, TxWitness),
@@ -49,9 +49,9 @@ impl fmt::Display for PlainTxAux {
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 // obfuscated TX payload
 pub struct TxObfuscated {
-    key_from: BlockHeight,
-    nonce: [u8; 12],
-    txpayload: Vec<u8>,
+    pub key_from: BlockHeight,
+    pub nonce: [u8; 12],
+    pub txpayload: Vec<u8>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -16,7 +16,6 @@ extern crate sgx_tstd as std;
 
 use std::prelude::v1::Vec;
 
-use chain_core::common::Timespec;
 use chain_core::init::coin::{Coin, CoinError};
 use chain_core::state::account::{DepositBondTx, StakedState, UnbondTx, WithdrawUnbondedTx};
 use chain_core::tx::data::input::TxoPointer;
@@ -26,6 +25,7 @@ use chain_core::tx::data::TxId;
 use chain_core::tx::fee::Fee;
 use chain_core::tx::witness::TxWitness;
 use chain_core::tx::TransactionId;
+pub use chain_core::ChainInfo;
 use parity_codec::{Decode, Encode};
 use secp256k1;
 use std::collections::BTreeSet;
@@ -106,19 +106,6 @@ impl fmt::Display for Error {
             AccountIncorrectNonce => write!(f, "incorrect transaction count for account operation"),
         }
     }
-}
-
-/// External information needed for TX validation
-#[derive(Clone, Copy)]
-pub struct ChainInfo {
-    /// minimal fee computed for the transaction
-    pub min_fee_computed: Fee,
-    /// network hexamedical ID
-    pub chain_hex_id: u8,
-    /// time in the previous committed block
-    pub previous_block_time: Timespec,
-    /// how much time is required to wait until stake state's unbonded amount can be withdrawn
-    pub unbonding_period: u32,
 }
 
 fn check_attributes(tx_chain_hex_id: u8, extra_info: &ChainInfo) -> Result<(), Error> {

--- a/client-common/src/tendermint/types/block.rs
+++ b/client-common/src/tendermint/types/block.rs
@@ -71,6 +71,7 @@ mod tests {
     use std::str::FromStr;
 
     use base64::encode;
+    use chain_core::tx::TxObfuscated;
     use parity_codec::Encode;
 
     #[test]
@@ -80,8 +81,11 @@ mod tests {
                 txid: [0u8; 32],
                 inputs: vec![],
                 no_of_outputs: 0,
-                nonce: [0u8; 12],
-                txpayload: vec![],
+                payload: TxObfuscated {
+                    key_from: 0,
+                    nonce: [0u8; 12],
+                    txpayload: vec![],
+                },
             }
             .encode(),
         );

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -247,7 +247,10 @@ mod tests {
             .to_coin();
 
         match tx_aux {
-            TxAux::TransferTx { txpayload, .. } => {
+            TxAux::TransferTx {
+                payload: TxObfuscated { txpayload, .. },
+                ..
+            } => {
                 if let Some(PlainTxAux::TransferTx(transaction, witness)) =
                     PlainTxAux::decode(&mut txpayload.as_slice())
                 {

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -9,6 +9,7 @@ use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::Tx;
 use chain_core::tx::fee::FeeAlgorithm;
 use chain_core::tx::PlainTxAux;
+use chain_core::tx::TxObfuscated;
 use chain_core::tx::{TransactionId, TxAux};
 use client_common::{ErrorKind, Result};
 use parity_codec::Encode;
@@ -95,8 +96,11 @@ where
                 txid: transaction.id(),
                 inputs: transaction.inputs.clone(),
                 no_of_outputs: transaction.outputs.len() as TxoIndex,
-                nonce: [0u8; 12],
-                txpayload: plain_tx_aux.encode(),
+                payload: TxObfuscated {
+                    key_from: 0,
+                    nonce: [0u8; 12],
+                    txpayload: plain_tx_aux.encode(),
+                },
             };
             let new_fees = self
                 .fee_algorithm

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -271,10 +271,12 @@ mod tests {
     use chain_core::common::TendermintEventType;
     use chain_core::init::coin::Coin;
     use chain_core::state::account::StakedStateOpWitness;
+    use chain_core::state::account::WithdrawUnbondedTx;
     use chain_core::tx::data::address::ExtendedAddr;
     use chain_core::tx::data::attribute::TxAttributes;
     use chain_core::tx::data::Tx;
     use chain_core::tx::PlainTxAux;
+    use chain_core::tx::TxObfuscated;
     use client_common::storage::MemoryStorage;
     use client_common::tendermint::types::*;
 
@@ -295,17 +297,21 @@ mod tests {
     impl MockClient {
         fn transaction(&self, height: u64) -> Option<TxAux> {
             if height == 1 {
-                Some(TxAux::WithdrawUnbondedStakeTx(
-                    WithdrawUnbondedTx {
-                        nonce: 0,
-                        outputs: vec![TxOut {
-                            address: self.addresses[0].clone(),
-                            value: Coin::new(100).unwrap(),
-                            valid_from: None,
-                        }],
-                        attributes: TxAttributes::new(171),
-                    },
-                    StakedStateOpWitness::new(
+                let withdrawtx = WithdrawUnbondedTx {
+                    nonce: 0,
+                    outputs: vec![TxOut {
+                        address: self.addresses[0].clone(),
+                        value: Coin::new(100).unwrap(),
+                        valid_from: None,
+                    }],
+                    attributes: TxAttributes::new(171),
+                };
+
+                // FIXME: mock enc
+                Some(TxAux::WithdrawUnbondedStakeTx {
+                    txid: withdrawtx.id(),
+                    no_of_outputs: 1,
+                    witness: StakedStateOpWitness::new(
                         RecoverableSignature::from_compact(
                             &[
                                 0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f, 0x04, 0x77, 0x2b,
@@ -319,7 +325,12 @@ mod tests {
                         )
                         .unwrap(),
                     ),
-                ))
+                    payload: TxObfuscated {
+                        key_from: 0,
+                        nonce: [0u8; 12],
+                        txpayload: PlainTxAux::WithdrawUnbondedStakeTx(withdrawtx).encode(),
+                    },
+                })
             } else if height == 2 {
                 let inputs = vec![TxoPointer {
                     id: self.transaction(1).unwrap().tx_id(),
@@ -338,8 +349,11 @@ mod tests {
                     txid: tx.id(),
                     inputs,
                     no_of_outputs: 1,
-                    nonce: [0u8; 12],
-                    txpayload: PlainTxAux::TransferTx(tx.clone(), vec![].into()).encode(),
+                    payload: TxObfuscated {
+                        key_from: 0,
+                        nonce: [0u8; 12],
+                        txpayload: PlainTxAux::TransferTx(tx.clone(), vec![].into()).encode(),
+                    },
                 })
             } else {
                 None

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -1,15 +1,22 @@
 //! This crate contains messages exchanged in REQ-REP socket between chain-abci app to enclave wrapper server
 
-use chain_core::common::Timespec;
 use chain_core::init::coin::Coin;
+use chain_core::state::account::DepositBondTx;
+use chain_core::state::account::StakedState;
+use chain_core::state::account::StakedStateOpWitness;
+use chain_core::state::account::WithdrawUnbondedTx;
 use chain_core::tx::data::Tx;
 use chain_core::tx::data::TxId;
-use chain_core::tx::{fee::Fee, PlainTxAux, TxAux};
+use chain_core::tx::witness::TxWitness;
+use chain_core::tx::{fee::Fee, TxAux};
+use chain_core::ChainInfo;
 use chain_tx_validation::TxWithOutputs;
 
 use parity_codec::{Decode, Encode, Input, Output};
 
 /// requests sent from chain-abci app to enclave wrapper server
+/// FIXME: the variant will be smaller once the TX storage is on the enclave side
+#[allow(clippy::large_enum_variant)]
 pub enum EnclaveRequest {
     /// a sanity check (sends the chain network ID -- last byte / two hex digits convention)
     /// during InitChain or startup (to test one connected to the correct process)
@@ -21,10 +28,9 @@ pub enum EnclaveRequest {
     /// FIXME: only certain Tx types should be sent -> create a datatype / enum for it (probably after encrypted Tx data types)
     VerifyTx {
         tx: TxAux,
+        account: Option<StakedState>,
         inputs: Vec<TxWithOutputs>,
-        min_fee_computed: Fee,
-        previous_block_time: Timespec,
-        unbonding_period: u32,
+        info: ChainInfo,
     },
 }
 
@@ -37,17 +43,15 @@ impl Encode for EnclaveRequest {
             }
             EnclaveRequest::VerifyTx {
                 tx,
+                account,
                 inputs,
-                min_fee_computed,
-                previous_block_time,
-                unbonding_period,
+                info,
             } => {
                 dest.push_byte(1);
                 tx.encode_to(dest);
+                account.encode_to(dest);
                 inputs.encode_to(dest);
-                min_fee_computed.to_coin().encode_to(dest);
-                previous_block_time.encode_to(dest);
-                unbonding_period.encode_to(dest);
+                info.encode_to(dest);
             }
         }
     }
@@ -63,16 +67,14 @@ impl Decode for EnclaveRequest {
             }
             1 => {
                 let tx = TxAux::decode(input)?;
+                let account: Option<StakedState> = Option::decode(input)?;
                 let inputs: Vec<TxWithOutputs> = Vec::decode(input)?;
-                let fee = Coin::decode(input)?;
-                let previous_block_time = Timespec::decode(input)?;
-                let unbonding_period = u32::decode(input)?;
+                let info = ChainInfo::decode(input)?;
                 Some(EnclaveRequest::VerifyTx {
                     tx,
+                    account,
                     inputs,
-                    min_fee_computed: Fee::new(fee),
-                    previous_block_time,
-                    unbonding_period,
+                    info,
                 })
             }
             _ => None,
@@ -85,8 +87,8 @@ impl Decode for EnclaveRequest {
 pub enum EnclaveResponse {
     /// returns OK if chain_hex_id matches the one embedded in enclave
     CheckChain(Result<(), ()>),
-    /// returns the paid fee if the TX is valid
-    VerifyTx(Result<Fee, ()>),
+    /// returns the affected (account) state (if any) and paid fee if the TX is valid
+    VerifyTx(Result<(Fee, Option<StakedState>), ()>),
     /// response if unsupported tx type is sent (e.g. unbondtx) -- TODO: probably unnecessary if there is a data type with a subset of TxAux
     UnsupportedTxType,
     /// response if the enclave failed to parse the request
@@ -104,14 +106,15 @@ impl Encode for EnclaveResponse {
                     dest.push_byte(1);
                 }
             }
-            EnclaveResponse::VerifyTx(result) => {
+            EnclaveResponse::VerifyTx(Err(_)) => {
                 dest.push_byte(1);
-                if result.is_ok() {
-                    dest.push_byte(0);
-                    result.unwrap().to_coin().encode_to(dest);
-                } else {
-                    dest.push_byte(1);
-                }
+                dest.push_byte(1);
+            }
+            EnclaveResponse::VerifyTx(Ok((fee, acc))) => {
+                dest.push_byte(1);
+                dest.push_byte(0);
+                fee.to_coin().encode_to(dest);
+                acc.encode_to(dest);
             }
             EnclaveResponse::UnsupportedTxType => {
                 dest.push_byte(2);
@@ -139,7 +142,8 @@ impl Decode for EnclaveResponse {
                 let result: u8 = input.read_byte()?;
                 if result == 0 {
                     let fee = Coin::decode(input)?;
-                    Some(EnclaveResponse::VerifyTx(Ok(Fee::new(fee))))
+                    let acc: Option<StakedState> = Option::decode(input)?;
+                    Some(EnclaveResponse::VerifyTx(Ok((Fee::new(fee), acc))))
                 } else {
                     Some(EnclaveResponse::VerifyTx(Err(())))
                 }
@@ -156,8 +160,10 @@ pub const FLAGS: i32 = 0;
 
 /// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
 #[derive(Encode, Decode)]
-pub struct EncryptionRequest {
-    pub tx: PlainTxAux,
+pub enum EncryptionRequest {
+    TransferTx(Tx, TxWitness),
+    DepositStake(DepositBondTx, TxWitness),
+    WithdrawStake(WithdrawUnbondedTx, StakedState, StakedStateOpWitness),
 }
 
 /// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)


### PR DESCRIPTION
Solution: changed the chain-core data types to split the private and public parts; updated the enclave protocol

--
note -- this is WIP, will also need to update https://github.com/crypto-com/chain-tx-enclave to support this after this PR is merged