### PR TITLE
Problem: ClientRPC method name are not standardized

### DIFF
--- a/client-cli/src/command/address_command.rs
+++ b/client-cli/src/command/address_command.rs
@@ -73,7 +73,7 @@ impl AddressCommand {
                 Ok(())
             }
             AddressType::Transfer => {
-                let address = wallet_client.new_single_transfer_address(name, &passphrase)?;
+                let address = wallet_client.new_transfer_address(name, &passphrase)?;
                 success(&format!("New address: {}", address));
                 Ok(())
             }

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -232,7 +232,7 @@ fn new_transfer_transaction<T: WalletClient>(
     );
     let outputs = ask_outputs()?;
 
-    let return_address = wallet_client.new_single_transfer_address(name, &passphrase)?;
+    let return_address = wallet_client.new_transfer_address(name, &passphrase)?;
 
     wallet_client.create_transaction(name, &passphrase, outputs, attributes, None, return_address)
 }

--- a/client-core/src/signer/default_signer.rs
+++ b/client-core/src/signer/default_signer.rs
@@ -138,7 +138,7 @@ mod tests {
         ];
 
         let tree_address = wallet_client
-            .new_transfer_address(
+            .new_multisig_transfer_address(
                 name,
                 passphrase,
                 public_keys.clone(),
@@ -185,7 +185,7 @@ mod tests {
         ];
 
         let tree_address = wallet_client
-            .new_transfer_address(
+            .new_multisig_transfer_address(
                 name,
                 passphrase,
                 public_keys.clone(),

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -203,16 +203,16 @@ mod tests {
 
         let addresses = vec![
             wallet_client
-                .new_single_transfer_address(name, passphrase)
+                .new_transfer_address(name, passphrase)
                 .unwrap(),
             wallet_client
-                .new_single_transfer_address(name, passphrase)
+                .new_transfer_address(name, passphrase)
                 .unwrap(),
             wallet_client
-                .new_single_transfer_address(name, passphrase)
+                .new_transfer_address(name, passphrase)
                 .unwrap(),
             wallet_client
-                .new_transfer_address(
+                .new_multisig_transfer_address(
                     name,
                     passphrase,
                     public_keys.clone(),
@@ -244,7 +244,7 @@ mod tests {
         unspent_transactions.apply_all(&[Operation::Sort(Sorter::HighestValueFirst)]);
 
         let return_address = wallet_client
-            .new_single_transfer_address(name, passphrase)
+            .new_transfer_address(name, passphrase)
             .unwrap();
 
         let signer = DefaultSigner::new(storage);
@@ -255,7 +255,7 @@ mod tests {
 
         let outputs = vec![TxOut::new(
             wallet_client
-                .new_single_transfer_address(name, passphrase)
+                .new_transfer_address(name, passphrase)
                 .unwrap(),
             Coin::new(1000).unwrap(),
         )];
@@ -346,10 +346,10 @@ mod tests {
 
         let addresses = vec![
             wallet_client
-                .new_single_transfer_address(name, passphrase)
+                .new_transfer_address(name, passphrase)
                 .unwrap(),
             wallet_client
-                .new_transfer_address(
+                .new_multisig_transfer_address(
                     name,
                     passphrase,
                     public_keys.clone(),
@@ -373,7 +373,7 @@ mod tests {
         unspent_transactions.apply_all(&[Operation::Sort(Sorter::HighestValueFirst)]);
 
         let return_address = wallet_client
-            .new_single_transfer_address(name, passphrase)
+            .new_transfer_address(name, passphrase)
             .unwrap();
 
         let signer = DefaultSigner::new(storage);
@@ -384,7 +384,7 @@ mod tests {
 
         let outputs = vec![TxOut::new(
             wallet_client
-                .new_single_transfer_address(name, passphrase)
+                .new_transfer_address(name, passphrase)
                 .unwrap(),
             Coin::new(1700).unwrap(),
         )];

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -78,8 +78,7 @@ pub trait WalletClient: Send + Sync {
     fn new_staking_address(&self, name: &str, passphrase: &SecUtf8) -> Result<StakedStateAddress>;
 
     /// Generates a new 1-of-1 transfer address
-    fn new_transfer_address(&self, name: &str, passphrase: &SecUtf8)
-        -> Result<ExtendedAddr>;
+    fn new_transfer_address(&self, name: &str, passphrase: &SecUtf8) -> Result<ExtendedAddr>;
 
     /// Generates a new multi-sig transfer address for creating m-of-n transactions
     ///

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -78,7 +78,7 @@ pub trait WalletClient: Send + Sync {
     fn new_staking_address(&self, name: &str, passphrase: &SecUtf8) -> Result<StakedStateAddress>;
 
     /// Generates a new 1-of-1 transfer address
-    fn new_single_transfer_address(&self, name: &str, passphrase: &SecUtf8)
+    fn new_transfer_address(&self, name: &str, passphrase: &SecUtf8)
         -> Result<ExtendedAddr>;
 
     /// Generates a new multi-sig transfer address for creating m-of-n transactions
@@ -91,7 +91,7 @@ pub trait WalletClient: Send + Sync {
     /// `self_public_key`: Public key of current co-signer
     /// `m`: Number of required co-signers
     /// `n`: Total number of co-signers
-    fn new_transfer_address(
+    fn new_multisig_transfer_address(
         &self,
         name: &str,
         passphrase: &SecUtf8,

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -162,13 +162,16 @@ where
         )))
     }
 
-    fn new_transfer_address(
-        &self,
-        name: &str,
-        passphrase: &SecUtf8,
-    ) -> Result<ExtendedAddr> {
+    fn new_transfer_address(&self, name: &str, passphrase: &SecUtf8) -> Result<ExtendedAddr> {
         let public_key = self.new_public_key(name, passphrase)?;
-        self.new_multisig_transfer_address(name, passphrase, vec![public_key.clone()], public_key, 1, 1)
+        self.new_multisig_transfer_address(
+            name,
+            passphrase,
+            vec![public_key.clone()],
+            public_key,
+            1,
+            1,
+        )
     }
 
     fn new_multisig_transfer_address(

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -162,16 +162,16 @@ where
         )))
     }
 
-    fn new_single_transfer_address(
+    fn new_transfer_address(
         &self,
         name: &str,
         passphrase: &SecUtf8,
     ) -> Result<ExtendedAddr> {
         let public_key = self.new_public_key(name, passphrase)?;
-        self.new_transfer_address(name, passphrase, vec![public_key.clone()], public_key, 1, 1)
+        self.new_multisig_transfer_address(name, passphrase, vec![public_key.clone()], public_key, 1, 1)
     }
 
-    fn new_transfer_address(
+    fn new_multisig_transfer_address(
         &self,
         name: &str,
         passphrase: &SecUtf8,
@@ -748,7 +748,7 @@ mod tests {
         assert_eq!(1, wallet.wallets().unwrap().len());
 
         let address = wallet
-            .new_single_transfer_address("name", &SecUtf8::from("passphrase"))
+            .new_transfer_address("name", &SecUtf8::from("passphrase"))
             .expect("Unable to generate new address");
 
         let addresses = wallet
@@ -794,19 +794,19 @@ mod tests {
             .new_wallet("wallet_1", &SecUtf8::from("passphrase"))
             .unwrap();
         let addr_1 = wallet
-            .new_single_transfer_address("wallet_1", &SecUtf8::from("passphrase"))
+            .new_transfer_address("wallet_1", &SecUtf8::from("passphrase"))
             .unwrap();
         wallet
             .new_wallet("wallet_2", &SecUtf8::from("passphrase"))
             .unwrap();
         let addr_2 = wallet
-            .new_single_transfer_address("wallet_2", &SecUtf8::from("passphrase"))
+            .new_transfer_address("wallet_2", &SecUtf8::from("passphrase"))
             .unwrap();
         wallet
             .new_wallet("wallet_3", &SecUtf8::from("passphrase"))
             .unwrap();
         let addr_3 = wallet
-            .new_single_transfer_address("wallet_3", &SecUtf8::from("passphrase"))
+            .new_transfer_address("wallet_3", &SecUtf8::from("passphrase"))
             .unwrap();
 
         assert_eq!(
@@ -1125,7 +1125,7 @@ mod tests {
         ];
 
         let tree_address = wallet
-            .new_transfer_address(
+            .new_multisig_transfer_address(
                 name,
                 &passphrase,
                 public_keys.clone(),
@@ -1177,7 +1177,7 @@ mod tests {
         ];
 
         let multi_sig_address = wallet
-            .new_transfer_address(
+            .new_multisig_transfer_address(
                 name,
                 passphrase,
                 public_keys.clone(),
@@ -1287,7 +1287,7 @@ mod tests {
         ];
 
         let tree_address = wallet
-            .new_transfer_address(
+            .new_multisig_transfer_address(
                 name,
                 passphrase,
                 public_keys.clone(),

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -260,7 +260,7 @@ where
 
         if let Err(e) = self
             .client
-            .new_single_transfer_address(&request.name, &request.passphrase)
+            .new_transfer_address(&request.name, &request.passphrase)
         {
             Err(to_rpc_error(e))
         } else {
@@ -313,7 +313,7 @@ where
 
         let return_address = self
             .client
-            .new_single_transfer_address(&request.name, &request.passphrase)
+            .new_transfer_address(&request.name, &request.passphrase)
             .map_err(to_rpc_error)?;
 
         let transaction = self

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -53,7 +53,8 @@ pub trait ClientRpc: Send + Sync {
     ) -> Result<String>;
 
     #[rpc(name = "multiSig_nonceCommitment")]
-    fn multi_sig_nonce_commitment(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
+    fn multi_sig_nonce_commitment(&self, session_id: String, passphrase: SecUtf8)
+        -> Result<String>;
 
     #[rpc(name = "multiSig_addNonceCommitment")]
     fn multi_sig_add_nonce_commitment(
@@ -77,7 +78,11 @@ pub trait ClientRpc: Send + Sync {
     ) -> Result<()>;
 
     #[rpc(name = "multiSig_partialSignature")]
-    fn multi_sig_partial_signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
+    fn multi_sig_partial_signature(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+    ) -> Result<String>;
 
     #[rpc(name = "multiSig_addPartialSignature")]
     fn multi_sig_add_partial_signature(
@@ -388,7 +393,11 @@ where
             .map_err(to_rpc_error)
     }
 
-    fn multi_sig_nonce_commitment(&self, session_id: String, passphrase: SecUtf8) -> Result<String> {
+    fn multi_sig_nonce_commitment(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+    ) -> Result<String> {
         let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
 
         self.client
@@ -438,7 +447,11 @@ where
             .map_err(to_rpc_error)
     }
 
-    fn multi_sig_partial_signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String> {
+    fn multi_sig_partial_signature(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+    ) -> Result<String> {
         let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
 
         self.client

--- a/client-rpc/src/client_rpc.rs
+++ b/client-rpc/src/client_rpc.rs
@@ -55,7 +55,7 @@ pub trait ClientRpc: Send + Sync {
     #[rpc(name = "multiSig_nonceCommitment")]
     fn multi_sig_nonce_commitment(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
 
-    #[rpc(name = "multi_sig_add_nonce_commitment")]
+    #[rpc(name = "multiSig_addNonceCommitment")]
     fn multi_sig_add_nonce_commitment(
         &self,
         session_id: String,
@@ -76,7 +76,7 @@ pub trait ClientRpc: Send + Sync {
         public_key: String,
     ) -> Result<()>;
 
-    #[rpc(name = "multiSig_partialSign")]
+    #[rpc(name = "multiSig_partialSignature")]
     fn multi_sig_partial_signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
 
     #[rpc(name = "multiSig_addPartialSignature")]


### PR DESCRIPTION
Solution: Standardized RPC method name

- RPCs are catogerized into `sync_*`, `wallet_*`, `stagking_*` and `multiSig_*`
- use camelcase to name RPC calls
- Renamed create single transfer address to `new_transfer_address`, create multisig address to `new_multisig_transfer_address` because I think this is more mentally straightforward.

