### PR TITLE
Problem: (CRO-215) No data structure to hold details of a block header

### DIFF
--- a/client-common/src/block_header.rs
+++ b/client-common/src/block_header.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+
+use chain_core::tx::data::TxId;
+use chain_tx_filter::BlockFilter;
+
+/// Structure for representing a block header on Crypto.com Chain
+pub struct BlockHeader {
+    /// Block height
+    pub block_height: u64,
+    /// Block time
+    pub block_time: DateTime<Utc>,
+    /// List of successfully committed transaction ids in this block
+    pub transaction_ids: Vec<TxId>,
+    /// Bloom filter for view keys
+    pub view_key_filter: BlockFilter,
+}

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs, unsafe_code, unstable_features)]
 //! This crate contains all the common types and utilities used by other `client-*` crates.
+mod block_header;
 mod transaction;
 
 pub mod balance;
@@ -8,6 +9,8 @@ pub mod key;
 pub mod storage;
 pub mod tendermint;
 
+#[doc(inline)]
+pub use block_header::BlockHeader;
 #[doc(inline)]
 pub use error::{Error, ErrorKind, Result};
 #[doc(inline)]

--- a/client-common/src/tendermint/client.rs
+++ b/client-common/src/tendermint/client.rs
@@ -19,6 +19,6 @@ pub trait Client: Send + Sync {
     /// Makes `broadcast_tx_sync` call to tendermint
     fn broadcast_transaction(&self, transaction: &[u8]) -> Result<()>;
 
-    /// Get abci query
-    fn query(&self, path: &str, data: &str) -> Result<QueryResult>;
+    /// Makes `abci_query` call to tendermint
+    fn query(&self, path: &str, data: &[u8]) -> Result<QueryResult>;
 }

--- a/client-common/src/tendermint/rpc_client.rs
+++ b/client-common/src/tendermint/rpc_client.rs
@@ -62,9 +62,13 @@ impl Client for RpcClient {
             .map(|_| ())
     }
 
-    fn query(&self, path: &str, data: &str) -> Result<QueryResult> {
-        // path, data, height, prove
-        let params = [json!(path), json!(data), json!(null), json!(null)];
+    fn query(&self, path: &str, data: &[u8]) -> Result<QueryResult> {
+        let params = [
+            json!(path),
+            json!(hex::encode(data)),
+            json!(null),
+            json!(null),
+        ];
         self.call("abci_query", &params)
     }
 }

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -441,7 +441,7 @@ mod tests {
         }
 
         /// Get abci query
-        fn query(&self, _path: &str, _data: &str) -> Result<QueryResult> {
+        fn query(&self, _path: &str, _data: &[u8]) -> Result<QueryResult> {
             Ok(QueryResult {
                 response: Response {
                     value: "".to_string(),

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -59,7 +59,7 @@ where
     /// Get account info
     fn get_account(&self, staked_state_address: &[u8]) -> Result<StakedState> {
         self.client
-            .query("account", hex::encode(staked_state_address).as_str())
+            .query("account", staked_state_address)
             .map(|x| x.response.value)
             .and_then(|value| match base64::decode(value.as_bytes()) {
                 Ok(a) => Ok(a),
@@ -312,7 +312,7 @@ mod tests {
             unreachable!()
         }
 
-        fn query(&self, _path: &str, _data: &str) -> Result<QueryResult> {
+        fn query(&self, _path: &str, _data: &[u8]) -> Result<QueryResult> {
             Ok(QueryResult {
                 response: Response {
                     value:

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -591,7 +591,7 @@ pub mod tests {
             unreachable!()
         }
 
-        fn query(&self, _path: &str, _data: &str) -> CommonResult<QueryResult> {
+        fn query(&self, _path: &str, _data: &[u8]) -> CommonResult<QueryResult> {
             unreachable!()
         }
     }


### PR DESCRIPTION
Solution: Added `BlockHeader` data type in `client-common`

- Also, changed tendermint RPC query data from `&str` to `&[u8]`