### PR TITLE
Problem: Integration tests fails because of changes in RPC response

### DIFF
--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -288,8 +288,8 @@ describe("Wallet transaction", () => {
 });
 
 enum TransactionDirection {
-	INCOMING = "incoming",
-	OUTGOING = "outgoing",
+	INCOMING = "Incoming",
+	OUTGOING = "Outgoing",
 }
 interface TransactionAssertion {
 	address?: string;

--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -235,7 +235,7 @@ describe("Wallet transaction", () => {
 			},
 			"Sender should have one Incoming transaction",
 		);
-		expect(senderWalletLastTransaction.kind).to.eq("incoming");
+		expect(senderWalletLastTransaction.kind).to.eq(TransactionDirection.INCOMING);
 		const senderWalletIncomingAmount = senderWalletLastTransaction.amount;
 		expect(
 			new BigNumber(senderWalletIncomingAmount).isLessThan(


### PR DESCRIPTION
Solution: Updated test suite to adapt with new response

```javascript
1) Wallet transaction
       can transfer funds between two wallets:
      AssertionError: expected 'Outgoing' to equal 'outgoing'
      + expected - actual
      -Outgoing
      +outgoing
      
      at expectTransactionShouldBe (test/wallet-transaction.test.ts:324:25)
      at Context.it (test/wallet-transaction.test.ts:102:3)
      at process._tickCallback (internal/process/next_tick.js:68:7)
  2) Wallet transaction
       can transfer funds between two wallets with fee included:
      AssertionError: expected 'Outgoing' to equal 'outgoing'
      + expected - actual
      -Outgoing
      +outgoing
      
      at expectTransactionShouldBe (test/wallet-transaction.test.ts:324:25)
      at Context.<anonymous> (test/wallet-transaction.test.ts:223:3)
      at process._tickCallback (internal/process/next_tick.js:68:7)