### PR TITLE
Problem: (CRO-215) Transaction synchronization code is tightly coupled with transaction index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.1.0",
+ "chain-tx-filter 0.1.0",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-common 0.1.0",
  "enclave-protocol 0.1.0",

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -196,7 +196,6 @@ impl Command {
 
     fn get_balance<T: WalletClient>(wallet_client: T, name: &str) -> Result<()> {
         let passphrase = ask_passphrase()?;
-        wallet_client.sync()?;
         let balance = wallet_client.balance(name, &passphrase)?;
 
         success(&format!("Wallet balance: {}", balance));
@@ -205,7 +204,6 @@ impl Command {
 
     fn get_history<T: WalletClient>(wallet_client: T, name: &str) -> Result<()> {
         let passphrase = ask_passphrase()?;
-        wallet_client.sync()?;
         let history = wallet_client.history(name, &passphrase)?;
 
         if !history.is_empty() {
@@ -244,7 +242,8 @@ impl Command {
         Ok(())
     }
 
-    fn resync<T: WalletClient>(wallet_client: T) -> Result<()> {
-        wallet_client.sync_all()
+    fn resync<T: WalletClient>(_wallet_client: T) -> Result<()> {
+        // TODO: Implement synchronization logic for current view key
+        Ok(())
     }
 }

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -152,10 +152,10 @@ pub trait WalletClient: Send + Sync {
     fn broadcast_transaction(&self, tx_aux: &TxAux) -> Result<()>;
 
     /// Synchronizes index with Crypto.com Chain (from last known height)
-    fn sync(&self) -> Result<()>;
+    fn sync(&self, view_key: &PublicKey, private_key: &PrivateKey) -> Result<()>;
 
     /// Synchronizes index with Crypto.com Chain (from genesis)
-    fn sync_all(&self) -> Result<()>;
+    fn sync_all(&self, view_key: &PublicKey, private_key: &PrivateKey) -> Result<()>;
 }
 
 /// Interface for a generic wallet for multi-signature transactions

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -280,12 +280,12 @@ where
         self.index.broadcast_transaction(&tx_aux.encode())
     }
 
-    fn sync(&self) -> Result<()> {
-        self.index.sync()
+    fn sync(&self, view_key: &PublicKey, private_key: &PrivateKey) -> Result<()> {
+        self.index.sync(view_key, private_key)
     }
 
-    fn sync_all(&self) -> Result<()> {
-        self.index.sync_all()
+    fn sync_all(&self, view_key: &PublicKey, private_key: &PrivateKey) -> Result<()> {
+        self.index.sync_all(view_key, private_key)
     }
 }
 
@@ -550,15 +550,15 @@ mod tests {
     }
 
     impl Index for MockIndex {
-        fn sync(&self) -> Result<()> {
+        fn sync(&self, _view_key: &PublicKey, _private_key: &PrivateKey) -> Result<()> {
             Ok(())
         }
 
-        fn sync_all(&self) -> Result<()> {
+        fn sync_all(&self, _view_key: &PublicKey, _private_key: &PrivateKey) -> Result<()> {
             Ok(())
         }
 
-        fn address_details(&self, address: &ExtendedAddr) -> Result<AddressDetails> {
+        fn address_details(&self, _address: &ExtendedAddr) -> Result<AddressDetails> {
             unreachable!()
         }
 
@@ -785,6 +785,9 @@ mod tests {
             .build()
             .unwrap();
 
+        let private_key = PrivateKey::new().unwrap();
+        let view_key = PublicKey::from(&private_key);
+
         wallet
             .new_wallet("wallet_1", &SecUtf8::from("passphrase"))
             .unwrap();
@@ -863,8 +866,8 @@ mod tests {
                 .len()
         );
 
-        assert!(wallet.sync().is_ok());
-        assert!(wallet.sync_all().is_ok());
+        assert!(wallet.sync(&view_key, &private_key).is_ok());
+        assert!(wallet.sync_all(&view_key, &private_key).is_ok());
 
         let signer = DefaultSigner::new(storage.clone());
 
@@ -1072,14 +1075,17 @@ mod tests {
                 .kind()
         );
 
+        let private_key = PrivateKey::new().unwrap();
+        let view_key = PublicKey::from(&private_key);
+
         assert_eq!(
             ErrorKind::PermissionDenied,
-            wallet.sync().unwrap_err().kind()
+            wallet.sync(&view_key, &private_key).unwrap_err().kind()
         );
 
         assert_eq!(
             ErrorKind::PermissionDenied,
-            wallet.sync_all().unwrap_err().kind()
+            wallet.sync_all(&view_key, &private_key).unwrap_err().kind()
         );
     }
 

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -15,6 +15,7 @@ jsonrpc = { version = "0.11", optional = true }
 base64 = "0.10"
 
 [dev-dependencies]
+chain-tx-filter = { path = "../chain-tx-filter" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
 
 [features]

--- a/client-index/src/handler.rs
+++ b/client-index/src/handler.rs
@@ -1,11 +1,13 @@
 //! Observer for block-headers, transactions, etc.
+mod default_block_handler;
 mod default_transaction_handler;
 
+pub use default_block_handler::DefaultBlockHandler;
 pub use default_transaction_handler::DefaultTransactionHandler;
 
 use chrono::{DateTime, Utc};
 
-use client_common::{Result, Transaction};
+use client_common::{BlockHeader, PrivateKey, PublicKey, Result, Transaction};
 
 /// Interface for handling stream of transactions in Crypto.com Chain
 pub trait TransactionHandler: Send + Sync {
@@ -15,5 +17,16 @@ pub trait TransactionHandler: Send + Sync {
         transaction: Transaction,
         block_height: u64,
         block_time: DateTime<Utc>,
+    ) -> Result<()>;
+}
+
+/// Interface for handling stream of block headers in Crypto.com Chain
+pub trait BlockHandler: Send + Sync {
+    /// Handles a block header in Crypto.com Chain
+    fn on_next(
+        &self,
+        block_header: BlockHeader,
+        view_key: &PublicKey,
+        private_key: &PrivateKey,
     ) -> Result<()>;
 }

--- a/client-index/src/handler/default_block_handler.rs
+++ b/client-index/src/handler/default_block_handler.rs
@@ -1,0 +1,203 @@
+use client_common::{BlockHeader, PrivateKey, PublicKey, Result, Storage};
+
+use crate::service::{GlobalStateService, TransactionService};
+use crate::{BlockHandler, TransactionCipher, TransactionHandler};
+
+/// Default implementation of `BlockHandler`
+pub struct DefaultBlockHandler<C, H, S>
+where
+    C: TransactionCipher,
+    H: TransactionHandler,
+    S: Storage,
+{
+    transaction_cipher: C,
+    transaction_handler: H,
+
+    transaction_service: TransactionService<S>,
+    global_state_service: GlobalStateService<S>,
+}
+
+impl<C, H, S> DefaultBlockHandler<C, H, S>
+where
+    C: TransactionCipher,
+    H: TransactionHandler,
+    S: Storage + Clone,
+{
+    /// Creates a new instance of `DefaultBlockHandler`
+    #[inline]
+    pub fn new(transaction_cipher: C, transaction_handler: H, storage: S) -> Self {
+        Self {
+            transaction_cipher,
+            transaction_handler,
+            transaction_service: TransactionService::new(storage.clone()),
+            global_state_service: GlobalStateService::new(storage),
+        }
+    }
+}
+
+impl<C, H, S> BlockHandler for DefaultBlockHandler<C, H, S>
+where
+    C: TransactionCipher,
+    H: TransactionHandler,
+    S: Storage,
+{
+    fn on_next(
+        &self,
+        block_header: BlockHeader,
+        view_key: &PublicKey,
+        private_key: &PrivateKey,
+    ) -> Result<()> {
+        if block_header
+            .view_key_filter
+            .check_view_key(&view_key.into())
+        {
+            let transactions = self
+                .transaction_cipher
+                .decrypt(&block_header.transaction_ids, private_key)?;
+
+            for transaction in transactions {
+                self.transaction_service.set(&transaction)?;
+
+                self.transaction_handler.on_next(
+                    transaction,
+                    block_header.block_height,
+                    block_header.block_time,
+                )?;
+            }
+        }
+
+        self.global_state_service
+            .set_last_block_height(view_key, block_header.block_height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::str::FromStr;
+
+    use chrono::{DateTime, Utc};
+
+    use chain_core::init::coin::Coin;
+    use chain_core::state::account::{StakedStateOpAttributes, UnbondTx};
+    use chain_core::tx::data::address::ExtendedAddr;
+    use chain_core::tx::data::attribute::TxAttributes;
+    use chain_core::tx::data::output::TxOut;
+    use chain_core::tx::data::{Tx, TxId};
+    use chain_core::tx::TransactionId;
+    use chain_tx_filter::BlockFilter;
+    use client_common::storage::MemoryStorage;
+    use client_common::Transaction;
+
+    struct MockTransactionCipher;
+
+    impl TransactionCipher for MockTransactionCipher {
+        fn decrypt(
+            &self,
+            transaction_ids: &[TxId],
+            _private_key: &PrivateKey,
+        ) -> Result<Vec<Transaction>> {
+            assert_eq!(1, transaction_ids.len());
+            assert_eq!(transfer_transaction().id(), transaction_ids[0]);
+            Ok(vec![transfer_transaction()])
+        }
+    }
+
+    struct MockTransactionHandler;
+
+    impl TransactionHandler for MockTransactionHandler {
+        fn on_next(
+            &self,
+            transaction: Transaction,
+            block_height: u64,
+            block_time: DateTime<Utc>,
+        ) -> Result<()> {
+            if transaction != transfer_transaction() && transaction != unbond_transaction() {
+                panic!("Invalid transaction")
+            }
+            assert_eq!(1, block_height);
+            assert_eq!(
+                <DateTime<Utc>>::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
+                block_time
+            );
+            Ok(())
+        }
+    }
+
+    fn transfer_transaction() -> Transaction {
+        Transaction::TransferTransaction(Tx::new_with(
+            Vec::new(),
+            vec![TxOut::new(
+                ExtendedAddr::OrTree([0; 32]),
+                Coin::new(100).unwrap(),
+            )],
+            TxAttributes::default(),
+        ))
+    }
+
+    fn unbond_transaction() -> Transaction {
+        Transaction::UnbondStakeTransaction(UnbondTx::new(
+            Coin::new(100).unwrap(),
+            0,
+            StakedStateOpAttributes::new(0),
+        ))
+    }
+
+    fn block_header(view_key: &PublicKey) -> BlockHeader {
+        let transaction_ids: Vec<TxId> = vec![transfer_transaction().id()];
+
+        let mut block_filter = BlockFilter::default();
+        block_filter.add_view_key(&view_key.into());
+
+        BlockHeader {
+            block_height: 1,
+            block_time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
+            transaction_ids,
+            view_key_filter: block_filter,
+        }
+    }
+
+    #[test]
+    fn check_block_flow() {
+        let storage = MemoryStorage::default();
+
+        let private_key = PrivateKey::new().unwrap();
+        let view_key = PublicKey::from(&private_key);
+
+        let block_header = block_header(&view_key);
+
+        let block_handler = DefaultBlockHandler::new(
+            MockTransactionCipher,
+            MockTransactionHandler,
+            storage.clone(),
+        );
+
+        let transaction_service = TransactionService::new(storage.clone());
+        let global_state_service = GlobalStateService::new(storage);
+
+        let transaction = transfer_transaction();
+
+        assert!(transaction_service
+            .get(&transaction.id())
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            0,
+            global_state_service.last_block_height(&view_key).unwrap()
+        );
+
+        block_handler
+            .on_next(block_header, &view_key, &private_key)
+            .unwrap();
+
+        assert_eq!(
+            transaction,
+            transaction_service.get(&transaction.id()).unwrap().unwrap()
+        );
+        assert_eq!(
+            1,
+            global_state_service.last_block_height(&view_key).unwrap()
+        );
+    }
+}

--- a/client-index/src/index.rs
+++ b/client-index/src/index.rs
@@ -11,17 +11,17 @@ use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::TxId;
 use client_common::balance::TransactionChange;
-use client_common::{Result, Transaction};
+use client_common::{PrivateKey, PublicKey, Result, Transaction};
 
 use crate::AddressDetails;
 
 /// Interface for interacting with transaction index
 pub trait Index: Send + Sync {
     /// Synchronizes transaction index with Crypto.com Chain (from last known height)
-    fn sync(&self) -> Result<()>;
+    fn sync(&self, view_key: &PublicKey, private_key: &PrivateKey) -> Result<()>;
 
     /// Synchronizes transaction index with Crypto.com Chain (from genesis)
-    fn sync_all(&self) -> Result<()>;
+    fn sync_all(&self, view_key: &PublicKey, private_key: &PrivateKey) -> Result<()>;
 
     /// Returns details for given address
     fn address_details(&self, address: &ExtendedAddr) -> Result<AddressDetails>;

--- a/client-index/src/index/unauthorized_index.rs
+++ b/client-index/src/index/unauthorized_index.rs
@@ -4,7 +4,7 @@ use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::TxId;
 use client_common::balance::TransactionChange;
-use client_common::{ErrorKind, Result, Transaction};
+use client_common::{ErrorKind, PrivateKey, PublicKey, Result, Transaction};
 
 use crate::{AddressDetails, Index};
 
@@ -13,11 +13,11 @@ use crate::{AddressDetails, Index};
 pub struct UnauthorizedIndex;
 
 impl Index for UnauthorizedIndex {
-    fn sync(&self) -> Result<()> {
+    fn sync(&self, _view_key: &PublicKey, _private_key: &PrivateKey) -> Result<()> {
         Err(ErrorKind::PermissionDenied.into())
     }
 
-    fn sync_all(&self) -> Result<()> {
+    fn sync_all(&self, _view_key: &PublicKey, _private_key: &PrivateKey) -> Result<()> {
         Err(ErrorKind::PermissionDenied.into())
     }
 

--- a/client-index/src/lib.rs
+++ b/client-index/src/lib.rs
@@ -8,7 +8,7 @@ pub mod service;
 #[doc(inline)]
 pub use crate::cipher::TransactionCipher;
 #[doc(inline)]
-pub use crate::handler::TransactionHandler;
+pub use crate::handler::{BlockHandler, TransactionHandler};
 #[doc(inline)]
 pub use crate::index::Index;
 #[doc(inline)]

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -227,19 +227,13 @@ where
     }
 
     fn sync(&self) -> Result<()> {
-        if let Err(e) = self.client.sync() {
-            Err(to_rpc_error(e))
-        } else {
-            Ok(())
-        }
+        // TODO: Implement synchronization logic for current view key
+        Ok(())
     }
 
     fn sync_all(&self) -> Result<()> {
-        if let Err(e) = self.client.sync_all() {
-            Err(to_rpc_error(e))
-        } else {
-            Ok(())
-        }
+        // TODO: Implement synchronization logic for current view key
+        Ok(())
     }
 
     fn transactions(&self, request: WalletRequest) -> Result<Vec<RowTx>> {
@@ -511,7 +505,7 @@ pub mod tests {
     use client_common::tendermint::types::*;
     use client_common::tendermint::Client;
     use client_common::Result as CommonResult;
-    use client_common::Transaction;
+    use client_common::{PrivateKey, PublicKey, Transaction};
     use client_core::signer::DefaultSigner;
     use client_core::transaction_builder::DefaultTransactionBuilder;
     use client_core::wallet::DefaultWalletClient;
@@ -522,11 +516,11 @@ pub mod tests {
     pub struct MockIndex;
 
     impl Index for MockIndex {
-        fn sync(&self) -> CommonResult<()> {
+        fn sync(&self, _view_key: &PublicKey, _private_key: &PrivateKey) -> CommonResult<()> {
             Ok(())
         }
 
-        fn sync_all(&self) -> CommonResult<()> {
+        fn sync_all(&self, _view_key: &PublicKey, _private_key: &PrivateKey) -> CommonResult<()> {
             Ok(())
         }
 


### PR DESCRIPTION
**Solution**: This is second of a series of PRs which will slowly extract out all the transaction synchronization code from transaction index.

**Note**: Current implementation of `BlockHandler` only handles transaction which are encrypted (`Transfer` and `Withdraw`). Implementation for `DepositStake` transactions will be a part of future PRs.