### PR TITLE
Problem: (CRO-215) BlockResults RPC call does not parse block filter.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.1.0",
+ "chain-tx-filter 0.1.0",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -231,8 +231,8 @@ impl Command {
                     Cell::from(&change.address),
                     Cell::from(&amount).style_spec("r"),
                     Cell::new(in_out).style_spec(spec),
-                    Cell::from(&change.height).style_spec("r"),
-                    Cell::from(&change.time),
+                    Cell::from(&change.block_height).style_spec("r"),
+                    Cell::from(&change.block_time),
                 ]));
             }
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 chain-core = { path = "../chain-core" }
+chain-tx-filter = { path = "../chain-tx-filter" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 rand = "0.7"
 failure = "0.1"

--- a/client-common/src/balance/transaction_change.rs
+++ b/client-common/src/balance/transaction_change.rs
@@ -23,9 +23,9 @@ pub struct TransactionChange {
     /// Change in balance
     pub balance_change: BalanceChange,
     /// Height of block which has this transaction
-    pub height: u64,
+    pub block_height: u64,
     /// Time of block which has this transaction
-    pub time: DateTime<Utc>,
+    pub block_time: DateTime<Utc>,
 }
 
 impl Encode for TransactionChange {
@@ -33,8 +33,8 @@ impl Encode for TransactionChange {
         self.transaction_id.encode_to(dest);
         self.address.encode_to(dest);
         self.balance_change.encode_to(dest);
-        self.height.encode_to(dest);
-        self.time.to_rfc3339().encode_to(dest);
+        self.block_height.encode_to(dest);
+        self.block_time.to_rfc3339().encode_to(dest);
     }
 }
 
@@ -43,14 +43,14 @@ impl Decode for TransactionChange {
         let transaction_id = TxId::decode(input)?;
         let address = ExtendedAddr::decode(input)?;
         let balance_change = BalanceChange::decode(input)?;
-        let height = u64::decode(input)?;
-        let time = DateTime::from_str(&String::decode(input)?).ok()?;
+        let block_height = u64::decode(input)?;
+        let block_time = DateTime::from_str(&String::decode(input)?).ok()?;
         Some(TransactionChange {
             transaction_id,
             address,
             balance_change,
-            height,
-            time,
+            block_height,
+            block_time,
         })
     }
 }
@@ -84,8 +84,8 @@ mod tests {
             transaction_id: txid_hash(&[0, 1, 2]),
             address: ExtendedAddr::OrTree(Default::default()),
             balance_change,
-            height: 0,
-            time: DateTime::from(SystemTime::now()),
+            block_height: 0,
+            block_time: DateTime::from(SystemTime::now()),
         }
     }
 

--- a/client-common/src/storage/sled_storage.rs
+++ b/client-common/src/storage/sled_storage.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "sled")]
 use std::path::Path;
+use std::sync::Arc;
 
 use failure::ResultExt;
 use sled::{ConfigBuilder, Db};
@@ -9,21 +10,21 @@ use crate::{ErrorKind, Result};
 
 /// Storage backed by Sled
 #[derive(Clone)]
-pub struct SledStorage(Db);
+pub struct SledStorage(Arc<Db>);
 
 impl SledStorage {
     /// Creates a new instance with specified path for data storage
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
         if cfg!(test) {
-            Ok(Self(
+            Ok(Self(Arc::new(
                 Db::start(ConfigBuilder::new().path(path).temporary(true).build())
                     .context(ErrorKind::StorageInitializationError)?,
-            ))
+            )))
         } else {
-            Ok(Self(
+            Ok(Self(Arc::new(
                 Db::start(ConfigBuilder::new().path(path).build())
                     .context(ErrorKind::StorageInitializationError)?,
-            ))
+            )))
         }
     }
 }

--- a/client-common/src/tendermint/types/query.rs
+++ b/client-common/src/tendermint/types/query.rs
@@ -1,5 +1,9 @@
 #![allow(missing_docs)]
+use base64::decode;
+use failure::ResultExt;
 use serde::Deserialize;
