### PR TITLE
Problem: (CRO-215) TransactionCipher does not support transaction encryption

### DIFF
--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -18,7 +18,7 @@ pub use key::{PrivateKey, PublicKey};
 #[doc(inline)]
 pub use storage::{SecureStorage, Storage};
 #[doc(inline)]
-pub use transaction::Transaction;
+pub use transaction::{SignedTransaction, Transaction};
 
 use secp256k1::{All, Secp256k1};
 

--- a/client-common/src/transaction.rs
+++ b/client-common/src/transaction.rs
@@ -1,8 +1,11 @@
 use parity_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use chain_core::state::account::{DepositBondTx, UnbondTx, WithdrawUnbondedTx};
+use chain_core::state::account::{
+    DepositBondTx, StakedState, StakedStateOpWitness, UnbondTx, WithdrawUnbondedTx,
+};
 use chain_core::tx::data::{Tx, TxId};
+use chain_core::tx::witness::TxWitness;
 use chain_core::tx::TransactionId;
 
 /// Enum containing different types of transactions
@@ -26,6 +29,35 @@ impl TransactionId for Transaction {
             Transaction::DepositStakeTransaction(ref transaction) => transaction.id(),
             Transaction::UnbondStakeTransaction(ref transaction) => transaction.id(),
             Transaction::WithdrawUnbondedStakeTransaction(ref transaction) => transaction.id(),
+        }
+    }
+}
+
+/// Enum representing a signed transaction
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+pub enum SignedTransaction {
+    /// Transfer transaction
+    TransferTransaction(Tx, TxWitness),
+    /// Deposit stake transaction
+    DepositStakeTransaction(DepositBondTx, TxWitness),
+    /// Unbound stake transaction
+    UnbondStakeTransaction(UnbondTx, StakedStateOpWitness),
+    /// Withdraw unbounded stake transaction
+    ///
+    /// NOTE: `StakedState` is needed because this type is primarily for encryption of transaction where we need
+    /// `StakedState`.
+    WithdrawUnbondedStakeTransaction(WithdrawUnbondedTx, StakedState, StakedStateOpWitness),
+}
+
+impl TransactionId for SignedTransaction {
+    fn id(&self) -> TxId {
+        match self {
+            SignedTransaction::TransferTransaction(ref transaction, _) => transaction.id(),
+            SignedTransaction::DepositStakeTransaction(ref transaction, _) => transaction.id(),
+            SignedTransaction::UnbondStakeTransaction(ref transaction, _) => transaction.id(),
+            SignedTransaction::WithdrawUnbondedStakeTransaction(ref transaction, _, _) => {
+                transaction.id()
+            }
         }
     }
 }

--- a/client-index/src/cipher.rs
+++ b/client-index/src/cipher.rs
@@ -4,7 +4,8 @@ mod abci_transaction_cipher;
 pub use abci_transaction_cipher::AbciTransactionCipher;
 
 use chain_core::tx::data::TxId;
-use client_common::{PrivateKey, Result, Transaction};
+use chain_core::tx::TxAux;
+use client_common::{PrivateKey, Result, SignedTransaction, Transaction};
 
 /// Interface for encryption and decryption of transactions
 pub trait TransactionCipher: Send + Sync {
@@ -16,5 +17,6 @@ pub trait TransactionCipher: Send + Sync {
         private_key: &PrivateKey,
     ) -> Result<Vec<Transaction>>;
 
-    // TODO: Implement `encrypt()`
+    /// Encrypts a signed transaction
+    fn encrypt(&self, transaction: SignedTransaction) -> Result<TxAux>;
 }

--- a/client-index/src/cipher/abci_transaction_cipher.rs
+++ b/client-index/src/cipher/abci_transaction_cipher.rs
@@ -1,10 +1,13 @@
 use parity_codec::{Decode, Encode};
 
 use chain_core::tx::data::{txid_hash, TxId};
-use chain_core::tx::TxWithOutputs;
+use chain_core::tx::{TxAux, TxWithOutputs};
 use client_common::tendermint::Client;
-use client_common::{Error, ErrorKind, PrivateKey, Result, Transaction};
-use enclave_protocol::{DecryptionRequest, DecryptionRequestBody, DecryptionResponse};
+use client_common::{Error, ErrorKind, PrivateKey, Result, SignedTransaction, Transaction};
+use enclave_protocol::{
+    DecryptionRequest, DecryptionRequestBody, DecryptionResponse, EncryptionRequest,
+    EncryptionResponse,
+};
 
 use crate::TransactionCipher;
 
@@ -24,6 +27,19 @@ where
     #[inline]
     pub fn new(client: C) -> Self {
         Self { client }
+    }
+
+    fn encrypt_request(&self, encryption_request: EncryptionRequest) -> Result<TxAux> {
+        let response = self
+            .client
+            .query("mockencrypt", &encryption_request.encode())?
+            .bytes()?;
+
+        let encrypted_transaction = EncryptionResponse::decode(&mut response.as_slice())
+            .ok_or_else(|| Error::from(ErrorKind::DeserializationError))?
+            .tx;
+
+        Ok(encrypted_transaction)
     }
 }
 
