### PR TITLE
Problem: Encoded types not using size_hint

### DIFF
--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -342,6 +342,12 @@ impl Encode for StakedStateOpWitness {
             }
         }
     }
+
+    fn size_hint(&self) -> usize {
+        match self {
+            StakedStateOpWitness::BasicRedeem(_) => 66,
+        }
+    }
 }
 
 impl Decode for StakedStateOpWitness {

--- a/chain-core/src/tx/data/access.rs
+++ b/chain-core/src/tx/data/access.rs
@@ -36,6 +36,10 @@ impl Encode for TxAccessPolicy {
         self.view_key.serialize().encode_to(dest);
         self.access.encode_to(dest);
     }
+
+    fn size_hint(&self) -> usize {
+        33 + self.access.size_hint()
+    }
 }
 
 impl Decode for TxAccessPolicy {

--- a/chain-core/src/tx/witness/mod.rs
+++ b/chain-core/src/tx/witness/mod.rs
@@ -99,6 +99,12 @@ impl Encode for TxInWitness {
             }
         }
     }
+
+    fn size_hint(&self) -> usize {
+        match self {
+            TxInWitness::TreeSig(_, ref proof) => 65 + proof.size_hint(),
+        }
+    }
 }
 
 impl Decode for TxInWitness {

--- a/client-common/src/balance/transaction_change.rs
+++ b/client-common/src/balance/transaction_change.rs
@@ -36,6 +36,14 @@ impl Encode for TransactionChange {
         self.block_height.encode_to(dest);
         self.block_time.to_rfc3339().encode_to(dest);
     }
+
+    fn size_hint(&self) -> usize {
+        self.transaction_id.size_hint()
+            + self.address.size_hint()
+            + self.balance_change.size_hint()
+            + self.block_height.size_hint()
+            + self.block_time.to_rfc3339().as_bytes().size_hint()
+    }
 }
 
 impl Decode for TransactionChange {

--- a/client-common/src/key/private_key.rs
+++ b/client-common/src/key/private_key.rs
@@ -54,6 +54,10 @@ impl Encode for PrivateKey {
     fn encode_to<W: Output>(&self, dest: &mut W) {
         self.serialize().encode_to(dest)
     }
+
+    fn size_hint(&self) -> usize {
+        33
+    }
 }
 
 impl Decode for PrivateKey {

--- a/client-common/src/key/public_key.rs
+++ b/client-common/src/key/public_key.rs
@@ -104,6 +104,10 @@ impl Encode for PublicKey {
     fn encode_to<W: Output>(&self, dest: &mut W) {
         self.serialize().encode_to(dest)
     }
+
+    fn size_hint(&self) -> usize {
+        66
+    }
 }
 
 impl Decode for PublicKey {


### PR DESCRIPTION
Solution: Added `size_hint` implementation in all manual implementations of `Encode`