### PR TITLE
Problem: (CRO-256) Client CLI does not exit with code > 0 when error occurs

### DIFF
--- a/client-cli/src/main.rs
+++ b/client-cli/src/main.rs
@@ -23,6 +23,8 @@ fn main() {
             }
             Err(_) => error(&format!("Error: {}", err)),
         }
+
+        std::process::exit(1);
     }
 }
 


### PR DESCRIPTION
Solution: Added exit code 1 in error scenarios