@@ -67,6 +83,23 @@ where
 
         Ok(transactions)
     }
+
+    fn encrypt(&self, transaction: SignedTransaction) -> Result<TxAux> {
+        match transaction {
+            SignedTransaction::TransferTransaction(tx, witness) => {
+                self.encrypt_request(EncryptionRequest::TransferTx(tx, witness))
+            }
+            SignedTransaction::DepositStakeTransaction(tx, witness) => {
+                self.encrypt_request(EncryptionRequest::DepositStake(tx, witness))
+            }
+            SignedTransaction::UnbondStakeTransaction(tx, witness) => {
+                Ok(TxAux::UnbondStakeTx(tx, witness))
+            }
+            SignedTransaction::WithdrawUnbondedStakeTransaction(tx, state, witness) => {
+                self.encrypt_request(EncryptionRequest::WithdrawStake(tx, state, witness))
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -76,7 +109,22 @@ mod tests {
     use base64::encode;
 
     use chain_core::tx::data::Tx;
+    use chain_core::tx::witness::TxWitness;
+    use chain_core::tx::TxObfuscated;
     use client_common::tendermint::types::*;
+
+    fn transfer_transaction() -> TxAux {
+        TxAux::TransferTx {
+            txid: [0; 32],
+            inputs: Vec::new(),
+            no_of_outputs: 2,
+            payload: TxObfuscated {
+                key_from: 0,
+                nonce: [0; 12],
+                txpayload: Vec::new(),
+            },
+        }
+    }
 
     struct MockClient;
 
@@ -101,17 +149,34 @@ mod tests {
             unreachable!()
         }
 
-        fn query(&self, _path: &str, _data: &[u8]) -> Result<QueryResult> {
-            let response = DecryptionResponse {
-                txs: vec![TxWithOutputs::Transfer(Tx::new())],
-            }
-            .encode();
+        fn query(&self, path: &str, _data: &[u8]) -> Result<QueryResult> {
+            match path {
+                "mockdecrypt" => {
+                    let response = DecryptionResponse {
+                        txs: vec![TxWithOutputs::Transfer(Tx::new())],
+                    }
+                    .encode();
 
-            Ok(QueryResult {
-                response: Response {
-                    value: encode(&response),
-                },
-            })
+                    Ok(QueryResult {
+                        response: Response {
+                            value: encode(&response),
+                        },
+                    })
+                }
+                "mockencrypt" => {
+                    let response = EncryptionResponse {
+                        tx: transfer_transaction(),
+                    }
+                    .encode();
+
+                    Ok(QueryResult {
+                        response: Response {
+                            value: encode(&response),
+                        },
+                    })
+                }
+                _ => Err(ErrorKind::InvalidInput.into()),
+            }
         }
     }
 
@@ -126,5 +191,22 @@ mod tests {
                 .unwrap()
                 .len()
         )
+    }
+
+    #[test]
+    fn check_encryption() {
+        let cipher = AbciTransactionCipher::new(MockClient);
+
+        let encrypted_transaction = cipher
+            .encrypt(SignedTransaction::TransferTransaction(
+                Tx::default(),
+                TxWitness::default(),
+            ))
+            .unwrap();
+
+        match encrypted_transaction {
+            TxAux::TransferTx { no_of_outputs, .. } => assert_eq!(2, no_of_outputs),
+            _ => unreachable!(),
+        }
     }
 }

--- a/client-index/src/handler/default_block_handler.rs
+++ b/client-index/src/handler/default_block_handler.rs
@@ -112,10 +112,10 @@ mod tests {
     use chain_core::tx::data::attribute::TxAttributes;
     use chain_core::tx::data::output::TxOut;
     use chain_core::tx::data::{Tx, TxId};
-    use chain_core::tx::TransactionId;
+    use chain_core::tx::{TransactionId, TxAux};
     use chain_tx_filter::BlockFilter;
     use client_common::storage::MemoryStorage;
-    use client_common::Transaction;
+    use client_common::{SignedTransaction, Transaction};
 
     struct MockTransactionCipher;
 
@@ -129,6 +129,10 @@ mod tests {
             assert_eq!(transfer_transaction().id(), transaction_ids[0]);
             assert_eq!(unbond_transaction().id(), transaction_ids[1]);
             Ok(vec![transfer_transaction()])
+        }
+
+        fn encrypt(&self, _transaction: SignedTransaction) -> Result<TxAux> {
+            unreachable!()
         }
     }
 


### PR DESCRIPTION
Solution: Added `encrypt()` to interface and also a default implementation using mockencrypt in ABCI