### PR TITLE
Problem: (CRO-260) Network operations in RPC does not broadcast to Chain

### DIFF
--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use chain_core::common::{H256, HASH_SIZE_256};
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{StakedStateAddress, StakedStateOpAttributes};
+use chain_core::tx::data::access::{TxAccess, TxAccessPolicy};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
@@ -20,7 +21,7 @@ use client_common::{Error, ErrorKind, PublicKey, Result as CommonResult, Storage
 use client_core::{MultiSigWalletClient, WalletClient};
 use client_index::synchronizer::ManualSynchronizer;
 use client_index::BlockHandler;
-use client_network::network_ops::NetworkOpsClient;
+use client_network::NetworkOpsClient;
 
 use crate::server::{rpc_error_from_string, to_rpc_error};
 
@@ -53,7 +54,8 @@ pub trait ClientRpc: Send + Sync {
         &self,
         request: WalletRequest,
         to_address: String,
-        amount: u64,
+        amount: Coin,
+        view_keys: Vec<String>,
     ) -> Result<()>;
 
     #[rpc(name = "sync")]
@@ -113,20 +115,30 @@ pub trait ClientRpc: Send + Sync {
     #[rpc(name = "multi_sig_signature")]
     fn signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
 
-    #[rpc(name = "create_deposit_bonded_stake_transaction")]
-    fn create_deposit_bonded_stake_transaction(&self, request: ClientRequest) -> Result<String>;
-
-    #[rpc(name = "create_unbond_stake_transaction")]
-    fn create_unbond_stake_transaction(
+    #[rpc(name = "deposit_stake")]
+    fn deposit_stake_transaction(
         &self,
-        request: CreateUnbondStakeTransactionRequest,
-    ) -> Result<String>;
+        request: WalletRequest,
+        to_address: String,
+        inputs: Vec<TxoPointer>,
+    ) -> Result<()>;
 
-    #[rpc(name = "create_withdraw_all_unbonded_stake_transaction")]
-    fn create_withdraw_all_unbonded_stake_transaction(
+    #[rpc(name = "unbond_stake")]
+    fn unbond_stake_transaction(
         &self,
-        request: ClientRequest,
-    ) -> Result<String>;
+        request: WalletRequest,
+        staking_address: String,
+        amount: Coin,
+    ) -> Result<()>;
+
+    #[rpc(name = "withdraw_all_unbonded_stake")]
+    fn withdraw_all_unbonded_stake_transaction(
+        &self,
+        request: WalletRequest,
+        from_address: String,
+        to_address: String,
+        view_keys: Vec<String>,
+    ) -> Result<()>;
 }
 
 pub struct ClientRpcImpl<T, N, S, C, H>
@@ -213,26 +225,47 @@ where
     }
 
     fn list(&self) -> Result<Vec<String>> {
-        match self.client.wallets() {
-            Ok(wallets) => Ok(wallets),
-            Err(e) => Err(to_rpc_error(e)),
-        }
+        self.client.wallets().map_err(to_rpc_error)
     }
 
     fn send_to_address(
         &self,
         request: WalletRequest,
         to_address: String,
-        amount: u64,
+        amount: Coin,
+        view_keys: Vec<String>,
     ) -> Result<()> {
         self.sync(request.clone())?;
 
         let address = to_address
             .parse::<ExtendedAddr>()
             .map_err(|err| rpc_error_from_string(format!("{}", err)))?;
-        let coin = Coin::new(amount).map_err(|err| rpc_error_from_string(format!("{}", err)))?;
-        let tx_out = TxOut::new(address, coin);
-        let tx_attributes = TxAttributes::new(self.network_id);
+        let tx_out = TxOut::new(address, amount);
+
+        let view_keys = view_keys
+            .into_iter()
+            .map(|key| PublicKey::from_str(&key))
+            .collect::<CommonResult<Vec<PublicKey>>>()
+            .map_err(to_rpc_error)?;
+
+        let view_key = self
+            .client
+            .view_key(&request.name, &request.passphrase)
+            .map_err(to_rpc_error)?;
+
+        let mut access_policies = vec![TxAccessPolicy {
+            view_key: view_key.into(),
+            access: TxAccess::AllData,
+        }];
+
+        for key in view_keys.iter() {
+            access_policies.push(TxAccessPolicy {
+                view_key: key.into(),
+                access: TxAccess::AllData,
+            });
+        }
+
+        let attributes = TxAttributes::new_with_access(self.network_id, access_policies);
 
         let return_address = self
             .client
@@ -245,7 +278,7 @@ where
                 &request.name,
                 &request.passphrase,
                 vec![tx_out],
-                tx_attributes,
+                attributes,
                 None,
                 return_address,
             )
