### PR TITLE
 Problem: latest chain core doesn't compile on tx-enclave (CRO-230) (CRO-208)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -287,7 +287,7 @@ name = "chain-core"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2836,7 +2836,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-"checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
+"checksum bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0089c35ab7c6f2bc55ab23f769913f0ac65b1023e7e74638a1f43128dd5df2"
 "checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["serde"]
+default = ["serde", "bech32"]
 
 
 [dependencies]
@@ -21,7 +21,7 @@ serde_json = "1.0"
 parity-codec = { features = ["derive"], version = "4.1.2" }
 base64 = "0.10"
 static_assertions = "0.3.3"
-bech32 = "0.7.1"
+bech32 = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 parity-codec = { features = ["derive"], version = "4.1.2" }
 base64 = "0.10"
 static_assertions = "0.3.3"
-bech32= "0.6.0"
+bech32 = "0.7.1"
 
 [dev-dependencies]
 quickcheck = "0.8"


### PR DESCRIPTION
Solution: upgraded to the latest bech32, made bech32 dependency optional (textual repr. not needed in enclave tx validation), feature-guarded its usage

--
Note that it'd also be possible to fork bech32 crate to make it sgx-friendly (mainly a few std-related tweaks), but I guess that's more hassle