+
+use crate::{ErrorKind, Result};
 
 #[derive(Debug, Deserialize)]
 pub struct QueryResult {
@@ -9,4 +13,10 @@ pub struct QueryResult {
 #[derive(Debug, Deserialize)]
 pub struct Response {
     pub value: String,
+}
+
+impl QueryResult {
+    pub fn bytes(&self) -> Result<Vec<u8>> {
+        Ok(decode(&self.response.value).context(ErrorKind::DeserializationError)?)
+    }
 }

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -564,15 +564,15 @@ mod tests {
                         transaction_id: [0u8; 32],
                         address: address.clone(),
                         balance_change: BalanceChange::Incoming(Coin::new(30).unwrap()),
-                        height: 1,
-                        time: DateTime::from(SystemTime::now()),
+                        block_height: 1,
+                        block_time: DateTime::from(SystemTime::now()),
                     },
                     TransactionChange {
                         transaction_id: [1u8; 32],
                         address: address.clone(),
                         balance_change: BalanceChange::Outgoing(Coin::new(30).unwrap()),
-                        height: 2,
-                        time: DateTime::from(SystemTime::now()),
+                        block_height: 2,
+                        block_time: DateTime::from(SystemTime::now()),
                     },
                 ])
             } else if address == &self.addr_2 {
@@ -582,15 +582,15 @@ mod tests {
                             transaction_id: [1u8; 32],
                             address: address.clone(),
                             balance_change: BalanceChange::Incoming(Coin::new(30).unwrap()),
-                            height: 1,
-                            time: DateTime::from(SystemTime::now()),
+                            block_height: 1,
+                            block_time: DateTime::from(SystemTime::now()),
                         },
                         TransactionChange {
                             transaction_id: [2u8; 32],
                             address: address.clone(),
                             balance_change: BalanceChange::Outgoing(Coin::new(30).unwrap()),
-                            height: 2,
-                            time: DateTime::from(SystemTime::now()),
+                            block_height: 2,
+                            block_time: DateTime::from(SystemTime::now()),
                         },
                     ])
                 } else {
@@ -598,8 +598,8 @@ mod tests {
                         transaction_id: [1u8; 32],
                         address: address.clone(),
                         balance_change: BalanceChange::Incoming(Coin::new(30).unwrap()),
-                        height: 2,
-                        time: DateTime::from(SystemTime::now()),
+                        block_height: 2,
+                        block_time: DateTime::from(SystemTime::now()),
                     }])
                 }
             } else if *self.changed.read().unwrap() && address == &self.addr_3 {
@@ -607,8 +607,8 @@ mod tests {
                     transaction_id: [1u8; 32],
                     address: address.clone(),
                     balance_change: BalanceChange::Incoming(Coin::new(30).unwrap()),
-                    height: 2,
-                    time: DateTime::from(SystemTime::now()),
+                    block_height: 2,
+                    block_time: DateTime::from(SystemTime::now()),
                 }])
             } else {
                 Ok(Default::default())

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -103,8 +103,8 @@ where
         memento: &mut AddressMemento,
         transaction_id: TxId,
         input: TxoPointer,
-        height: u64,
-        time: DateTime<Utc>,
+        block_height: u64,
+        block_time: DateTime<Utc>,
     ) -> Result<()> {
         let output = self.transaction_service.get_output(&input)?;
 
@@ -112,8 +112,8 @@ where
             transaction_id,
             address: output.address,
             balance_change: BalanceChange::Outgoing(output.value),
-            height,
-            time,
+            block_height,
+            block_time,
         };
 
         let address = change.address.clone();
@@ -135,15 +135,15 @@ where
         transaction_id: TxId,
         output: TxOut,
         index: usize,
-        height: u64,
-        time: DateTime<Utc>,
+        block_height: u64,
+        block_time: DateTime<Utc>,
     ) {
         let change = TransactionChange {
             transaction_id,
             address: output.address.clone(),
             balance_change: BalanceChange::Incoming(output.value),
-            height,
-            time,
+            block_height,
+            block_time,
         };
 
         let address = change.address.clone();
@@ -170,7 +170,7 @@ where
         let current_block_height = self.client.status()?.last_block_height()?;
 
         for height in (last_block_height + 1)..=current_block_height {
-            let valid_transaction_ids = self.client.block_results(height)?.ids()?;
+            let valid_transaction_ids = self.client.block_results(height)?.transaction_ids()?;
             let block = self.client.block(height)?;
             let transactions = block.transactions()?;
 
@@ -410,6 +410,7 @@ mod tests {
                                 }],
                             }],
                         }]),
+                        end_block: None,
                     },
                 })
             } else if height == 2 {
@@ -427,6 +428,7 @@ mod tests {
                                 }],
                             }],
                         }]),
+                        end_block: None,
                     },
                 })
             } else {

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -509,8 +509,8 @@ pub mod tests {
                 transaction_id: [0u8; 32],
                 address: address.clone(),
                 balance_change: BalanceChange::Incoming(Coin::new(30).unwrap()),
-                height: 1,
-                time: DateTime::from(SystemTime::now()),
+                block_height: 1,
+                block_time: DateTime::from(SystemTime::now()),
             }])
         }
 


### PR DESCRIPTION
Solution: Changed block results RPC call to parse `end_block` section of response.

- Also includes a small change of wrapping `sled::Db` in `Arc` in `client_common::SledStorage`.