### PR TITLE
Problem: (CRO-252) Client sends batch request for one parameter set

### DIFF
--- a/client-common/src/tendermint/rpc_client.rs
+++ b/client-common/src/tendermint/rpc_client.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 use crate::tendermint::types::*;
 use crate::tendermint::Client;
 use crate::{Error, ErrorKind, Result};
+
 /// Tendermint RPC Client
 #[derive(Clone)]
 pub struct RpcClient {
@@ -46,28 +47,34 @@ impl RpcClient {
             return Ok(Default::default());
         }
 
-        // jsonrpc does not handle Hyper connection reset properly. The current
-        // inefficient workaround is to create a new client on every call.
-        // https://github.com/apoelstra/rust-jsonrpc/issues/26
-        let client = JsonRpcClient::new(self.url.to_owned(), None, None);
-        let requests = params
-            .iter()
-            .map(|(name, params)| client.build_request(name, params))
-            .collect::<Vec<Request>>();
-        let responses = client.send_batch(&requests).context(ErrorKind::RpcError)?;
-        responses
-            .into_iter()
-            .map(|response| -> Result<Option<T>> {
-                response
-                    .map(|inner| -> Result<T> {
-                        inner
-                            .result::<T>()
-                            .context(ErrorKind::RpcError)
-                            .map_err(Into::into)
-                    })
-                    .transpose()
-            })
-            .collect::<Result<Vec<Option<T>>>>()
+        if params.len() == 1 {
+            // Do not send batch request when there is only one set of params
+            self.call::<T>(params[0].0, &params[0].1)
+                .map(|value| vec![Some(value)])
+        } else {
+            // jsonrpc does not handle Hyper connection reset properly. The current
+            // inefficient workaround is to create a new client on every call.
+            // https://github.com/apoelstra/rust-jsonrpc/issues/26
+            let client = JsonRpcClient::new(self.url.to_owned(), None, None);
+            let requests = params
+                .iter()
+                .map(|(name, params)| client.build_request(name, params))
+                .collect::<Vec<Request>>();
+            let responses = client.send_batch(&requests).context(ErrorKind::RpcError)?;
+            responses
+                .into_iter()
+                .map(|response| -> Result<Option<T>> {
+                    response
+                        .map(|inner| -> Result<T> {
+                            inner
+                                .result::<T>()
+                                .context(ErrorKind::RpcError)
+                                .map_err(Into::into)
+                        })
+                        .transpose()
+                })
+                .collect::<Result<Vec<Option<T>>>>()
+        }
     }
 }
 


### PR DESCRIPTION
Solution: Added a check to send non-batch request when `params.len() == 1`

Note: This change is necessary because Tendermint's batch RPC API returns an object instead of an array of objects when there is only one set of params in request which makes serde deserializer to fail because it expects an array in case of batch requests.