### PR TITLE
Problem: (CRO-215) No way to decrypt an encrypted transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "chain-core 0.1.0",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-common 0.1.0",
+ "enclave-protocol 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 client-common = { path = "../client-common" }
+enclave-protocol = { path = "../enclave-protocol" }
 failure = "0.1"
 parity-codec = { features = ["derive"], version = "4.1.3" }
 chrono = { version = "0.4", features = ["serde"] }

--- a/client-index/src/cipher.rs
+++ b/client-index/src/cipher.rs
@@ -1,0 +1,20 @@
+//! Utilities for encryption and decryption
+mod abci_transaction_cipher;
+
+pub use abci_transaction_cipher::AbciTransactionCipher;
+
+use chain_core::tx::data::TxId;
+use client_common::{PrivateKey, Result, Transaction};
+
+/// Interface for encryption and decryption of transactions
+pub trait TransactionCipher: Send + Sync {
+    /// Retrieves decrypted transactions with given ids. Only transactions of type `Transfer` and `Withdraw` need to be
+    /// decrypted.
+    fn decrypt(
+        &self,
+        transaction_ids: &[TxId],
+        private_key: &PrivateKey,
+    ) -> Result<Vec<Transaction>>;
+
+    // TODO: Implement `encrypt()`
+}

--- a/client-index/src/cipher/abci_transaction_cipher.rs
+++ b/client-index/src/cipher/abci_transaction_cipher.rs
@@ -1,0 +1,130 @@
+use parity_codec::{Decode, Encode};
+
+use chain_core::tx::data::{txid_hash, TxId};
+use chain_core::tx::TxWithOutputs;
+use client_common::tendermint::Client;
+use client_common::{Error, ErrorKind, PrivateKey, Result, Transaction};
+use enclave_protocol::{DecryptionRequest, DecryptionRequestBody, DecryptionResponse};
+
+use crate::TransactionCipher;
+
+/// Implementation of transaction cipher which uses Tendermint ABCI to encrypt/decrypt transactions
+pub struct AbciTransactionCipher<C>
+where
+    C: Client,
+{
+    client: C,
+}
+
+impl<C> AbciTransactionCipher<C>
+where
+    C: Client,
+{
+    /// Creates a new instance of `AbciTransactionCipher`
+    #[inline]
+    pub fn new(client: C) -> Self {
+        Self { client }
+    }
+}
+
+impl<C> TransactionCipher for AbciTransactionCipher<C>
+where
+    C: Client,
+{
+    fn decrypt(
+        &self,
+        transaction_ids: &[TxId],
+        private_key: &PrivateKey,
+    ) -> Result<Vec<Transaction>> {
+        let body = DecryptionRequestBody {
+            txs: transaction_ids.to_owned(),
+        };
+
+        let message = txid_hash(&body.encode());
+        let signature = private_key.sign(message)?.serialize_compact().1;
+
+        let request = DecryptionRequest {
+            body,
+            view_key_sig: signature,
+        };
+
+        let response = self
+            .client
+            .query("mockdecrypt", &request.encode())?
+            .bytes()?;
+
+        let txs = DecryptionResponse::decode(&mut response.as_slice())
+            .ok_or_else(|| Error::from(ErrorKind::DeserializationError))?
+            .txs;
+
+        let transactions = txs
+            .into_iter()
+            .map(|tx| match tx {
+                TxWithOutputs::Transfer(t) => Transaction::TransferTransaction(t),
+                TxWithOutputs::StakeWithdraw(t) => Transaction::WithdrawUnbondedStakeTransaction(t),
+            })
+            .collect::<Vec<Transaction>>();
+
+        Ok(transactions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use base64::encode;
+
+    use chain_core::tx::data::Tx;
+    use client_common::tendermint::types::*;
+
+    struct MockClient;
+
+    impl Client for MockClient {
+        fn genesis(&self) -> Result<Genesis> {
+            unreachable!()
+        }
+
+        fn status(&self) -> Result<Status> {
+            unreachable!()
+        }
+
+        fn block(&self, _height: u64) -> Result<Block> {
+            unreachable!()
+        }
+
+        fn block_results(&self, _height: u64) -> Result<BlockResults> {
+            unreachable!()
+        }
+
+        fn broadcast_transaction(&self, _transaction: &[u8]) -> Result<()> {
+            unreachable!()
+        }
+
+        fn query(&self, _path: &str, _data: &[u8]) -> Result<QueryResult> {
+            let response = DecryptionResponse {
+                txs: vec![TxWithOutputs::Transfer(Tx::new())],
+            }
+            .encode();
+
+            Ok(QueryResult {
+                response: Response {
+                    value: encode(&response),
+                },
+            })
+        }
+    }
+
+    #[test]
+    fn check_decryption() {
+        let cipher = AbciTransactionCipher::new(MockClient);
+
+        assert_eq!(
+            1,
+            cipher
+                .decrypt(&[[0; 32]], &PrivateKey::new().unwrap())
+                .unwrap()
+                .len()
+        )
+    }
+}

--- a/client-index/src/lib.rs
+++ b/client-index/src/lib.rs
@@ -1,8 +1,10 @@
 #![deny(missing_docs, unsafe_code, unstable_features)]
 //! This crate exposes functionality to index transactions committed in Crypto.com Chain.
-
+pub mod cipher;
 pub mod index;
 pub mod service;
 
+#[doc(inline)]
+pub use crate::cipher::TransactionCipher;
 #[doc(inline)]
 pub use crate::index::Index;

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -260,8 +260,8 @@ where
                             kind: bc.0.to_string(),
                             transaction_id: hex::encode(c.transaction_id),
                             address: c.address.to_string(),
-                            height: c.height.to_string(),
-                            time: c.time.to_string(),
+                            height: c.block_height.to_string(),
+                            time: c.block_time.to_string(),
                             amount: bc.1.to_string(),
                         }
                     })


### PR DESCRIPTION
**Solution**: Implemented `TransactionCipher` which can be used to decrypt a set if transaction_ids using current mock implementation in `chain-abci`

**Note**: `encrypt()` will be implemented in future PRs.