### PR TITLE
(CRO-271) Refactor ClientRPC to separate into different modules

### DIFF
--- a/client-rpc/src/main.rs
+++ b/client-rpc/src/main.rs
@@ -1,4 +1,3 @@
-mod client_rpc;
 mod rpc;
 mod server;
 

--- a/client-rpc/src/main.rs
+++ b/client-rpc/src/main.rs
@@ -1,4 +1,5 @@
 mod client_rpc;
+mod rpc;
 mod server;
 
 use structopt::StructOpt;

--- a/client-rpc/src/rpc.rs
+++ b/client-rpc/src/rpc.rs
@@ -1,1 +1,4 @@
+pub mod multisig_rpc;
+pub mod staking_rpc;
 pub mod sync_rpc;
+pub mod wallet_rpc;

--- a/client-rpc/src/rpc.rs
+++ b/client-rpc/src/rpc.rs
@@ -1,0 +1,1 @@
+pub mod sync_rpc;

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -1,0 +1,224 @@
+use failure::ResultExt;
+use hex::{decode, encode};
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+use secstr::SecUtf8;
+
+use chain_core::common::{H256, HASH_SIZE_256};
+use client_common::{Error, ErrorKind, PublicKey, Result as CommonResult};
+use client_core::{MultiSigWalletClient, WalletClient};
+
+use crate::server::{to_rpc_error, WalletRequest};
+
+#[rpc]
+pub trait MultiSigRpc: Send + Sync {
+    #[rpc(name = "multiSig_newSession")]
+    fn new_session(
+        &self,
+        request: WalletRequest,
+        message: String,
+        signer_public_keys: Vec<String>,
+        self_public_key: String,
+    ) -> Result<String>;
+
+    #[rpc(name = "multiSig_nonceCommitment")]
+    fn nonce_commitment(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
+
+    #[rpc(name = "multiSig_addNonceCommitment")]
+    fn add_nonce_commitment(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+        nonce_commitment: String,
+        public_key: String,
+    ) -> Result<()>;
+
+    #[rpc(name = "multiSig_nonce")]
+    fn nonce(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
+
+    #[rpc(name = "multiSig_addNonce")]
+    fn add_nonce(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+        nonce: String,
+        public_key: String,
+    ) -> Result<()>;
+
+    #[rpc(name = "multiSig_partialSign")]
+    fn partial_signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
+
+    #[rpc(name = "multiSig_addPartialSignature")]
+    fn add_partial_signature(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+        partial_signature: String,
+        public_key: String,
+    ) -> Result<()>;
+
+    #[rpc(name = "multiSig_signature")]
+    fn signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String>;
+}
+
+pub struct MultiSigRpcImpl<T>
+where
+    T: WalletClient,
+{
+    client: T,
+}
+
+impl<T> MultiSigRpcImpl<T>
+where
+    T: WalletClient,
+{
+    pub fn new(
+        client: T,
+    ) -> Self {
+        MultiSigRpcImpl {
+            client,
+        }
+    }
+}
+
+impl<T> MultiSigRpc for MultiSigRpcImpl<T>
+where
+    T: WalletClient + MultiSigWalletClient + 'static,
+{
+    fn new_session(
+        &self,
+        request: WalletRequest,
+        message: String,
+        signer_public_keys: Vec<String>,
+        self_public_key: String,
+    ) -> Result<String> {
+        let message = parse_hash_256(message).map_err(to_rpc_error)?;
+        let signer_public_keys = signer_public_keys
+            .into_iter()
+            .map(parse_public_key)
+            .collect::<CommonResult<Vec<PublicKey>>>()
+            .map_err(to_rpc_error)?;
+        let self_public_key = parse_public_key(self_public_key).map_err(to_rpc_error)?;
+
+        self.client
+            .new_multi_sig_session(
+                &request.name,
+                &request.passphrase,
+                message,
+                signer_public_keys,
+                self_public_key,
+            )
+            .map(serialize_hash_256)
+            .map_err(to_rpc_error)
+    }
+
+    fn nonce_commitment(&self, session_id: String, passphrase: SecUtf8) -> Result<String> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+
+        self.client
+            .nonce_commitment(&session_id, &passphrase)
+            .map(serialize_hash_256)
+            .map_err(to_rpc_error)
+    }
+
+    fn add_nonce_commitment(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+        nonce_commitment: String,
+        public_key: String,
+    ) -> Result<()> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+        let nonce_commitment = parse_hash_256(nonce_commitment).map_err(to_rpc_error)?;
+        let public_key = parse_public_key(public_key).map_err(to_rpc_error)?;
+
+        self.client
+            .add_nonce_commitment(&session_id, &passphrase, nonce_commitment, &public_key)
+            .map_err(to_rpc_error)
+    }
+
+    fn nonce(&self, session_id: String, passphrase: SecUtf8) -> Result<String> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+
+        self.client
+            .nonce(&session_id, &passphrase)
+            .map(serialize_public_key)
+            .map_err(to_rpc_error)
+    }
+
+    fn add_nonce(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+        nonce: String,
+        public_key: String,
+    ) -> Result<()> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+        let nonce = parse_public_key(nonce).map_err(to_rpc_error)?;
+        let public_key = parse_public_key(public_key).map_err(to_rpc_error)?;
+
+        self.client
+            .add_nonce(&session_id, &passphrase, &nonce, &public_key)
+            .map_err(to_rpc_error)
+    }
+
+    fn partial_signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+
+        self.client
+            .partial_signature(&session_id, &passphrase)
+            .map(serialize_hash_256)
+            .map_err(to_rpc_error)
+    }
+
+    fn add_partial_signature(
+        &self,
+        session_id: String,
+        passphrase: SecUtf8,
+        partial_signature: String,
+        public_key: String,
+    ) -> Result<()> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+        let partial_signature = parse_hash_256(partial_signature).map_err(to_rpc_error)?;
+        let public_key = parse_public_key(public_key).map_err(to_rpc_error)?;
+
+        self.client
+            .add_partial_signature(&session_id, &passphrase, partial_signature, &public_key)
+            .map_err(to_rpc_error)
+    }
+
+    fn signature(&self, session_id: String, passphrase: SecUtf8) -> Result<String> {
+        let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
+
+        self.client
+            .signature(&session_id, &passphrase)
+            .map(|sig| sig.to_string())
+            .map_err(to_rpc_error)
+    }
+}
+
+fn serialize_hash_256(hash: H256) -> String {
+    encode(&hash)
+}
+
+fn parse_hash_256(hash: String) -> CommonResult<H256> {
+    let array = decode(hash).context(ErrorKind::DeserializationError)?;
+
+    if array.len() != HASH_SIZE_256 {
+        return Err(Error::from(ErrorKind::DeserializationError));
+    }
+
+    let mut new_hash: H256 = [0; HASH_SIZE_256];
+    new_hash.copy_from_slice(&array);
+
+    Ok(new_hash)
+}
+
+fn serialize_public_key(public_key: PublicKey) -> String {
+    encode(&public_key.serialize())
+}
+
+fn parse_public_key(public_key: String) -> CommonResult<PublicKey> {
+    let array = decode(public_key).context(ErrorKind::DeserializationError)?;
+    PublicKey::deserialize_from(&array)
+}

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -1,0 +1,190 @@
+use std::str::FromStr;
+
+use failure::ResultExt;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+
+use chain_core::init::coin::Coin;
+use chain_core::state::account::{StakedStateAddress, StakedStateOpAttributes};
+use chain_core::tx::data::access::{TxAccess, TxAccessPolicy};
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::input::TxoPointer;
+use client_common::{Error, ErrorKind, PublicKey, Result as CommonResult};
+use client_core::{MultiSigWalletClient, WalletClient};
+use client_network::NetworkOpsClient;
+
+use crate::server::{to_rpc_error, WalletRequest};
+
+#[rpc]
+pub trait StakingRpc: Send + Sync {
+    #[rpc(name = "staking_depositStake")]
+    fn staking_deposit_stake(
+        &self,
+        request: WalletRequest,
+        to_address: String,
+        inputs: Vec<TxoPointer>,
+    ) -> Result<()>;
+
+    #[rpc(name = "staking_unbondStake")]
+    fn staking_unbond_stake(
+        &self,
+        request: WalletRequest,
+        staking_address: String,
+        amount: Coin,
+    ) -> Result<()>;
+
+    #[rpc(name = "staking_withdrawAllUnbondedStake")]
+    fn staking_withdraw_all_unbonded_stake(
+        &self,
+        request: WalletRequest,
+        from_address: String,
+        to_address: String,
+        view_keys: Vec<String>,
+    ) -> Result<()>;
+}
+
+pub struct StakingRpcImpl<T, N>
+where
+    T: WalletClient,
+    N: NetworkOpsClient,
+{
+    client: T,
+    ops_client: N,
+    network_id: u8,
+}
+
+impl<T, N> StakingRpcImpl<T, N>
+where
+    T: WalletClient,
+    N: NetworkOpsClient,
+{
+    pub fn new(
+        client: T,
+        ops_client: N,
+        network_id: u8,
+    ) -> Self {
+        StakingRpcImpl {
+            client,
+            ops_client,
+            network_id,
+        }
+    }
+}
+
+impl<T, N> StakingRpc for StakingRpcImpl<T, N>
+where
+    T: WalletClient + MultiSigWalletClient + 'static,
+    N: NetworkOpsClient + 'static,
+{
+    fn staking_deposit_stake(
+        &self,
+        request: WalletRequest,
+        to_address: String,
+        inputs: Vec<TxoPointer>,
+    ) -> Result<()> {
+        let addr = StakedStateAddress::from_str(&to_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+        let attr = StakedStateOpAttributes::new(self.network_id);
+        let transaction = self
+            .ops_client
+            .create_deposit_bonded_stake_transaction(
+                &request.name,
+                &request.passphrase,
+                inputs,
+                addr,
+                attr,
+            )
+            .map_err(to_rpc_error)?;
+
+        self.client
+            .broadcast_transaction(&transaction)
+            .map_err(to_rpc_error)
+    }
+
+    fn staking_unbond_stake(
+        &self,
+        request: WalletRequest,
+        staking_address: String,
+        amount: Coin,
+    ) -> Result<()> {
+        let attr = StakedStateOpAttributes::new(self.network_id);
+        let addr = StakedStateAddress::from_str(&staking_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+
+        let transaction = self
+            .ops_client
+            .create_unbond_stake_transaction(
+                &request.name,
+                &request.passphrase,
+                &addr,
+                amount,
+                attr,
+            )
+            .map_err(to_rpc_error)?;
+
+        self.client
+            .broadcast_transaction(&transaction)
+            .map_err(to_rpc_error)
+    }
+
+    fn staking_withdraw_all_unbonded_stake(
+        &self,
+        request: WalletRequest,
+        from_address: String,
+        to_address: String,
+        view_keys: Vec<String>,
+    ) -> Result<()> {
+        let from_address = StakedStateAddress::from_str(&from_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+        let to_address = ExtendedAddr::from_str(&to_address)
+            .context(ErrorKind::DeserializationError)
+            .map_err(Into::<Error>::into)
+            .map_err(to_rpc_error)?;
+        let view_keys = view_keys
+            .into_iter()
+            .map(|key| PublicKey::from_str(&key))
+            .collect::<CommonResult<Vec<PublicKey>>>()
+            .map_err(to_rpc_error)?;
+
+        let view_key = self
+            .client
+            .view_key(&request.name, &request.passphrase)
+            .map_err(to_rpc_error)?;
+
+        let mut access_policies = vec![TxAccessPolicy {
+            view_key: view_key.into(),
+            access: TxAccess::AllData,
+        }];
+
+        for key in view_keys.iter() {
+            access_policies.push(TxAccessPolicy {
+                view_key: key.into(),
+                access: TxAccess::AllData,
+            });
+        }
+
+        let attributes = TxAttributes::new_with_access(self.network_id, access_policies);
+
+        let transaction = self
+            .ops_client
+            .create_withdraw_all_unbonded_stake_transaction(
+                &request.name,
+                &request.passphrase,
+                &from_address,
+                to_address,
+                attributes,
+            )
+            .map_err(to_rpc_error)?;
+
+        self.client
+            .broadcast_transaction(&transaction)
+            .map_err(to_rpc_error)
+    }
+}

--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -1,0 +1,93 @@
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+
+use chain_core::state::account::StakedStateAddress;
+use client_common::{Error, ErrorKind, PrivateKey, PublicKey, Storage};
+use client_common::tendermint::Client;
+use client_core::{MultiSigWalletClient, WalletClient};
+use client_index::synchronizer::ManualSynchronizer;
+use client_index::BlockHandler;
+
+use crate::server::{to_rpc_error, WalletRequest};
+
+#[rpc]
+pub trait SyncRpc: Send + Sync {
+    #[rpc(name = "sync")]
+    fn sync(&self, request: WalletRequest) -> Result<()>;
+
+    #[rpc(name = "sync_all")]
+    fn sync_all(&self, request: WalletRequest) -> Result<()>;
+}
+
+pub struct SyncRpcImpl<T, S, C, H>
+where
+    T: WalletClient,
+    S: Storage,
+    C: Client,
+    H: BlockHandler,
+{
+    client: T,
+    synchronizer: ManualSynchronizer<S, C, H>,
+}
+
+impl<T, S, C, H> SyncRpc for SyncRpcImpl<T, S, C, H>
+where
+    T: WalletClient + MultiSigWalletClient + 'static,
+    S: Storage + 'static,
+    C: Client + 'static,
+    H: BlockHandler + 'static,
+{
+    fn sync(&self, request: WalletRequest) -> Result<()> {
+        let (view_key, private_key, staking_addresses) = self.prepare_synchronized_parameters(&request)?;
+
+        self.synchronizer
+            .sync(&staking_addresses, &view_key, &private_key)
+            .map_err(to_rpc_error)
+    }
+
+    fn sync_all(&self, request: WalletRequest) -> Result<()> {
+        let (view_key, private_key, staking_addresses) = self.prepare_synchronized_parameters(&request)?;
+
+        self.synchronizer
+            .sync_all(&staking_addresses, &view_key, &private_key)
+            .map_err(to_rpc_error)
+    }
+}
+
+impl<T, S, C, H> SyncRpcImpl<T, S, C, H>
+where
+    T: WalletClient,
+    S: Storage,
+    C: Client,
+    H: BlockHandler,
+{
+    pub fn new(
+        client: T,
+        synchronizer: ManualSynchronizer<S, C, H>,
+    ) -> Self {
+        SyncRpcImpl {
+            client,
+            synchronizer,
+        }
+    }
+
+    fn prepare_synchronized_parameters(&self, request: &WalletRequest) -> Result<(PublicKey, PrivateKey, Vec<StakedStateAddress>)> {
+        let view_key = self
+            .client
+            .view_key(&request.name, &request.passphrase)
+            .map_err(to_rpc_error)?;
+        let private_key = self
+            .client
+            .private_key(&request.passphrase, &view_key)
+            .map_err(to_rpc_error)?
+            .ok_or_else(|| Error::from(ErrorKind::WalletNotFound))
+            .map_err(to_rpc_error)?;
+
+        let staking_addresses = self
+            .client
+            .staking_addresses(&request.name, &request.passphrase)
+            .map_err(to_rpc_error)?;
+
+        Ok((view_key, private_key, staking_addresses))
+    }
+}


### PR DESCRIPTION
Extract RPC calls into different module
- `multisig`
- `sync`
- `staking`
- `wallet`