### PR TITLE
Problem: tx decryption done using a mock abci query (CRO-274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ name = "backtrace-sys"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -205,6 +205,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byte-slice-cast"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -278,7 +283,7 @@ dependencies = [
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -298,7 +303,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -312,7 +317,7 @@ dependencies = [
  "chain-core 0.1.0",
  "ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
 ]
 
 [[package]]
@@ -320,7 +325,7 @@ name = "chain-tx-validation"
 version = "0.1.0"
 dependencies = [
  "chain-core 0.1.0",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
 ]
 
 [[package]]
@@ -383,7 +388,7 @@ dependencies = [
  "miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -406,7 +411,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -416,6 +421,7 @@ name = "client-index"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.1.0",
  "chain-tx-filter 0.1.0",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -423,8 +429,14 @@ dependencies = [
  "enclave-protocol 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yasna 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -441,7 +453,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -491,7 +503,7 @@ name = "cmake"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -721,6 +733,7 @@ dependencies = [
  "chain-core 0.1.0",
  "chain-tx-validation 0.1.0",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)",
 ]
 
 [[package]]
@@ -1089,6 +1102,14 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "js-sys"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,7 +1277,7 @@ name = "libloading"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1409,6 +1430,24 @@ dependencies = [
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-integer"
@@ -1988,6 +2027,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rlp"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2075,18 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustls"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2063,11 +2128,20 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "secp256k1zkp"
 version = "0.13.0"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9#ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212#29991f23eaaa55ec86491dc78e7455f8f1fe3212"
 dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_tstd 1.0.8 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.8)",
@@ -2239,6 +2313,11 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sourcefile"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2714,6 +2793,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "untrusted"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,6 +2811,14 @@ dependencies = [
 name = "utf8-ranges"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uuid"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vec_map"
@@ -2756,6 +2848,98 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasm-bindgen-webidl"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "weedle"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2817,6 +3001,16 @@ dependencies = [
 name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "yasna"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "zeroize"
@@ -2887,13 +3081,14 @@ dependencies = [
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum bstr 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "59604ece62a407dc9164732e5adea02467898954c3a5811fd2dc140af14ef15b"
+"checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
 "checksum byte-slice-cast 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7cbcbf18128ec71d8d4a0d054461ec59fff5b75b7d10a4c9b7c7cb1a379c3e77"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
-"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
+"checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
@@ -2962,6 +3157,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
 "checksum jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "436f3455a8a4e9c7b14de9f1206198ee5d0bdc2db1b560339d2141093d7dd389"
 "checksum jsonrpc-client-transports 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bb6fd4acf48d1f17eb7b0e27ab7043c16f063ad0aa7020ec92a431648286c2f"
 "checksum jsonrpc-core 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d379861584fe4e3678f6ae9ee60b41726df2989578c1dc0f90190dfc92dbe0"
@@ -2995,6 +3191,8 @@ dependencies = [
 "checksum miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e37d77fff73f19e198036d3ca2bdbf8d4bca650daeda979bae0fdd31fce11d9"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
@@ -3057,11 +3255,13 @@ dependencies = [
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum ring 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8cb66ed257d923d56a0c1327332543d887be3c8e8288d0e6187a5d90f9a9533c"
 "checksum rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0d56c1450bfbef1181fdeb78b902dc1d23178de77c23d705317508e03d1b7c"
 "checksum rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37473170aedbe66ffa3ad3726939ba677d83c646ad4fd99e5b4bc38712f45ec"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
@@ -3069,7 +3269,8 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-"checksum secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9)" = "<none>"
+"checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+"checksum secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=29991f23eaaa55ec86491dc78e7455f8f1fe3212)" = "<none>"
 "checksum secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb003d53cef244a97516226b01155057c7fa6eb52914933c32f6c98a84182188"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -3090,6 +3291,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum sled 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a780266d241e270e52cab0010e11aecfc6d52e33aa98e52eb9792023abd23aa"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum starling 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be9c2e6b47cf3a084051585cd5e4258c0c039c13e62ccafefc5d23c1a8b98832"
@@ -3144,12 +3346,23 @@ dependencies = [
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
+"checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7904a7e2bb3cdf0cf5e783f44204a85a37a93151738fa349f06680f59a98b45"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
+"checksum wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
+"checksum wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"
+"checksum wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f07d50f74bf7a738304f6b8157f4a581e1512cd9e9cdb5baad8c31bbe8ffd81d"
+"checksum wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "95cf8fe77e45ba5f91bc8f3da0c3aa5d464b3d8ed85d84f4d4c7cc106436b1d7"
+"checksum wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c2d4d4756b2e46d3a5422e06277d02e4d3e1d62d138b76a4c681e925743623"
+"checksum wasm-bindgen-webidl 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "24e47859b4eba3d3b9a5c2c299f9d6f8d0b613671315f6f0c5c7f835e524b36a"
+"checksum web-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "86d515d2f713d3a6ab198031d2181b7540f8e319e4637ec2d4a41a208335ef29"
+"checksum webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4"
+"checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
@@ -3159,6 +3372,7 @@ dependencies = [
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+"checksum yasna 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a563d10ead87e2d798e357d44f40f495ad70bcee4d5c0d3f77a5b1b7376645d9"
 "checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"
 "checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 "checksum zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afd1469e4bbca3b96606d26ba6e9bd6d3aed3b1299c82b92ec94377d22d78dbc"

--- a/NOTICE
+++ b/NOTICE
@@ -12,3 +12,8 @@ This project contains portions of code derived from the following libraries:
  * Copyright: Copyright (c) 2018 ETCDEV
  * License: Apache License 2.0
  * Repository: https://github.com/ETCDEVTeam/emerald-rs
+
+* MesaTEE
+ * Copyright: Copyright (c) 2019 Baidu, Inc.
+ * License: Apache License 2.0
+ * Repository: https://github.com/mesalock-linux/mesatee

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -6,6 +6,10 @@ description = "Pre-alpha version prototype of Crypto.com Chain node (Tendermint 
 readme = "README.md"
 edition = "2018"
 
+[features]
+mock-enc-dec = []
+default = ["mock-enc-dec"]
+
 [dependencies]
 abci = "0.6"
 chain-core = { path = "../chain-core" }
@@ -27,7 +31,7 @@ hex = "0.3"
 protobuf = "2.7.0"
 integer-encoding = "1.0.7"
 clap = { features = ["yaml"], version = "2.33.0" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["recovery", "endomorphism"] }
 blake2 = "0.8"
 parity-scale-codec = { features = ["derive"], version = "1.0" }
 zmq = "0.9"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -14,7 +14,7 @@ default = ["serde", "bech32"]
 digest = "0.8"
 tiny-keccak = { version = "1.5.0", default-features = false, features = ["keccak"] }
 hex = "0.3"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["recovery", "endomorphism", "serde"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["recovery", "endomorphism", "serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = "0.8"
 serde_json = "1.0"

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 chain-core = { path = "../chain-core" }
 parity-scale-codec = { version = "1.0" }
 ethbloom = "0.6.4"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["endomorphism"] }

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 chain-core = { path = "../chain-core" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["recovery", "endomorphism"] }

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -15,7 +15,7 @@ use client_common::{Error, ErrorKind, Result, Storage};
 use client_core::signer::DefaultSigner;
 use client_core::transaction_builder::DefaultTransactionBuilder;
 use client_core::wallet::{DefaultWalletClient, WalletClient};
-use client_index::cipher::AbciTransactionCipher;
+use client_index::cipher::MockAbciTransactionObfuscation;
 use client_index::handler::{DefaultBlockHandler, DefaultTransactionHandler};
 use client_index::index::DefaultIndex;
 use client_index::synchronizer::ManualSynchronizer;
@@ -137,7 +137,8 @@ impl Command {
                 let tendermint_client = RpcClient::new(&tendermint_url());
                 let signer = DefaultSigner::new(storage.clone());
                 let fee_algorithm = tendermint_client.genesis()?.fee_policy();
-                let transaction_cipher = AbciTransactionCipher::new(tendermint_client.clone());
+                let transaction_cipher =
+                    MockAbciTransactionObfuscation::new(tendermint_client.clone());
                 let transaction_builder = DefaultTransactionBuilder::new(
                     signer.clone(),
                     fee_algorithm,
@@ -165,7 +166,8 @@ impl Command {
                 let tendermint_client = RpcClient::new(&tendermint_url());
                 let signer = DefaultSigner::new(storage.clone());
                 let fee_algorithm = tendermint_client.genesis()?.fee_policy();
-                let transaction_cipher = AbciTransactionCipher::new(tendermint_client.clone());
+                let transaction_cipher =
+                    MockAbciTransactionObfuscation::new(tendermint_client.clone());
                 let transaction_builder = DefaultTransactionBuilder::new(
                     signer.clone(),
                     fee_algorithm,
@@ -193,7 +195,8 @@ impl Command {
                 let tendermint_client = RpcClient::new(&tendermint_url());
 
                 let transaction_handler = DefaultTransactionHandler::new(storage.clone());
-                let transaction_cipher = AbciTransactionCipher::new(tendermint_client.clone());
+                let transaction_cipher =
+                    MockAbciTransactionObfuscation::new(tendermint_client.clone());
                 let block_handler = DefaultBlockHandler::new(
                     transaction_cipher,
                     transaction_handler,

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 chain-tx-filter = { path = "../chain-tx-filter" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 rand = "0.7"
 failure = "0.1"
 miscreant = "0.4"

--- a/client-common/src/error.rs
+++ b/client-common/src/error.rs
@@ -107,6 +107,18 @@ pub enum ErrorKind {
     /// Signing error
     #[fail(display = "Signing error")]
     SigningError,
+    /// Invalid certificate
+    #[fail(display = "Invalid certificate format in TLS")]
+    InvalidCertFormat,
+    /// Bad attestation report
+    #[fail(display = "Bad SGX attestation report")]
+    BadAttnReport,
+    /// Webpki check failure
+    #[fail(display = "Webpki check failure")]
+    WebpkiFailure,
+    /// TDQE connection failure
+    #[fail(display = "Transaction decryption enclave connection failure")]
+    TDQEConnectionError,
 }
 
 impl Fail for Error {

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 chain-core = { path = "../chain-core" }
 client-common = { path = "../client-common" }
 client-index = { path = "../client-index" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 rand = "0.7"
 failure = "0.1"
 hex = "0.3"

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -9,7 +9,7 @@ use chain_core::tx::data::Tx;
 use chain_core::tx::fee::FeeAlgorithm;
 use chain_core::tx::{TransactionId, TxAux};
 use client_common::{ErrorKind, Result, SignedTransaction};
-use client_index::TransactionCipher;
+use client_index::TransactionObfuscation;
 
 use crate::{SelectedUnspentTransactions, Signer, TransactionBuilder, UnspentTransactions};
 
@@ -32,7 +32,7 @@ pub struct DefaultTransactionBuilder<S, F, C>
 where
     S: Signer,
     F: FeeAlgorithm,
-    C: TransactionCipher,
+    C: TransactionObfuscation,
 {
     signer: S,
     fee_algorithm: F,
@@ -43,7 +43,7 @@ impl<S, F, C> DefaultTransactionBuilder<S, F, C>
 where
     S: Signer,
     F: FeeAlgorithm,
-    C: TransactionCipher,
+    C: TransactionObfuscation,
 {
     /// Creates a new instance of transaction builder
     #[inline]
@@ -60,7 +60,7 @@ impl<S, F, C> TransactionBuilder for DefaultTransactionBuilder<S, F, C>
 where
     S: Signer,
     F: FeeAlgorithm,
-    C: TransactionCipher,
+    C: TransactionObfuscation,
 {
     fn build(
         &self,
@@ -154,7 +154,7 @@ mod tests {
     #[derive(Debug)]
     struct MockTransactionCipher;
 
-    impl TransactionCipher for MockTransactionCipher {
+    impl TransactionObfuscation for MockTransactionCipher {
         fn decrypt(
             &self,
             _transaction_ids: &[TxId],

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -526,7 +526,7 @@ mod tests {
     use client_common::balance::BalanceChange;
     use client_common::storage::MemoryStorage;
     use client_common::{PrivateKey, SignedTransaction, Transaction};
-    use client_index::{AddressDetails, TransactionCipher};
+    use client_index::{AddressDetails, TransactionObfuscation};
 
     use crate::signer::DefaultSigner;
     use crate::transaction_builder::DefaultTransactionBuilder;
@@ -534,7 +534,7 @@ mod tests {
     #[derive(Debug)]
     struct MockTransactionCipher;
 
-    impl TransactionCipher for MockTransactionCipher {
+    impl TransactionObfuscation for MockTransactionCipher {
         fn decrypt(
             &self,
             _transaction_ids: &[TxId],

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -14,9 +14,16 @@ parity-scale-codec = { features = ["derive"], version = "1.0" }
 chrono = { version = "0.4", features = ["serde"] }
 jsonrpc = { version = "0.11", optional = true }
 base64 = "0.10"
+webpki = "0.21"
+rustls =  {version = "0.16", features = ["dangerous_configuration"]}
+yasna = { version = "0.3.0", features = ["bit-vec", "num-bigint", "chrono"] }
+bit-vec = "0.6.1"
+num-bigint = "0.2.2"
+serde_json = "1.0.39"
+uuid = { version = "0.7.4", features = ["v4"] }
 
 [dev-dependencies]
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
 
 [features]
 default = ["sled", "rpc"]

--- a/client-index/src/cipher.rs
+++ b/client-index/src/cipher.rs
@@ -1,14 +1,17 @@
 //! Utilities for encryption and decryption
 mod abci_transaction_cipher;
+pub mod cert;
+mod default;
+pub mod sgx;
 
-pub use abci_transaction_cipher::AbciTransactionCipher;
+pub use abci_transaction_cipher::MockAbciTransactionObfuscation;
 
 use chain_core::tx::data::TxId;
 use chain_core::tx::TxAux;
 use client_common::{PrivateKey, Result, SignedTransaction, Transaction};
 
 /// Interface for encryption and decryption of transactions
-pub trait TransactionCipher: Send + Sync {
+pub trait TransactionObfuscation: Send + Sync {
     /// Retrieves decrypted transactions with given ids. Only transactions of type `Transfer` and `Withdraw` need to be
     /// decrypted.
     fn decrypt(

--- a/client-index/src/cipher/cert.rs
+++ b/client-index/src/cipher/cert.rs
@@ -1,0 +1,397 @@
+#![allow(missing_docs)]
+#![allow(clippy::needless_lifetimes)]
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright (c) 2019, Foris Limited (licensed under the Apache License, Version 2.0)
+// TODO: document ASN1 parsing
+// TODO: check the needless lifetimes
+use yasna::ASN1Result;
+use yasna::{BERReader, BERReaderSeq, BERReaderSet};
+use yasna::{DERWriter, DERWriterSeq, DERWriterSet};
+
+pub type Writer<'a> = DERWriter<'a>;
+pub type Reader<'a, 'b> = BERReader<'a, 'b>;
+
+pub trait ConsWriter<'a> {
+    fn next<'b>(&'b mut self) -> Writer<'b>;
+}
+
+pub trait ConsReader<'a, 'b>
+where
+    'a: 'b,
+{
+    fn next<'c>(&'c mut self, tags: &[yasna::Tag]) -> ASN1Result<Reader<'a, 'c>>;
+}
+
+impl<'a> ConsWriter<'a> for DERWriterSeq<'a> {
+    fn next<'b>(&'b mut self) -> Writer<'b> {
+        self.next()
+    }
+}
+
+impl<'a> ConsWriter<'a> for DERWriterSet<'a> {
+    fn next<'b>(&'b mut self) -> Writer<'b> {
+        self.next()
+    }
+}
+
+impl<'a, 'b> ConsReader<'a, 'b> for BERReaderSeq<'a, 'b> {
+    fn next<'c>(&'c mut self, _tags: &[yasna::Tag]) -> ASN1Result<Reader<'a, 'c>> {
+        Ok(self.next())
+    }
+}
+
+impl<'a, 'b> ConsReader<'a, 'b> for BERReaderSet<'a, 'b> {
+    fn next<'c>(&'c mut self, tags: &[yasna::Tag]) -> ASN1Result<Reader<'a, 'c>> {
+        self.next(tags)
+    }
+}
+
+pub trait Asn1Ty {
+    type ValueTy;
+    const TAG: yasna::Tag;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) -> ();
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b;
+}
+
+pub trait Asn1ConsTy
+where
+    Self: std::marker::Sized,
+{
+    type ValueTy;
+    fn dump<'a, W: ConsWriter<'a>>(writer: &mut W, value: Self::ValueTy) -> ();
+    fn load<'a, 'b, R>(reader: &mut R) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+        R: ConsReader<'a, 'b>;
+}
+
+pub trait Asn1Tag {
+    const TAG: yasna::Tag;
+}
+
+const fn context_tag(tnum: u64) -> yasna::Tag {
+    yasna::Tag {
+        tag_class: yasna::TagClass::ContextSpecific,
+        tag_number: tnum,
+    }
+}
+
+mod no_instance {
+    #![allow(dead_code)]
+
+    use super::{Asn1ConsTy, Asn1Tag, Asn1Ty};
+    use std::marker::PhantomData;
+
+    pub(crate) struct CtxT0;
+    pub(crate) struct CtxT1;
+    pub(crate) struct CtxT3;
+
+    pub(crate) struct Oid;
+    pub(crate) struct U8;
+    pub(crate) struct I8;
+    pub(crate) struct BigUint;
+    pub(crate) struct Utf8Str;
+    pub(crate) struct UtcTime;
+    pub(crate) struct BitVec;
+    pub(crate) struct Bytes;
+    pub(crate) struct Tagged<T: Asn1Tag, S: Asn1Ty> {
+        t: PhantomData<T>,
+        s: PhantomData<S>,
+    }
+    pub(crate) struct Sequence<U: Asn1Ty, V: Asn1ConsTy> {
+        u: PhantomData<U>,
+        v: PhantomData<V>,
+    }
+    pub(crate) struct Set<U: Asn1Ty, V: Asn1ConsTy> {
+        u: PhantomData<U>,
+        v: PhantomData<V>,
+    }
+    pub(crate) struct Cons<U: Asn1Ty, V: Asn1ConsTy> {
+        u: PhantomData<U>,
+        v: PhantomData<V>,
+    }
+    pub(crate) struct Nil;
+}
+
+use no_instance::*;
+
+impl Asn1Tag for CtxT0 {
+    const TAG: yasna::Tag = context_tag(0);
+}
+
+impl Asn1Tag for CtxT1 {
+    const TAG: yasna::Tag = context_tag(1);
+}
+
+impl Asn1Tag for CtxT3 {
+    const TAG: yasna::Tag = context_tag(3);
+}
+
+impl<U: Asn1Ty, V: Asn1ConsTy> Asn1ConsTy for Cons<U, V> {
+    type ValueTy = (U::ValueTy, V::ValueTy);
+    fn dump<'a, W: ConsWriter<'a>>(writer: &mut W, value: Self::ValueTy) {
+        U::dump(writer.next(), value.0);
+        V::dump(writer, value.1);
+    }
+    fn load<'a, 'b, R>(reader: &mut R) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+        R: ConsReader<'a, 'b>,
+    {
+        let first = U::load(reader.next(&[U::TAG])?)?;
+        let second = V::load(reader)?;
+        Ok((first, second))
+    }
+}
+
+impl Asn1ConsTy for Nil {
+    type ValueTy = ();
+    fn dump<'a, W: ConsWriter<'a>>(_writer: &mut W, _value: Self::ValueTy) {}
+    fn load<'a, 'b, R>(_reader: &mut R) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+        R: ConsReader<'a, 'b>,
+    {
+        Ok(())
+    }
+}
+
+impl<T: Asn1Tag, S: Asn1Ty> Asn1Ty for Tagged<T, S> {
+    type ValueTy = S::ValueTy;
+    const TAG: yasna::Tag = T::TAG;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_tagged(T::TAG, |writer| S::dump(writer, value));
+    }
+    /// seems the closure is needed for type inference
+    #[allow(clippy::redundant_closure)]
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_tagged(T::TAG, |reader| S::load(reader))
+    }
+}
+
+impl<U: Asn1Ty, V: Asn1ConsTy> Asn1Ty for Sequence<U, V> {
+    type ValueTy = (U::ValueTy, V::ValueTy);
+    const TAG: yasna::Tag = yasna::tags::TAG_SEQUENCE;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_sequence(|writer| {
+            U::dump(writer.next(), value.0);
+            V::dump(writer, value.1);
+        });
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_sequence(|reader| {
+            let first = U::load(reader.next())?;
+            let second = V::load(reader)?;
+            Ok((first, second))
+        })
+    }
+}
+
+impl<U: Asn1Ty, V: Asn1ConsTy> Asn1Ty for Set<U, V> {
+    type ValueTy = (U::ValueTy, V::ValueTy);
+    const TAG: yasna::Tag = yasna::tags::TAG_SET;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_set(|writer| {
+            U::dump(writer.next(), value.0);
+            V::dump(writer, value.1);
+        });
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_set(|reader| {
+            let first = U::load(reader.next(&[U::TAG])?)?;
+            let second = V::load(reader)?;
+            Ok((first, second))
+        })
+    }
+}
+
+impl Asn1Ty for U8 {
+    type ValueTy = u8;
+    const TAG: yasna::Tag = yasna::tags::TAG_INTEGER;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_u8(value);
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_u8()
+    }
+}
+
+impl Asn1Ty for I8 {
+    type ValueTy = i8;
+    const TAG: yasna::Tag = yasna::tags::TAG_INTEGER;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_i8(value);
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_i8()
+    }
+}
+
+impl Asn1Ty for BigUint {
+    type ValueTy = num_bigint::BigUint;
+    const TAG: yasna::Tag = yasna::tags::TAG_INTEGER;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_biguint(&value);
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_biguint()
+    }
+}
+
+impl Asn1Ty for Utf8Str {
+    type ValueTy = String;
+    const TAG: yasna::Tag = yasna::tags::TAG_UTF8STRING;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_utf8_string(value.as_str());
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_utf8string()
+    }
+}
+
+impl Asn1Ty for Oid {
+    type ValueTy = yasna::models::ObjectIdentifier;
+    const TAG: yasna::Tag = yasna::tags::TAG_OID;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_oid(&value);
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_oid()
+    }
+}
+
+impl Asn1Ty for UtcTime {
+    type ValueTy = yasna::models::UTCTime;
+    const TAG: yasna::Tag = yasna::tags::TAG_UTCTIME;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_utctime(&value);
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_utctime()
+    }
+}
+
+impl Asn1Ty for BitVec {
+    type ValueTy = bit_vec::BitVec;
+    const TAG: yasna::Tag = yasna::tags::TAG_BITSTRING;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_bitvec(&value);
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_bitvec()
+    }
+}
+
+impl Asn1Ty for Bytes {
+    type ValueTy = Vec<u8>;
+    const TAG: yasna::Tag = yasna::tags::TAG_OCTETSTRING;
+    fn dump<'a>(writer: Writer<'a>, value: Self::ValueTy) {
+        writer.write_bytes(&value.as_slice());
+    }
+    fn load<'a, 'b>(reader: Reader<'a, 'b>) -> ASN1Result<Self::ValueTy>
+    where
+        'a: 'b,
+    {
+        reader.read_bytes()
+    }
+}
+
+macro_rules! cons {
+    () => { Nil };
+    ($t: ty) => { Cons<$t, Nil> };
+    ($t: ty, $($tt: ty),* $(,)?) => {
+        Cons<$t, cons! { $($tt),* }>
+    };
+}
+
+macro_rules! asn1_seq_ty {
+    ($t: ty) => { Sequence<$t, Nil> };
+    ($t: ty, $($tt: ty),* $(,)?) => {
+        Sequence<$t, cons! { $($tt),* }>
+    };
+}
+
+macro_rules! asn1_set_ty {
+    ($t: ty) => { Set<$t, Nil> };
+    ($t: ty, $($tt: ty),* $(,)?) => {
+        Set<$t, cons! { $($tt),* }>
+    };
+}
+
+#[cfg(feature = "mesalock_sgx")]
+macro_rules! asn1_seq {
+    () => { () };
+    ($e: expr) => {
+        ($e, ())
+    };
+    ($e: expr , $($ee: expr),* $(,)?) => {
+        ($e, asn1_seq!{ $($ee),* } )
+    };
+}
+
+pub(crate) type Version = Tagged<CtxT0, I8>;
+pub(crate) type Serial = U8;
+pub(crate) type CertSignAlgo = asn1_seq_ty!(Oid);
+pub(crate) type ValidRange = asn1_seq_ty!(UtcTime, UtcTime);
+pub(crate) type Issuer = asn1_seq_ty!(asn1_set_ty!(asn1_seq_ty!(Oid, Utf8Str)));
+pub(crate) type Subject = Issuer;
+pub(crate) type PubKeyAlgo = asn1_seq_ty!(Oid, Oid);
+pub(crate) type PubKey = asn1_seq_ty!(PubKeyAlgo, BitVec);
+pub(crate) type SgxRaCertExt = Tagged<CtxT3, asn1_seq_ty!(asn1_seq_ty!(Oid, Bytes))>;
+pub(crate) type TbsCert = asn1_seq_ty!(
+    Version,
+    Serial,
+    CertSignAlgo,
+    Issuer,
+    ValidRange,
+    Subject,
+    PubKey,
+    SgxRaCertExt,
+);
+pub(crate) type CertSig = BitVec;
+pub(crate) type X509 = asn1_seq_ty!(TbsCert, CertSignAlgo, CertSig);

--- a/client-index/src/cipher/default.rs
+++ b/client-index/src/cipher/default.rs
@@ -1,0 +1,102 @@
+use super::sgx::EnclaveAttr;
+use crate::TransactionObfuscation;
+use chain_core::tx::data::TxId;
+use chain_core::tx::{TxAux, TxWithOutputs};
+use client_common::SECP;
+use client_common::{Error, ErrorKind, PrivateKey, Result, SignedTransaction, Transaction};
+use enclave_protocol::{DecryptionRequest, DecryptionResponse};
+use failure::ResultExt;
+use parity_scale_codec::{Decode, Encode};
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+fn get_tls_config() -> Arc<rustls::ClientConfig> {
+    // TODO: static config cache
+    let mut client_cfg = rustls::ClientConfig::new();
+    // TODO: client auth?
+
+    // this is needed for the custom extra validation of the attestation report in the certificate extension
+    client_cfg
+        .dangerous()
+        .set_certificate_verifier(Arc::new(EnclaveAttr {}));
+    client_cfg.versions.clear();
+    // TODO: test/try 1.3 and possibly switch
+    client_cfg.versions.push(rustls::ProtocolVersion::TLSv1_2);
+    Arc::new(client_cfg)
+}
+
+/// Implementation of transaction obfuscation which directly talks to transaction decryption query and encryption enclaves
+/// TODO: querying from multiple nodes / addresses
+#[derive(Debug, Clone)]
+pub struct DefaultTransactionObfuscation {
+    tdqe_address: String,
+    tdqe_hostname: String,
+}
+
+impl DefaultTransactionObfuscation {
+    #[allow(dead_code)]
+    pub fn new(tdqe_address: String, tdqe_hostname: String) -> Self {
+        DefaultTransactionObfuscation {
+            tdqe_address,
+            tdqe_hostname,
+        }
+    }
+}
+
+impl TransactionObfuscation for DefaultTransactionObfuscation {
+    fn decrypt(
+        &self,
+        transaction_ids: &[TxId],
+        private_key: &PrivateKey,
+    ) -> Result<Vec<Transaction>> {
+        let client_config = get_tls_config();
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str(&self.tdqe_hostname)
+            .context(ErrorKind::WebpkiFailure)?;
+        let mut sess = rustls::ClientSession::new(&client_config, dns_name);
+
+        let mut conn =
+            TcpStream::connect(&self.tdqe_address).context(ErrorKind::TDQEConnectionError)?;
+
+        let mut tls = rustls::Stream::new(&mut sess, &mut conn);
+        let mut challenge = [0u8; 32];
+        tls.read_exact(&mut challenge)
+            .context(ErrorKind::TDQEConnectionError)?;
+        let request = SECP.with(|secp| {
+            DecryptionRequest::create(
+                &secp,
+                transaction_ids.to_owned(),
+                challenge,
+                &private_key.into(),
+            )
+        });
+        tls.write_all(&request.encode())
+            .context(ErrorKind::TDQEConnectionError)?;
+
+        let mut plaintext = Vec::new();
+        match tls.read_to_end(&mut plaintext) {
+            Ok(_) => {
+                let txs = DecryptionResponse::decode(&mut plaintext.as_slice())
+                    .context(ErrorKind::DeserializationError)?
+                    .txs;
+
+                let transactions = txs
+                    .into_iter()
+                    .map(|tx| match tx {
+                        TxWithOutputs::Transfer(t) => Transaction::TransferTransaction(t),
+                        TxWithOutputs::StakeWithdraw(t) => {
+                            Transaction::WithdrawUnbondedStakeTransaction(t)
+                        }
+                    })
+                    .collect::<Vec<Transaction>>();
+
+                Ok(transactions)
+            }
+            Err(_) => Err(Error::from(ErrorKind::TDQEConnectionError)),
+        }
+    }
+
+    fn encrypt(&self, _transaction: SignedTransaction) -> Result<TxAux> {
+        unimplemented!()
+    }
+}

--- a/client-index/src/cipher/sgx.rs
+++ b/client-index/src/cipher/sgx.rs
@@ -1,0 +1,442 @@
+#![allow(missing_docs)]
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright (c) 2019, Foris Limited (licensed under the Apache License, Version 2.0)
+// TODO: document the SGX stuff
+use chrono::DateTime;
+use client_common::error::{Error, ErrorKind, Result};
+use failure::ResultExt;
+use rustls;
+use serde_json;
+use serde_json::Value;
+use std::convert::TryFrom;
+use std::io::BufReader;
+use std::time::Duration;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+// TODO: do they all need to be supported?
+type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
+static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[
+    &webpki::ECDSA_P256_SHA256,
+    &webpki::ECDSA_P256_SHA384,
+    &webpki::ECDSA_P384_SHA256,
+    &webpki::ECDSA_P384_SHA384,
+    &webpki::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
+    &webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
+    &webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
+    &webpki::RSA_PKCS1_2048_8192_SHA256,
+    &webpki::RSA_PKCS1_2048_8192_SHA384,
+    &webpki::RSA_PKCS1_2048_8192_SHA512,
+    &webpki::RSA_PKCS1_3072_8192_SHA384,
+];
+
+#[derive(PartialEq, Debug)]
+pub enum SgxQuoteStatus {
+    OK,
+    GroupOutOfDate,
+    ConfigurationNeeded,
+    UnknownBadStatus,
+}
+
+impl From<&str> for SgxQuoteStatus {
+    fn from(status: &str) -> Self {
+        match status {
+            "OK" => SgxQuoteStatus::OK,
+            "GROUP_OUT_OF_DATE" => SgxQuoteStatus::GroupOutOfDate,
+            "CONFIGURATION_NEEDED" => SgxQuoteStatus::ConfigurationNeeded,
+            _ => SgxQuoteStatus::UnknownBadStatus,
+        }
+    }
+}
+
+pub enum SgxQuoteSigType {
+    Unlinkable,
+    Linkable,
+}
+
+pub struct SgxReport {
+    pub cpu_svn: [u8; 16],
+    pub misc_select: u32,
+    pub attributes: [u8; 16],
+    pub mr_enclave: [u8; 32],
+    pub mr_signer: [u8; 32],
+    pub isv_prod_id: u16,
+    pub isv_svn: u16,
+    pub report_data: [u8; 64],
+}
+
+pub enum SgxQuoteVersion {
+    V1,
+    V2,
+}
+
+pub struct SgxQuoteBody {
+    pub version: SgxQuoteVersion,
+    pub signature_type: SgxQuoteSigType,
+    pub gid: u32,
+    pub isv_svn_qe: u16,
+    pub isv_svn_pce: u16,
+    pub qe_vendor_id: Uuid,
+    pub user_data: [u8; 20],
+    pub report_body: SgxReport,
+}
+
+impl SgxQuoteBody {
+    // TODO: A Result should be returned instead of Option
+    fn parse_from<'a>(bytes: &'a [u8]) -> Option<Self> {
+        let mut pos: usize = 0;
+        // TODO: It is really unnecessary to construct a Vec<u8> each time.
+        // Try to optimize this.
+        let mut take = |n: usize| -> Option<&'a [u8]> {
+            if n > 0 && bytes.len() >= pos + n {
+                let ret = Some(&bytes[pos..pos + n]);
+                pos += n;
+                ret
+            } else {
+                None
+            }
+        };
+
+        // off 0, size 2
+        let version = match u16::from_le_bytes(<[u8; 2]>::try_from(take(2)?).ok()?) {
+            1 => SgxQuoteVersion::V1,
+            2 => SgxQuoteVersion::V2,
+            _ => return None,
+        };
+
+        // off 2, size 2
+        let signature_type = match u16::from_le_bytes(<[u8; 2]>::try_from(take(2)?).ok()?) {
+            0 => SgxQuoteSigType::Unlinkable,
+            1 => SgxQuoteSigType::Linkable,
+            _ => return None,
+        };
+
+        // off 4, size 4
+        let gid = u32::from_le_bytes(<[u8; 4]>::try_from(take(4)?).ok()?);
+
+        // off 8, size 2
+        let isv_svn_qe = u16::from_le_bytes(<[u8; 2]>::try_from(take(2)?).ok()?);
+
+        // off 10, size 2
+        let isv_svn_pce = u16::from_le_bytes(<[u8; 2]>::try_from(take(2)?).ok()?);
+
+        // off 12, size 16
+        let qe_vendor_id_raw = <[u8; 16]>::try_from(take(16)?).ok()?;
+        let qe_vendor_id = Uuid::from_slice(&qe_vendor_id_raw).ok()?;
+
+        // off 28, size 20
+        let user_data = <[u8; 20]>::try_from(take(20)?).ok()?;
+
+        // off 48, size 16
+        let cpu_svn = <[u8; 16]>::try_from(take(16)?).ok()?;
+
+        // off 64, size 4
+        let misc_select = u32::from_le_bytes(<[u8; 4]>::try_from(take(4)?).ok()?);
+
+        // off 68, size 28
+        let _reserved = take(28)?;
+
+        // off 96, size 16
+        let attributes = <[u8; 16]>::try_from(take(16)?).ok()?;
+
+        // off 112, size 32
+        let mr_enclave = <[u8; 32]>::try_from(take(32)?).ok()?;
+
+        // off 144, size 32
+        let _reserved = take(32)?;
+
+        // off 176, size 32
+        let mr_signer = <[u8; 32]>::try_from(take(32)?).ok()?;
+
+        // off 208, size 96
+        let _reserved = take(96)?;
+
+        // off 304, size 2
+        let isv_prod_id = u16::from_le_bytes(<[u8; 2]>::try_from(take(2)?).ok()?);
+
+        // off 306, size 2
+        let isv_svn = u16::from_le_bytes(<[u8; 2]>::try_from(take(2)?).ok()?);
+
+        // off 308, size 60
+        let _reserved = take(60)?;
+
+        // off 368, size 64
+        let mut report_data = [0u8; 64];
+        let _report_data = take(64)?;
+        let mut _it = _report_data.iter();
+        for i in report_data.iter_mut() {
+            *i = *_it.next()?;
+        }
+
+        if pos != bytes.len() {
+            return None;
+        }
+
+        Some(Self {
+            version,
+            signature_type,
+            gid,
+            isv_svn_qe,
+            isv_svn_pce,
+            qe_vendor_id,
+            user_data,
+            report_body: SgxReport {
+                cpu_svn,
+                misc_select,
+                attributes,
+                mr_enclave,
+                mr_signer,
+                isv_prod_id,
+                isv_svn,
+                report_data,
+            },
+        })
+    }
+}
+
+pub struct SgxQuote {
+    pub freshness: Duration,
+    pub status: SgxQuoteStatus,
+    pub body: SgxQuoteBody,
+}
+
+fn extract_att_parts(payload: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+    // Extract each field
+    let mut iter = payload.split(|x| *x == 0x7C);
+    let attn_report_raw = iter
+        .next()
+        .ok_or_else(|| Error::from(ErrorKind::InvalidCertFormat))?;
+    let sig_raw = iter
+        .next()
+        .ok_or_else(|| Error::from(ErrorKind::InvalidCertFormat))?;
+    let sig = base64::decode(&sig_raw).context(ErrorKind::InvalidCertFormat)?;
+    let sig_cert_raw = iter
+        .next()
+        .ok_or_else(|| Error::from(ErrorKind::InvalidCertFormat))?;
+    let sig_cert_dec = base64::decode_config(&sig_cert_raw, base64::STANDARD)
+        .context(ErrorKind::InvalidCertFormat)?;
+    Ok((attn_report_raw.to_vec(), sig, sig_cert_dec))
+}
+
+fn extract_quote_body(attn_report: Value) -> Result<(u64, SgxQuoteStatus, SgxQuoteBody)> {
+    // TODO: reduce the boilerplate (for monadic operations)
+    // 1. Check timestamp is within 24H (90day is recommended by Intel)
+    let time = attn_report
+        .get("timestamp")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| Error::from(ErrorKind::BadAttnReport))?;
+    let time_fixed = String::from(time) + "+0000";
+    let date_time = DateTime::parse_from_str(&time_fixed, "%Y-%m-%dT%H:%M:%S%.f%z")
+        .context(ErrorKind::BadAttnReport)?;
+    let ts = date_time.naive_utc();
+    let now = DateTime::<chrono::offset::Utc>::from(SystemTime::now()).naive_utc();
+    let quote_freshness =
+        u64::try_from((now - ts).num_seconds()).context(ErrorKind::BadAttnReport)?;
+
+    // 2. Get quote status
+    let status_string = attn_report
+        .get("isvEnclaveQuoteStatus")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| Error::from(ErrorKind::BadAttnReport))?;
+    let quote_status = SgxQuoteStatus::from(status_string);
+
+    // 3. Get quote body
+    let quote_encoded = attn_report
+        .get("isvEnclaveQuoteBody")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| Error::from(ErrorKind::BadAttnReport))?;
+    let quote_raw =
+        base64::decode(&(quote_encoded.as_bytes())).context(ErrorKind::BadAttnReport)?;
+    let quote_body = SgxQuoteBody::parse_from(quote_raw.as_slice())
+        .ok_or_else(|| Error::from(ErrorKind::BadAttnReport))?;
+
+    Ok((quote_freshness, quote_status, quote_body))
+}
+
+/// seems the closure is needed for type inference
+#[allow(clippy::redundant_closure)]
+fn extract_sgx_quote_from_mra_cert(cert_der: &[u8]) -> Result<SgxQuote> {
+    // Before we reach here, Webpki already verifed the cert is properly signed
+    use super::cert::*;
+
+    let x509 = yasna::parse_der(cert_der, |reader| X509::load(reader))
+        .context(ErrorKind::InvalidCertFormat)?;
+
+    let tbs_cert: <TbsCert as Asn1Ty>::ValueTy = x509.0;
+
+    let pub_key: <PubKey as Asn1Ty>::ValueTy = ((((((tbs_cert.1).1).1).1).1).1).0;
+    let pub_k = (pub_key.1).0;
+
+    let sgx_ra_cert_ext: <SgxRaCertExt as Asn1Ty>::ValueTy = (((((((tbs_cert.1).1).1).1).1).1).1).0;
+
+    let payload: Vec<u8> = ((sgx_ra_cert_ext.0).1).0;
+
+    let (attn_report_raw, sig, sig_cert_dec) = extract_att_parts(payload)?;
+
+    let sig_cert =
+        webpki::EndEntityCert::from(&sig_cert_dec).context(ErrorKind::InvalidCertFormat)?;
+
+    // Verify if the signing cert is issued by Intel CA
+    // TODO: move to a file and include_bytes
+    let ias_report_ca = "
+    -----BEGIN CERTIFICATE-----
+MIIFSzCCA7OgAwIBAgIJANEHdl0yo7CUMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
+BAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwLU2FudGEgQ2xhcmExGjAYBgNV
+BAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQDDCdJbnRlbCBTR1ggQXR0ZXN0
+YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwIBcNMTYxMTE0MTUzNzMxWhgPMjA0OTEy
+MzEyMzU5NTlaMH4xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEUMBIGA1UEBwwL
+U2FudGEgQ2xhcmExGjAYBgNVBAoMEUludGVsIENvcnBvcmF0aW9uMTAwLgYDVQQD
+DCdJbnRlbCBTR1ggQXR0ZXN0YXRpb24gUmVwb3J0IFNpZ25pbmcgQ0EwggGiMA0G
+CSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCfPGR+tXc8u1EtJzLA10Feu1Wg+p7e
+LmSRmeaCHbkQ1TF3Nwl3RmpqXkeGzNLd69QUnWovYyVSndEMyYc3sHecGgfinEeh
+rgBJSEdsSJ9FpaFdesjsxqzGRa20PYdnnfWcCTvFoulpbFR4VBuXnnVLVzkUvlXT
+L/TAnd8nIZk0zZkFJ7P5LtePvykkar7LcSQO85wtcQe0R1Raf/sQ6wYKaKmFgCGe
+NpEJUmg4ktal4qgIAxk+QHUxQE42sxViN5mqglB0QJdUot/o9a/V/mMeH8KvOAiQ
+byinkNndn+Bgk5sSV5DFgF0DffVqmVMblt5p3jPtImzBIH0QQrXJq39AT8cRwP5H
+afuVeLHcDsRp6hol4P+ZFIhu8mmbI1u0hH3W/0C2BuYXB5PC+5izFFh/nP0lc2Lf
+6rELO9LZdnOhpL1ExFOq9H/B8tPQ84T3Sgb4nAifDabNt/zu6MmCGo5U8lwEFtGM
+RoOaX4AS+909x00lYnmtwsDVWv9vBiJCXRsCAwEAAaOByTCBxjBgBgNVHR8EWTBX
+MFWgU6BRhk9odHRwOi8vdHJ1c3RlZHNlcnZpY2VzLmludGVsLmNvbS9jb250ZW50
+L0NSTC9TR1gvQXR0ZXN0YXRpb25SZXBvcnRTaWduaW5nQ0EuY3JsMB0GA1UdDgQW
+BBR4Q3t2pn680K9+QjfrNXw7hwFRPDAfBgNVHSMEGDAWgBR4Q3t2pn680K9+Qjfr
+NXw7hwFRPDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBADANBgkq
+hkiG9w0BAQsFAAOCAYEAeF8tYMXICvQqeXYQITkV2oLJsp6J4JAqJabHWxYJHGir
+IEqucRiJSSx+HjIJEUVaj8E0QjEud6Y5lNmXlcjqRXaCPOqK0eGRz6hi+ripMtPZ
+sFNaBwLQVV905SDjAzDzNIDnrcnXyB4gcDFCvwDFKKgLRjOB/WAqgscDUoGq5ZVi
+zLUzTqiQPmULAQaB9c6Oti6snEFJiCQ67JLyW/E83/frzCmO5Ru6WjU4tmsmy8Ra
+Ud4APK0wZTGtfPXU7w+IBdG5Ez0kE1qzxGQaL4gINJ1zMyleDnbuS8UicjJijvqA
+152Sq049ESDz+1rRGc2NVEqh1KaGXmtXvqxXcTB+Ljy5Bw2ke0v8iGngFBPqCTVB
+3op5KBG3RjbF6RRSzwzuWfL7QErNC8WEy5yDVARzTA5+xmBc388v9Dm21HGfcC8O
+DD+gT9sSpssq0ascmvH49MOgjt1yoysLtdCtJW/9FZpoOypaHx0R+mJTLwPXVMrv
+DaVzWh5aiEx+idkSGMnX
+-----END CERTIFICATE-----
+    "
+    .to_owned()
+    .into_bytes();
+    let mut ias_ca_stripped: Vec<u8> = ias_report_ca.clone();
+    ias_ca_stripped.retain(|&x| x != 0x0d && x != 0x0a);
+    let head_len = "-----BEGIN CERTIFICATE-----".len();
+    let tail_len = "-----END CERTIFICATE-----".len();
+    let full_len = ias_ca_stripped.len();
+    let ias_ca_core: &[u8] = &ias_ca_stripped[head_len..full_len - tail_len];
+    let ias_cert_dec = base64::decode_config(ias_ca_core, base64::STANDARD)
+        .context(ErrorKind::InvalidCertFormat)?;
+    let ias_cert_input = &ias_cert_dec;
+
+    let mut ca_reader = BufReader::new(&ias_report_ca[..]);
+
+    let mut root_store = rustls::RootCertStore::empty();
+    // this should not fail
+    root_store
+        .add_pem_file(&mut ca_reader)
+        .expect("Failed to add CA");
+
+    let trust_anchors: Vec<webpki::TrustAnchor> = root_store
+        .roots
+        .iter()
+        .map(|cert| cert.to_trust_anchor())
+        .collect();
+
+    let now_func = webpki::Time::try_from(SystemTime::now())
+        .map_err(|_| Error::from(ErrorKind::WebpkiFailure))?;
+
+    let chain = vec![ias_cert_input.as_slice()];
+
+    sig_cert
+        .verify_is_valid_tls_server_cert(
+            SUPPORTED_SIG_ALGS,
+            &webpki::TLSServerTrustAnchors(&trust_anchors),
+            chain.as_slice(),
+            now_func,
+        )
+        .context(ErrorKind::WebpkiFailure)?;
+
+    // Verify the signature against the signing cert
+    sig_cert
+        .verify_signature(&webpki::RSA_PKCS1_2048_8192_SHA256, &attn_report_raw, &sig)
+        .context(ErrorKind::WebpkiFailure)?;
+
+    // Verify attestation report and extract quote body
+    let attn_report: Value =
+        serde_json::from_slice(&attn_report_raw).context(ErrorKind::BadAttnReport)?;
+
+    let (quote_freshness, quote_status, quote_body) = extract_quote_body(attn_report)?;
+    let raw_pub_k = pub_k.to_bytes();
+
+    // According to RFC 5480 `Elliptic Curve Cryptography Subject Public Key Information',
+    // SEC 2.2:
+    // ``The first octet of the OCTET STRING indicates whether the key is
+    // compressed or uncompressed.  The uncompressed form is indicated
+    // by 0x04 and the compressed form is indicated by either 0x02 or
+    // 0x03 (see 2.3.3 in [SEC1]).  The public key MUST be rejected if
+    // any other value is included in the first octet.''
+    //
+    // Here, only the uncompressed form is allowed.
+    let is_uncompressed = raw_pub_k[0] == 4;
+    let pub_k = &raw_pub_k.as_slice()[1..];
+    if !is_uncompressed || pub_k != &quote_body.report_body.report_data[..] {
+        return Err(ErrorKind::BadAttnReport.into());
+    }
+
+    Ok(SgxQuote {
+        freshness: std::time::Duration::from_secs(quote_freshness),
+        status: quote_status,
+        body: quote_body,
+    })
+}
+
+#[derive(Clone)]
+pub struct EnclaveAttr {}
+
+impl EnclaveAttr {
+    fn check_quote(&self, _quote: &SgxQuote) -> bool {
+        // FIXME: check quote.body.report_body.mr_signer matches the expected one etc.
+        true
+    }
+
+    fn check_in_cert_quote(&self, cert_der: &[u8]) -> bool {
+        let quote_result = extract_sgx_quote_from_mra_cert(&cert_der);
+        let quote: SgxQuote = match quote_result {
+            Err(_) => {
+                return false;
+            }
+            Ok(quote) => quote,
+        };
+        self.check_quote(&quote)
+    }
+}
+
+impl rustls::ServerCertVerifier for EnclaveAttr {
+    fn verify_server_cert(
+        &self,
+        _roots: &rustls::RootCertStore,
+        certs: &[rustls::Certificate],
+        _hostname: webpki::DNSNameRef,
+        _ocsp: &[u8],
+    ) -> std::result::Result<rustls::ServerCertVerified, rustls::TLSError> {
+        // This call automatically verifies certificate signature
+        if certs.len() != 1 {
+            return Err(rustls::TLSError::NoCertificatesPresented);
+        }
+        if self.check_in_cert_quote(&certs[0].0) {
+            Ok(rustls::ServerCertVerified::assertion())
+        } else {
+            Err(rustls::TLSError::WebPKIError(
+                webpki::Error::ExtensionValueInvalid,
+            ))
+        }
+    }
+}

--- a/client-index/src/handler/default_block_handler.rs
+++ b/client-index/src/handler/default_block_handler.rs
@@ -4,12 +4,12 @@ use chain_core::tx::TransactionId;
 use client_common::{BlockHeader, PrivateKey, PublicKey, Result, Storage, Transaction};
 
 use crate::service::{GlobalStateService, TransactionService};
-use crate::{BlockHandler, TransactionCipher, TransactionHandler};
+use crate::{BlockHandler, TransactionHandler, TransactionObfuscation};
 
 /// Default implementation of `BlockHandler`
 pub struct DefaultBlockHandler<C, H, S>
 where
-    C: TransactionCipher,
+    C: TransactionObfuscation,
     H: TransactionHandler,
     S: Storage,
 {
@@ -22,7 +22,7 @@ where
 
 impl<C, H, S> DefaultBlockHandler<C, H, S>
 where
-    C: TransactionCipher,
+    C: TransactionObfuscation,
     H: TransactionHandler,
     S: Storage + Clone,
 {
@@ -40,7 +40,7 @@ where
 
 impl<C, H, S> DefaultBlockHandler<C, H, S>
 where
-    C: TransactionCipher,
+    C: TransactionObfuscation,
     H: TransactionHandler,
     S: Storage,
 {
@@ -59,7 +59,7 @@ where
 
 impl<C, H, S> BlockHandler for DefaultBlockHandler<C, H, S>
 where
-    C: TransactionCipher,
+    C: TransactionObfuscation,
     H: TransactionHandler,
     S: Storage,
 {
@@ -119,7 +119,7 @@ mod tests {
 
     struct MockTransactionCipher;
 
-    impl TransactionCipher for MockTransactionCipher {
+    impl TransactionObfuscation for MockTransactionCipher {
         fn decrypt(
             &self,
             transaction_ids: &[TxId],

--- a/client-index/src/lib.rs
+++ b/client-index/src/lib.rs
@@ -7,7 +7,7 @@ pub mod service;
 pub mod synchronizer;
 
 #[doc(inline)]
-pub use crate::cipher::TransactionCipher;
+pub use crate::cipher::TransactionObfuscation;
 #[doc(inline)]
 pub use crate::handler::{BlockHandler, TransactionHandler};
 #[doc(inline)]

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -20,4 +20,4 @@ parity-scale-codec = { features = ["derive"], version = "1.0" }
 hex = "0.3.2"
 
 [dev-dependencies]
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -16,7 +16,7 @@ use chain_core::tx::{TransactionId, TxAux};
 use client_common::tendermint::Client;
 use client_common::{Error, ErrorKind, Result, SignedTransaction};
 use client_core::{Signer, UnspentTransactions, WalletClient};
-use client_index::TransactionCipher;
+use client_index::TransactionObfuscation;
 
 use crate::NetworkOpsClient;
 
@@ -27,7 +27,7 @@ where
     S: Signer,
     C: Client,
     F: FeeAlgorithm,
-    E: TransactionCipher,
+    E: TransactionObfuscation,
 {
     /// WalletClient
     wallet_client: W,
@@ -43,7 +43,7 @@ where
     S: Signer,
     C: Client,
     F: FeeAlgorithm,
-    E: TransactionCipher,
+    E: TransactionObfuscation,
 {
     /// use WalletClient
     pub fn get_wallet(&self) -> &W {
@@ -95,7 +95,7 @@ where
     S: Signer,
     C: Client,
     F: FeeAlgorithm,
-    E: TransactionCipher,
+    E: TransactionObfuscation,
 {
     fn create_deposit_bonded_stake_transaction(
         &self,
@@ -278,7 +278,7 @@ mod tests {
     #[derive(Debug)]
     struct MockTransactionCipher;
 
-    impl TransactionCipher for MockTransactionCipher {
+    impl TransactionObfuscation for MockTransactionCipher {
         fn decrypt(
             &self,
             _transaction_ids: &[TxId],

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -263,7 +263,7 @@ pub mod tests {
     use client_core::signer::DefaultSigner;
     use client_core::transaction_builder::DefaultTransactionBuilder;
     use client_core::wallet::DefaultWalletClient;
-    use client_index::{AddressDetails, Index, TransactionCipher};
+    use client_index::{AddressDetails, Index, TransactionObfuscation};
 
     #[derive(Default)]
     pub struct MockIndex;
@@ -324,7 +324,7 @@ pub mod tests {
     #[derive(Debug)]
     struct MockTransactionCipher;
 
-    impl TransactionCipher for MockTransactionCipher {
+    impl TransactionObfuscation for MockTransactionCipher {
         fn decrypt(
             &self,
             _transaction_ids: &[TxId],

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 chain-core = { path = "../chain-core" }
 chain-tx-validation = { path = "../chain-tx-validation" }
 parity-scale-codec = { version = "1.0", features = ["derive"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "29991f23eaaa55ec86491dc78e7455f8f1fe3212" }

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -1,16 +1,33 @@
 //! This crate contains messages exchanged in REQ-REP socket between chain-abci app to enclave wrapper server
-use parity_scale_codec::{Decode, Encode, Error, Input};
+//! as well as direct communication over TCP-TLS with optional querying enclaves
 
+#![cfg_attr(all(feature = "mesalock_sgx", not(target_env = "sgx")), no_std)]
+#![cfg_attr(
+    all(target_env = "sgx", target_vendor = "mesalock"),
+    feature(rustc_private)
+)]
+
+#[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+use std::prelude::v1::Vec;
+
+use chain_core::common::{H256, H264, H512};
 use chain_core::state::account::DepositBondTx;
 use chain_core::state::account::StakedState;
 use chain_core::state::account::StakedStateOpWitness;
 use chain_core::state::account::WithdrawUnbondedTx;
-use chain_core::tx::data::Tx;
-use chain_core::tx::data::TxId;
+use chain_core::tx::data::{txid_hash, Tx, TxId};
 use chain_core::tx::witness::TxWitness;
 use chain_core::tx::{fee::Fee, TxAux};
 use chain_core::ChainInfo;
 use chain_tx_validation::TxWithOutputs;
+use secp256k1::{
+    key::{PublicKey, SecretKey},
+    Message, Secp256k1, Signature, Signing, Verification,
+};
 
 const ENCRYPTION_REQUEST_SIZE: usize = 1024 * 60; // 60 KB
 
@@ -94,23 +111,129 @@ pub struct EncryptionResponse {
     pub tx: TxAux,
 }
 
-/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
-/// TODO: limit txs size + no of view keys in each TX?
-#[derive(Encode, Decode)]
+/// Request in direct communication (over one-side attested TLS) to TDQE
 pub struct DecryptionRequestBody {
+    /// transactions to check
     pub txs: Vec<TxId>,
+    /// requester's public view key
+    pub view_key: PublicKey,
+    /// 32-byte challenge obtained from TDQE after establishing TLS connection
+    pub challenge: H256,
 }
 
-/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
-#[derive(Encode, Decode)]
+impl DecryptionRequestBody {
+    pub fn new(txs: Vec<TxId>, view_key: PublicKey, challenge: H256) -> Self {
+        DecryptionRequestBody {
+            txs,
+            view_key,
+            challenge,
+        }
+    }
+}
+
+impl Encode for DecryptionRequestBody {
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        self.txs.encode_to(dest);
+        self.view_key.serialize().encode_to(dest);
+        self.challenge.encode_to(dest);
+    }
+}
+
+impl Decode for DecryptionRequestBody {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+        let txs: Vec<TxId> = Vec::decode(input)?;
+        let view_key_bytes = H264::decode(input)?;
+        let view_key = PublicKey::from_slice(&view_key_bytes)
+            .map_err(|_| parity_scale_codec::Error::from("Unable to parse public key"))?;
+        let challenge = H256::decode(input)?;
+        Ok(DecryptionRequestBody::new(txs, view_key, challenge))
+    }
+}
+
+/// Signed request in direct communication (over one-side attested TLS) to TDQE
 pub struct DecryptionRequest {
     pub body: DecryptionRequestBody,
-    /// ecdsa on the body in compact form?
-    pub view_key_sig: [u8; 64],
+    pub view_key_sig: Signature,
 }
 
-/// TODO: rethink / should be direct communication with the enclave (rather than via abci+zmq)
+impl DecryptionRequest {
+    pub fn new(body: DecryptionRequestBody, view_key_sig: Signature) -> Self {
+        DecryptionRequest { body, view_key_sig }
+    }
+
+    pub fn create<C: Signing>(
+        secp: &Secp256k1<C>,
+        txs: Vec<TxId>,
+        challenge: H256,
+        view_secret_key: &SecretKey,
+    ) -> Self {
+        let public_key = PublicKey::from_secret_key(&secp, &view_secret_key);
+        let body = DecryptionRequestBody::new(txs, public_key, challenge);
+        let body_hash = txid_hash(&body.encode());
+        let message = Message::from_slice(&body_hash[..]).expect("32 bytes");
+        let sig = secp.sign(&message, &view_secret_key);
+        DecryptionRequest::new(body, sig)
+    }
+
+    pub fn verify<C: Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        challenge: H256,
+    ) -> Result<(), secp256k1::Error> {
+        if self.body.challenge != challenge {
+            return Err(secp256k1::Error::InvalidMessage);
+        }
+        let body_hash = txid_hash(&self.body.encode());
+        let message = Message::from_slice(&body_hash[..]).expect("32 bytes");
+        secp.verify(&message, &self.view_key_sig, &self.body.view_key)
+    }
+}
+
+impl Encode for DecryptionRequest {
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        self.body.encode_to(dest);
+        self.view_key_sig.serialize_compact().encode_to(dest);
+    }
+}
+
+impl Decode for DecryptionRequest {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+        let body: DecryptionRequestBody = DecryptionRequestBody::decode(input)?;
+        let view_sig_bytes = H512::decode(input)?;
+        let view_key_sig = Signature::from_compact(&view_sig_bytes)
+            .map_err(|_| parity_scale_codec::Error::from("Unable to parse signature"))?;
+        Ok(DecryptionRequest::new(body, view_key_sig))
+    }
+}
+
+/// Response in direct communication (over one-side attested TLS) from TDQE
 #[derive(Encode, Decode)]
 pub struct DecryptionResponse {
     pub txs: Vec<TxWithOutputs>,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn check_basic_dec_verify() {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
+        let req =
+            DecryptionRequest::create(&secp, vec![[0u8; 32], [1u8; 32]], [2u8; 32], &secret_key);
+        let encoded = req.encode();
+        let decoded_req =
+            DecryptionRequest::decode(&mut encoded.as_slice()).expect("encode-decode request");
+        assert!(decoded_req.verify(&secp, [2u8; 32]).is_ok());
+    }
+
+    #[test]
+    fn check_wrong_challenge_not_verify() {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
+        let req =
+            DecryptionRequest::create(&secp, vec![[0u8; 32], [1u8; 32]], [2u8; 32], &secret_key);
+        assert!(req.verify(&secp, [0u8; 32]).is_err());
+    }
 }


### PR DESCRIPTION
Solution:
- extended the enclave protocol for direction communication
- refactored abci and client libs to make it explicit they've been using a mock (+ warning in abci)
- ported some of the MesaTEE client facility (using the failure crate instead of custom monadic macro)
- "switch" to the direct communication with TDQE (refusing abci queries etc.) is currently feature-guarded, as TDQE "server" is still WIP