@@ -439,69 +472,115 @@ where
             .map_err(to_rpc_error)
     }
 
-    fn create_deposit_bonded_stake_transaction(&self, request: ClientRequest) -> Result<String> {
-        let utxo: Vec<TxoPointer> = vec![];
-        let addr: StakedStateAddress =
-            StakedStateAddress::from_str(request.address.as_str()).unwrap();
+    fn deposit_stake_transaction(
+        &self,
+        request: WalletRequest,
+        to_address: String,
+        inputs: Vec<TxoPointer>,
+    ) -> Result<()> {
+        let addr = StakedStateAddress::from_str(&to_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+        let attr = StakedStateOpAttributes::new(self.network_id);
+        let transaction = self
+            .ops_client
+            .create_deposit_bonded_stake_transaction(
+                &request.name,
+                &request.passphrase,
+                inputs,
+                addr,
+                attr,
+            )
+            .map_err(to_rpc_error)?;
 
-        let attr: StakedStateOpAttributes = StakedStateOpAttributes::new(self.network_id);
-        let result = self.ops_client.create_deposit_bonded_stake_transaction(
-            request.name.as_str(),
-            &request.passphrase,
-            utxo,
-            addr,
-            attr,
-        );
-
-        match result {
-            Ok(_a) => Ok("success".to_string()),
-            Err(_b) => Ok("fail".to_string()),
-        }
+        self.client
+            .broadcast_transaction(&transaction)
+            .map_err(to_rpc_error)
     }
 
-    fn create_unbond_stake_transaction(
+    fn unbond_stake_transaction(
         &self,
-        request: CreateUnbondStakeTransactionRequest,
-    ) -> Result<String> {
-        let value = Coin::from_str(request.amount.as_str()).unwrap();
-        let attr: StakedStateOpAttributes = StakedStateOpAttributes::new(self.network_id);
-        let addr: StakedStateAddress =
-            StakedStateAddress::from_str(request.address.as_str()).unwrap();
+        request: WalletRequest,
+        staking_address: String,
+        amount: Coin,
+    ) -> Result<()> {
+        let attr = StakedStateOpAttributes::new(self.network_id);
+        let addr = StakedStateAddress::from_str(&staking_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
 
-        let result = self.ops_client.create_unbond_stake_transaction(
-            request.name.as_str(),
-            &request.passphrase,
-            &addr,
-            value,
-            attr,
-        );
-        match result {
-            Ok(_a) => Ok("success".to_string()),
-            Err(_b) => Ok("fail".to_string()),
-        }
+        let transaction = self
+            .ops_client
+            .create_unbond_stake_transaction(
+                &request.name,
+                &request.passphrase,
+                &addr,
+                amount,
+                attr,
+            )
+            .map_err(to_rpc_error)?;
+
+        self.client
+            .broadcast_transaction(&transaction)
+            .map_err(to_rpc_error)
     }
 
-    fn create_withdraw_all_unbonded_stake_transaction(
+    fn withdraw_all_unbonded_stake_transaction(
         &self,
-        request: ClientRequest,
-    ) -> Result<String> {
-        let addr: StakedStateAddress =
-            StakedStateAddress::from_str(request.address.as_str()).unwrap();
-        let utxo: Vec<TxOut> = vec![];
-        let attr = TxAttributes::new(self.network_id);
+        request: WalletRequest,
+        from_address: String,
+        to_address: String,
+        view_keys: Vec<String>,
+    ) -> Result<()> {
+        let from_address = StakedStateAddress::from_str(&from_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+        let to_address = ExtendedAddr::from_str(&to_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+        let view_keys = view_keys
+            .into_iter()
+            .map(|key| PublicKey::from_str(&key))
+            .collect::<CommonResult<Vec<PublicKey>>>()
+            .map_err(to_rpc_error)?;
 
-        let result = self.ops_client.create_withdraw_unbonded_stake_transaction(
-            request.name.as_str(),
-            &request.passphrase,
-            &addr,
-            utxo,
-            attr,
-        );
+        let view_key = self
+            .client
+            .view_key(&request.name, &request.passphrase)
+            .map_err(to_rpc_error)?;
 
-        match result {
-            Ok(_a) => Ok("success".to_string()),
-            Err(_b) => Ok("fail".to_string()),
+        let mut access_policies = vec![TxAccessPolicy {
+            view_key: view_key.into(),
+            access: TxAccess::AllData,
+        }];
+
+        for key in view_keys.iter() {
+            access_policies.push(TxAccessPolicy {
+                view_key: key.into(),
+                access: TxAccess::AllData,
+            });
         }
+
+        let attributes = TxAttributes::new_with_access(self.network_id, access_policies);
+
+        let transaction = self
+            .ops_client
+            .create_withdraw_all_unbonded_stake_transaction(
+                &request.name,
+                &request.passphrase,
+                &from_address,
+                to_address,
+                attributes,
+            )
+            .map_err(to_rpc_error)?;
+
+        self.client
+            .broadcast_transaction(&transaction)
+            .map_err(to_rpc_error)
     }
 }
 
@@ -535,20 +614,6 @@ fn parse_public_key(public_key: String) -> CommonResult<PublicKey> {
 pub struct WalletRequest {
     name: String,
     passphrase: SecUtf8,
-}
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ClientRequest {
-    name: String,
-    passphrase: SecUtf8,
-    address: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CreateUnbondStakeTransactionRequest {
-    name: String,
-    passphrase: SecUtf8,
-    address: String,
-    amount: String, // u64 as String
 }
 
 #[cfg(test)]
@@ -858,43 +923,6 @@ pub mod tests {
         )
     }
 
-    #[test]
-    fn test_create_deposit_bonded_stake_transaction() {
-        let client_rpc = setup_wallet_rpc();
-        assert!(client_rpc
-            .create_deposit_bonded_stake_transaction(create_client_request(
-                "Default",
-                "123456",
-                "0x0e7c045110b8dbf29765047380898919c5cb56f4",
-            ))
-            .is_ok());
-    }
-
-    #[test]
-    fn test_create_unbond_stake_transaction() {
-        let client_rpc = setup_wallet_rpc();
-        assert!(client_rpc
-            .create_unbond_stake_transaction(create_unbonded_stake_client_request(
-                "Default",
-                "123456",
-                "0x0e7c045110b8dbf29765047380898919c5cb56f4",
-                "1",
-            ))
-            .is_ok());
-    }
-
-    #[test]
-    fn test_create_withdraw_all_unbonded_stake_transaction() {
-        let client_rpc = setup_wallet_rpc();
-        assert!(client_rpc
-            .create_withdraw_all_unbonded_stake_transaction(create_client_request(
-                "Default",
-                "123456",
-                "0x0e7c045110b8dbf29765047380898919c5cb56f4",
-            ))
-            .is_ok());
-    }
-
     fn make_test_wallet_client(storage: MemoryStorage) -> TestWalletClient {
         let signer = DefaultSigner::new(storage.clone());
         DefaultWalletClient::builder()
@@ -958,28 +986,6 @@ pub mod tests {
         WalletRequest {
             name: name.to_owned(),
             passphrase: SecUtf8::from(passphrase),
-        }
-    }
-
-    fn create_client_request(name: &str, passphrase: &str, address: &str) -> ClientRequest {
-        ClientRequest {
-            name: name.to_owned(),
-            passphrase: SecUtf8::from(passphrase),
-            address: address.to_owned(),
-        }
-    }
-
-    fn create_unbonded_stake_client_request(
-        name: &str,
-        passphrase: &str,
-        address: &str,
-        amount: &str,
-    ) -> CreateUnbondStakeTransactionRequest {
-        CreateUnbondStakeTransactionRequest {
-            name: name.to_owned(),
-            passphrase: SecUtf8::from(passphrase),
-            address: address.to_owned(),
-            amount: amount.to_owned(),
         }
     }
 }


### PR DESCRIPTION
Solution:
- Modified `client-rpc` code to correctly create network transactions and broadcast them
- Also, modified transfer transaction to use user provided `view_keys`