### PR TITLE
Problem: (CRO-276) Unnecessary Encode and Decode impls of types supported by parity_scale_codec

### DIFF
--- a/chain-core/src/lib.rs
+++ b/chain-core/src/lib.rs
@@ -21,8 +21,7 @@ pub mod tx;
 
 use blake2::Blake2s;
 use common::{hash256, MerkleTree, Timespec, H256};
-use init::coin::Coin;
-use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use parity_scale_codec::{Decode, Encode};
 use state::RewardsPoolState;
 use tx::fee::Fee;
 
@@ -45,7 +44,7 @@ pub fn compute_app_hash(
 }
 
 /// External information needed for TX validation
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Encode, Decode)]
 pub struct ChainInfo {
     /// minimal fee computed for the transaction
     pub min_fee_computed: Fee,
@@ -55,28 +54,4 @@ pub struct ChainInfo {
     pub previous_block_time: Timespec,
     /// how much time is required to wait until stake state's unbonded amount can be withdrawn
     pub unbonding_period: u32,
-}
-
-impl Encode for ChainInfo {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        self.min_fee_computed.to_coin().encode_to(dest);
-        dest.push_byte(self.chain_hex_id);
-        self.previous_block_time.encode_to(dest);
-        self.unbonding_period.encode_to(dest);
-    }
-}
-
-impl Decode for ChainInfo {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-        let fee = Coin::decode(input)?;
-        let chain_hex_id: u8 = input.read_byte()?;
-        let previous_block_time = Timespec::decode(input)?;
-        let unbonding_period = u32::decode(input)?;
-        Ok(ChainInfo {
-            min_fee_computed: Fee::new(fee),
-            chain_hex_id,
-            previous_block_time,
-            unbonding_period,
-        })
-    }
 }

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -171,7 +171,7 @@ impl StakedState {
 }
 
 /// attributes in StakedState-related transactions
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StakedStateOpAttributes {
     pub chain_hex_id: u8,
@@ -181,28 +181,6 @@ pub struct StakedStateOpAttributes {
 impl StakedStateOpAttributes {
     pub fn new(chain_hex_id: u8) -> Self {
         StakedStateOpAttributes { chain_hex_id }
-    }
-}
-
-impl Encode for StakedStateOpAttributes {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        dest.push_byte(0);
-        dest.push_byte(1);
-        dest.push_byte(self.chain_hex_id);
-    }
-}
-
-impl Decode for StakedStateOpAttributes {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-        let tag = input.read_byte()?;
-        let constructor_len = input.read_byte()?;
-        match (tag, constructor_len) {
-            (0, 1) => {
-                let chain_hex_id: u8 = input.read_byte()?;
-                Ok(StakedStateOpAttributes { chain_hex_id })
-            }
-            _ => Err(Error::from("Invalid tag and length")),
-        }
     }
 }
 

--- a/chain-core/src/tx/data/attribute.rs
+++ b/chain-core/src/tx/data/attribute.rs
@@ -1,4 +1,4 @@
-use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::prelude::v1::Vec;
@@ -6,36 +6,12 @@ use std::prelude::v1::Vec;
 use crate::tx::data::access::TxAccessPolicy;
 
 /// Tx extra metadata, e.g. network ID
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxAttributes {
     pub chain_hex_id: u8,
     pub allowed_view: Vec<TxAccessPolicy>,
     // TODO: other attributes, e.g. versioning info
-}
-
-impl Encode for TxAttributes {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        dest.push_byte(0);
-        dest.push_byte(2);
-        dest.push_byte(self.chain_hex_id);
-        self.allowed_view.encode_to(dest);
-    }
-}
-
-impl Decode for TxAttributes {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-        let tag = input.read_byte()?;
-        let constructor_len = input.read_byte()?;
-        match (tag, constructor_len) {
-            (0, 2) => {
-                let chain_hex_id: u8 = input.read_byte()?;
-                let allowed_view: Vec<TxAccessPolicy> = Vec::decode(input)?;
-                Ok(TxAttributes::new_with_access(chain_hex_id, allowed_view))
-            }
-            _ => Err(Error::from("Invalid tag and length")),
-        }
-    }
 }
 
 impl TxAttributes {

--- a/chain-core/src/tx/fee/mod.rs
+++ b/chain-core/src/tx/fee/mod.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use std::{error, fmt};
 
 /// A fee value that represent either a fee to pay, or a fee paid.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Encode, Decode)]
 pub struct Fee(Coin);
 
 impl Fee {

--- a/chain-core/src/tx/witness/tree.rs
+++ b/chain-core/src/tx/witness/tree.rs
@@ -1,13 +1,13 @@
 use std::cmp::Ordering;
 use std::fmt;
 
-use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use parity_scale_codec::{Decode, Encode};
 
 use crate::common::{H264, H512};
 
 // there was no [T; 33] / [u8; 33] impl in parity-codec :/
 // TODO: Do we remove `RawPubKey` and directly use [u8; 33] as `Encode` and `Decode` impls are now available?
-#[derive(Clone)]
+#[derive(Clone, Encode, Decode)]
 pub struct RawPubkey(H264);
 
 #[cfg(feature = "serde")]
@@ -96,24 +96,6 @@ impl RawPubkey {
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
-    }
-}
-
-impl Encode for RawPubkey {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        for item in self.0.iter() {
-            dest.push_byte(*item);
-        }
-    }
-}
-
-impl Decode for RawPubkey {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-        let mut r = [0u8; 33];
-        for item in (&mut r).iter_mut() {
-            *item = input.read_byte()?;
-        }
-        Ok(RawPubkey(r))
     }
 }
 


### PR DESCRIPTION
Solution: Removed manual implementation and auto derived `Encode` and `Decode`