### PR TITLE
Problem: (CRO-252) Tendermint client does not support batched RPC requests

### DIFF
--- a/client-common/src/tendermint/client.rs
+++ b/client-common/src/tendermint/client.rs
@@ -13,8 +13,15 @@ pub trait Client: Send + Sync {
     /// Makes `block` call to tendermint
     fn block(&self, height: u64) -> Result<Block>;
 
+    /// Makes batched `block` call to tendermint
+    fn block_batch<T: Iterator<Item = u64>>(&self, heights: T) -> Result<Vec<Block>>;
+
     /// Makes `block_results` call to tendermint
     fn block_results(&self, height: u64) -> Result<BlockResults>;
+
+    /// Makes batched `block_results` call to tendermint
+    fn block_results_batch<T: Iterator<Item = u64>>(&self, heights: T)
+        -> Result<Vec<BlockResults>>;
 
     /// Makes `broadcast_tx_sync` call to tendermint
     fn broadcast_transaction(&self, transaction: &[u8]) -> Result<()>;

--- a/client-index/src/cipher/abci_transaction_cipher.rs
+++ b/client-index/src/cipher/abci_transaction_cipher.rs
@@ -140,7 +140,18 @@ mod tests {
             unreachable!()
         }
 
+        fn block_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> Result<Vec<Block>> {
+            unreachable!()
+        }
+
         fn block_results(&self, _height: u64) -> Result<BlockResults> {
+            unreachable!()
+        }
+
+        fn block_results_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<BlockResults>> {
             unreachable!()
         }
 

--- a/client-index/src/handler/default_transaction_handler.rs
+++ b/client-index/src/handler/default_transaction_handler.rs
@@ -233,7 +233,18 @@ mod tests {
             unreachable!()
         }
 
+        fn block_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> Result<Vec<Block>> {
+            unreachable!()
+        }
+
         fn block_results(&self, _height: u64) -> Result<BlockResults> {
+            unreachable!()
+        }
+
+        fn block_results_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<BlockResults>> {
             unreachable!()
         }
 

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -88,7 +88,18 @@ mod tests {
             unreachable!()
         }
 
+        fn block_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> Result<Vec<Block>> {
+            unreachable!()
+        }
+
         fn block_results(&self, _height: u64) -> Result<BlockResults> {
+            unreachable!()
+        }
+
+        fn block_results_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<BlockResults>> {
             unreachable!()
         }
 

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -348,7 +348,18 @@ mod tests {
             unreachable!()
         }
 
-        fn block_results(&self, _: u64) -> Result<BlockResults> {
+        fn block_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> Result<Vec<Block>> {
+            unreachable!()
+        }
+
+        fn block_results(&self, _height: u64) -> Result<BlockResults> {
+            unreachable!()
+        }
+
+        fn block_results_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<BlockResults>> {
             unreachable!()
         }
 

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -420,8 +420,19 @@ mod test {
             unreachable!("block")
         }
 
+        fn block_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> CommonResult<Vec<Block>> {
+            unreachable!("block_batch")
+        }
+
         fn block_results(&self, _height: u64) -> CommonResult<BlockResults> {
             unreachable!("block_results")
+        }
+
+        fn block_results_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> CommonResult<Vec<BlockResults>> {
+            unreachable!("block_results_batch")
         }
 
         fn broadcast_transaction(&self, _transaction: &[u8]) -> CommonResult<()> {

--- a/client-rpc/src/rpc/transaction_rpc.rs
+++ b/client-rpc/src/rpc/transaction_rpc.rs
@@ -83,7 +83,7 @@ mod test {
     use chain_core::init::address::CroAddress;
     use chain_core::init::coin::Coin;
     use chain_core::tx::data::address::ExtendedAddr;
-    use client_common::{Error, ErrorKind, PrivateKey};
+    use client_common::PrivateKey;
 
     #[test]
     fn create_raw_flow() {

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -383,6 +383,18 @@ pub mod tests {
             })
         }
 
+        fn block_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> CommonResult<Vec<Block>> {
+            Ok(vec![Block {
+                block: BlockInner {
+                    header: Header {
+                        height: "1".to_string(),
+                        time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
+                    },
+                    data: Data { txs: None },
+                },
+            }])
+        }
+
         fn block_results(&self, _height: u64) -> CommonResult<BlockResults> {
             Ok(BlockResults {
                 height: "1".to_string(),
@@ -391,6 +403,19 @@ pub mod tests {
                     end_block: None,
                 },
             })
+        }
+
+        fn block_results_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> CommonResult<Vec<BlockResults>> {
+            Ok(vec![BlockResults {
+                height: "1".to_string(),
+                results: Results {
+                    deliver_tx: None,
+                    end_block: None,
+                },
+            }])
         }
 
         fn broadcast_transaction(&self, _transaction: &[u8]) -> CommonResult<()> {


### PR DESCRIPTION
**Solution**: Created batched RPC request functions for `block` and `block_results`. 

**Note**: Right now, we only need `block` and `block_results` RPC calls in batch mode. Other methods can be added later as needed.