### PR TITLE
Problem: (CRO-344) Integration test is not friendly to development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,12 +96,10 @@ jobs:
           tar xvfz zeromq-4.2.5.tar.gz
           cd zeromq-4.2.5 && ./configure --prefix=$HOME --with-libsodium && make && make install && cd ..
           cargo clean
-          cargo build
         - nvm install 10
         - |
           sudo cp integration-tests/docker/wait-for-it.sh /usr/local/bin
           sudo chmod +x /usr/local/bin/wait-for-it.sh
-        - git clone https://github.com/crypto-com/chain-tx-enclave ./integration-tests/docker/chain-tx-enclave
       script:
         - cd integration-tests
         - ./prepare.sh || travis_terminate 1;

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -14,34 +14,101 @@ Note: This step is needed only in local environment. TravisCI will initialize th
 1\. Build the [Crypto.com chain](https://www.github.com/crypto-com/chain) project.
 
 2\. Go to the `integration-tests` folder, run
+
 ```bash
 $ ./prepare.sh
 ```
 
+## Start Local Integration Tests environment
+
+There are two ways you can start the local integration tests environment for testing:
+
+### 1. Start using your local chain code
+
+The environment used your local build, which is suitable when you are under active development.
+
+- **When to use**: Under active development
+- **Advantages**: Using your local build gives faster build time and feedback loop
+- **Disadvantages**: Takes more steps to setup
+
+#### Howto
+
+You have to start each component one-by-one using the provided script, each component has normal (With fee) mode and zero-fee mode. Suffix the component name with `-zerofee` for zero-fee mode.
+
+e.g. `tendermint` to `tendermint-zerofee`
+
+#### Start Chain Tx Enclave
+
+```bash
+$ ./integration-tests/start-local.sh chain-tx-enclave
+# Or
+$ ./integration-tests/start-local.sh chain-tx-enclave-zerofee
+```
+
+#### Start Tendermint
+
+```bash
+$ ./integration-tests/start-local.sh tendermint
+# Or
+$ ./integration-tests/start-local.sh tendermint-zerofee
+```
+
+#### Start Chain ABCI
+
+```bash
+$ ./integration-tests/start-local.sh chain-abci
+# Or
+$ ./integration-tests/start-local.sh chain-abci-zerofee
+```
+
+#### Start ClientRPC
+
+```bash
+$ ./integration-tests/start-local.sh client-rpc
+# Or
+$ ./integration-tests/start-local.sh client-rpc-zerofee
+```
+
+### 2. Start using Docker Compose
+
+The environment will be built on-the-fly on docker-compose, which does not require much human intervention but has to be re-built from scratch whenever code changes.
+
+- **When to use**: One-off running of integration tests
+- **Advantages**: The whole environment is built and started with one command
+- **Disadvantages**: Since docker manages the build for you, docker has to re-build on every code changes
+
+#### Howto
+
+```bash
+$ . ./integration-tests/env.sh
+$ docker-compose -f ./integration-tests/docker-compose.yml up
+```
+
 ## List of Integration Tests
 
-| Integration Test Suite | Description |
-| --- | --- |
-| run-test.sh | Test Tendermint, Chain ABCI and ClientRPC are connect together |
+| Integration Test Suite | Description                                                    |
+| ---------------------- | -------------------------------------------------------------- |
+| run-test.sh            | Test Tendermint, Chain ABCI and ClientRPC are connect together |
+| client-rpc | Test related to client RPC server operations |
 
-## How to spin up and teardown Docker Compose Services
+## How to run `client-rpc` Integration Tests Suite
 
-Go to the `integration-tests` folder, run
-
-### Spin up
+Go to `client-rpc` directory, run
 ```bash
-$ docker-compose up
+$ yarn
+$ yarn test
 ```
 
-### Teardown
-```bash
-$ docker-compose down
-```
+## Appendix
 
-## How to run  Integration Tests Suite
+### Initialized Wallet
 
-1. Build and spin up Docker containers
-2. Go to the `integration-tests` folder, run
-```bash
-$ ./run-test.sh
-```
+The wallet initialized by the prepare script contains a wallet named `Default` with passpharse `123456`. An initial genesis funds of `2500000000000000000` basic unit of CRO is bonded to the first address of the wallet.
+
+### Update Tendermint version
+
+There are two places specifying Tendermint version to build and run:
+- integration-tests/constant-env.sh
+- integration-tests/docker-compose.yml
+
+If you want to specify your Tendermint version, you can also set environment `TENDERMINT_VERSION` to your desired version before prepare, build and start.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -35,6 +35,8 @@ The environment used your local build, which is suitable when you are under acti
 
 You have to start each component one-by-one using the provided script, each component has normal (With fee) mode and zero-fee mode. Suffix the component name with `-zerofee` for zero-fee mode.
 
+When a component is started, it will create a new "workspace" for the component. It will contain only the initialized wallet and genesis funds distribution. Any data you have in previous session, such as transactions data are gone.
+
 e.g. `tendermint` to `tendermint-zerofee`
 
 #### Start Chain Tx Enclave
@@ -89,11 +91,12 @@ $ docker-compose -f ./integration-tests/docker-compose.yml up
 | Integration Test Suite | Description                                                    |
 | ---------------------- | -------------------------------------------------------------- |
 | run-test.sh            | Test Tendermint, Chain ABCI and ClientRPC are connect together |
-| client-rpc | Test related to client RPC server operations |
+| client-rpc             | Test related to client RPC server operations                   |
 
 ## How to run `client-rpc` Integration Tests Suite
 
 Go to `client-rpc` directory, run
+
 ```bash
 $ yarn
 $ yarn test
@@ -108,6 +111,7 @@ The wallet initialized by the prepare script contains a wallet named `Default` w
 ### Update Tendermint version
 
 There are two places specifying Tendermint version to build and run:
+
 - integration-tests/constant-env.sh
 - integration-tests/docker-compose.yml
 

--- a/integration-tests/client-rpc/package.json
+++ b/integration-tests/client-rpc/package.json
@@ -14,7 +14,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^12.0.2",
+    "@types/node": "^12.7.2",
     "@types/sinon": "^7.0.11",
     "axios": "^0.19.0",
     "bignumber.js": "^8.1.1",

--- a/integration-tests/client-rpc/test/core/setup.ts
+++ b/integration-tests/client-rpc/test/core/setup.ts
@@ -48,12 +48,26 @@ export const newWalletRequest = (
 	};
 };
 
-export const unbondAndWithdrawStake = async () => {
-	const zeroFeeClient: RpcClient = newRpcClient();
-	await unbondAndWithdrawStakeFromClient(zeroFeeClient);
+export const shouldTest = (feeSchema: FEE_SCHEMA) => {
+	const testOnly = process.env.TEST_ONLY;
+	return (!testOnly || testOnly === feeSchema);
+}
 
-	const withFeeClient: RpcClient = newRpcClient("localhost", 26659);
-	await unbondAndWithdrawStakeFromClient(withFeeClient);
+export enum FEE_SCHEMA {
+	ZERO_FEE = "ZERO_FEE",
+	WITH_FEE = "WITH_FEE",
+}
+
+export const unbondAndWithdrawStake = async () => {
+	if (shouldTest(FEE_SCHEMA.ZERO_FEE)) {
+		const zeroFeeClient: RpcClient = newRpcClient();
+		await unbondAndWithdrawStakeFromClient(zeroFeeClient);
+	}
+
+	if (shouldTest(FEE_SCHEMA.WITH_FEE)) {
+		const withFeeClient: RpcClient = newRpcClient("localhost", 26659);
+		await unbondAndWithdrawStakeFromClient(withFeeClient);
+	}
 };
 
 const unbondAndWithdrawStakeFromClient = async (client: RpcClient) => {
@@ -77,3 +91,10 @@ const unbondAndWithdrawStakeFromClient = async (client: RpcClient) => {
 
 	await client.request("sync", [walletRequest]);
 };
+
+if (!shouldTest(FEE_SCHEMA.ZERO_FEE)) {
+	console.info("[Test] Skipping Zero Fee Tests");
+}
+if (!shouldTest(FEE_SCHEMA.WITH_FEE)) {
+	console.info("[Test] Skipping With Fee Tests");
+}

--- a/integration-tests/client-rpc/test/wallet-management.test.ts
+++ b/integration-tests/client-rpc/test/wallet-management.test.ts
@@ -6,6 +6,9 @@ import {
 	generateWalletName,
 	newWalletRequest,
 	unbondAndWithdrawStake,
+	newZeroFeeRpcClient,
+	shouldTest,
+	FEE_SCHEMA,
 	newWithFeeRpcClient,
 } from "./core/setup";
 chaiUse(chaiAsPromised);
@@ -14,7 +17,11 @@ describe("Wallet management", () => {
 	let client: RpcClient;
 	before(async () => {
 		await unbondAndWithdrawStake();
-		client = newWithFeeRpcClient();
+		if (shouldTest(FEE_SCHEMA.WITH_FEE)) {
+			client = newWithFeeRpcClient();
+		} else if (shouldTest(FEE_SCHEMA.ZERO_FEE)) {
+			client = newZeroFeeRpcClient();
+		}
 	});
 
 	it("cannot access un-existing wallet", async () => {

--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -12,6 +12,8 @@ import {
 	newWithFeeRpcClient,
 	sleep,
 	unbondAndWithdrawStake,
+	shouldTest,
+	FEE_SCHEMA,
 } from "./core/setup";
 chaiUse(chaiAsPromised);
 
@@ -24,266 +26,275 @@ describe("Wallet transaction", () => {
 		withFeeClient = newWithFeeRpcClient();
 	});
 
-	it("cannot send funds larger than wallet balance", async () => {
-		const walletRequest = newWalletRequest("Default", "123456");
+	describe("Zero Fee", () => {
+		it("cannot send funds larger than wallet balance", async () => {
+			const walletRequest = newWalletRequest("Default", "123456");
 
-		const totalCROSupply = "10000000000000000000";
-		return expect(
-			zeroFeeClient.request("wallet_sendToAddress", [
-				walletRequest,
-				WALLET_TRANSFER_ADDRESS_2,
-				totalCROSupply,
+			const totalCROSupply = "10000000000000000000";
+			return expect(
+				zeroFeeClient.request("wallet_sendToAddress", [
+					walletRequest,
+					WALLET_TRANSFER_ADDRESS_2,
+					totalCROSupply,
+					[],
+				]),
+			).to.eventually.rejectedWith("Insufficient balance");
+		});
+
+		it("can transfer funds between two wallets", async () => {
+			const receiverWalletName = generateWalletName("Receive");
+			const senderWalletRequest = newWalletRequest("Default", "123456");
+			const receiverWalletRequest = newWalletRequest(receiverWalletName, "123456");
+			const transferAmount = "1000";
+
+			await zeroFeeClient.request("wallet_create", [receiverWalletRequest]);
+
+			const senderWalletTransactionListBeforeSend = await zeroFeeClient.request(
+				"wallet_transactions",
+				[senderWalletRequest],
+			);
+			const senderWalletBalanceBeforeSend = await zeroFeeClient.request(
+				"wallet_balance",
+				[senderWalletRequest],
+			);
+
+			const receiverWalletTransferAddress = await zeroFeeClient.request(
+				"wallet_createTransferAddress",
+				[receiverWalletRequest],
+			);
+			const receiverWalletTransactionListBeforeReceive = await zeroFeeClient.request(
+				"wallet_transactions",
+				[receiverWalletRequest],
+			);
+			const receiverWalletBalanceBeforeReceive = await zeroFeeClient.request(
+				"wallet_balance",
+				[receiverWalletRequest],
+			);
+
+			const txId = await zeroFeeClient.request("wallet_sendToAddress", [
+				senderWalletRequest,
+				receiverWalletTransferAddress,
+				transferAmount,
 				[],
-			]),
-		).to.eventually.rejectedWith("Insufficient balance");
+			]);
+			expect(txId.length).to.eq(
+				64,
+				"wallet_sendToAddress should return transaction id",
+			);
+
+			await sleep(2000);
+
+			await zeroFeeClient.request("sync", [senderWalletRequest]);
+			await zeroFeeClient.request("sync", [receiverWalletRequest]);
+
+			const senderWalletTransactionListAfterSend = await zeroFeeClient.request(
+				"wallet_transactions",
+				[senderWalletRequest],
+			);
+
+			expect(senderWalletTransactionListAfterSend.length).to.eq(
+				senderWalletTransactionListBeforeSend.length + 2,
+				"Sender should have two extra transaction records",
+			);
+			const senderWalletSecondLastTransaction = getSecondLastElementOfArray(
+				senderWalletTransactionListAfterSend,
+			);
+			const senderWalletLastTransaction = getLastElementOfArray(
+				senderWalletTransactionListAfterSend,
+			);
+			expectTransactionShouldBe(
+				senderWalletSecondLastTransaction,
+				{
+					direction: TransactionDirection.OUTGOING,
+					amount: senderWalletBalanceBeforeSend,
+				},
+				"Sender should have one Outgoing transaction",
+			);
+			expectTransactionShouldBe(
+				senderWalletLastTransaction,
+				{
+					direction: TransactionDirection.INCOMING,
+					amount: new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
+				},
+				"Sender should have one Incoming transaction",
+			);
+
+			const senderWalletBalanceAfterSend = await zeroFeeClient.request(
+				"wallet_balance",
+				[senderWalletRequest],
+			);
+			expect(senderWalletBalanceAfterSend).to.eq(
+				new BigNumber(senderWalletBalanceBeforeSend)
+					.minus(transferAmount)
+					.toString(10),
+				"Sender balance should be deducted by transfer amount",
+			);
+
+			const receiverWalletTransactionListAfterReceive = await zeroFeeClient.request(
+				"wallet_transactions",
+				[receiverWalletRequest],
+			);
+			expect(receiverWalletTransactionListAfterReceive.length).to.eq(
+				receiverWalletTransactionListBeforeReceive.length + 1,
+				"Receiver should have one extra transaction record",
+			);
+
+			const receiverWalletLastTransaction = getLastElementOfArray(
+				receiverWalletTransactionListAfterReceive,
+			);
+			expectTransactionShouldBe(
+				receiverWalletLastTransaction,
+				{
+					direction: TransactionDirection.INCOMING,
+					amount: new BigNumber(transferAmount),
+				},
+				"Receiver should have one Incoming transaction of the received amount",
+			);
+
+			const receiverWalletBalanceAfterReceive = await zeroFeeClient.request(
+				"wallet_balance",
+				[receiverWalletRequest],
+			);
+			expect(receiverWalletBalanceAfterReceive).to.eq(
+				new BigNumber(receiverWalletBalanceBeforeReceive)
+					.plus(transferAmount)
+					.toString(10),
+				"Receiver balance should be increased by transfer amount",
+			);
+		});
 	});
 
-	it("can transfer funds between two wallets", async () => {
-		const receiverWalletName = generateWalletName("Receive");
-		const senderWalletRequest = newWalletRequest("Default", "123456");
-		const receiverWalletRequest = newWalletRequest(receiverWalletName, "123456");
-		const transferAmount = "1000";
+	describe("With Fee", () => {
+		it("can transfer funds between two wallets with fee included", async function() {
+			const receiverWalletName = generateWalletName("Receive");
+			const senderWalletRequest = newWalletRequest("Default", "123456");
+			const receiverWalletRequest = newWalletRequest(receiverWalletName, "123456");
+			const transferAmount = "1000";
 
-		await zeroFeeClient.request("wallet_create", [receiverWalletRequest]);
+			await withFeeClient.request("wallet_create", [receiverWalletRequest]);
 
-		const senderWalletTransactionListBeforeSend = await zeroFeeClient.request(
-			"wallet_transactions",
-			[senderWalletRequest],
-		);
-		const senderWalletBalanceBeforeSend = await zeroFeeClient.request(
-			"wallet_balance",
-			[senderWalletRequest],
-		);
+			const senderWalletTransactionListBeforeSend = await withFeeClient.request(
+				"wallet_transactions",
+				[senderWalletRequest],
+			);
+			const senderWalletBalanceBeforeSend = await withFeeClient.request(
+				"wallet_balance",
+				[senderWalletRequest],
+			);
 
-		const receiverWalletTransferAddress = await zeroFeeClient.request(
-			"wallet_createTransferAddress",
-			[receiverWalletRequest],
-		);
-		const receiverWalletTransactionListBeforeReceive = await zeroFeeClient.request(
-			"wallet_transactions",
-			[receiverWalletRequest],
-		);
-		const receiverWalletBalanceBeforeReceive = await zeroFeeClient.request(
-			"wallet_balance",
-			[receiverWalletRequest],
-		);
+			const receiverWalletTransferAddress = await withFeeClient.request(
+				"wallet_createTransferAddress",
+				[receiverWalletRequest],
+			);
+			const receiverWalletTransactionListBeforeReceive = await withFeeClient.request(
+				"wallet_transactions",
+				[receiverWalletRequest],
+			);
+			const receiverWalletBalanceBeforeReceive = await withFeeClient.request(
+				"wallet_balance",
+				[receiverWalletRequest],
+			);
 
-		const txId = await zeroFeeClient.request("wallet_sendToAddress", [
-			senderWalletRequest,
-			receiverWalletTransferAddress,
-			transferAmount,
-			[],
-		]);
-		expect(txId.length).to.eq(
-			64,
-			"wallet_sendToAddress should return transaction id",
-		);
+			const txId = await withFeeClient.request("wallet_sendToAddress", [
+				senderWalletRequest,
+				receiverWalletTransferAddress,
+				transferAmount,
+				[],
+			]);
+			expect(txId.length).to.eq(
+				64,
+				"wallet_sendToAddress should return transaction id",
+			);
 
-		await sleep(2000);
+			await sleep(2000);
 
-		await zeroFeeClient.request("sync", [senderWalletRequest]);
-		await zeroFeeClient.request("sync", [receiverWalletRequest]);
+			await withFeeClient.request("sync", [senderWalletRequest]);
+			await withFeeClient.request("sync", [receiverWalletRequest]);
 
-		const senderWalletTransactionListAfterSend = await zeroFeeClient.request(
-			"wallet_transactions",
-			[senderWalletRequest],
-		);
+			const senderWalletTransactionListAfterSend = await withFeeClient.request(
+				"wallet_transactions",
+				[senderWalletRequest],
+			);
+			expect(senderWalletTransactionListAfterSend.length).to.eq(
+				senderWalletTransactionListBeforeSend.length + 2,
+				"Sender should have two extra transaction records",
+			);
+			const senderWalletSecondLastTransaction = getSecondLastElementOfArray(
+				senderWalletTransactionListAfterSend,
+			);
+			const senderWalletLastTransaction = getLastElementOfArray(
+				senderWalletTransactionListAfterSend,
+			);
+			expectTransactionShouldBe(
+				senderWalletSecondLastTransaction,
+				{
+					direction: TransactionDirection.OUTGOING,
+					amount: senderWalletBalanceBeforeSend,
+				},
+				"Sender should have one Outgoing transaction",
+			);
+			expectTransactionShouldBe(
+				senderWalletLastTransaction,
+				{
+					direction: TransactionDirection.INCOMING,
+				},
+				"Sender should have one Incoming transaction",
+			);
+			expect(senderWalletLastTransaction.kind).to.eq(
+				TransactionDirection.INCOMING,
+			);
+			const senderWalletIncomingAmount = senderWalletLastTransaction.amount;
+			expect(
+				new BigNumber(senderWalletIncomingAmount).isLessThan(
+					new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
+				),
+			).to.eq(true, "Sender should pay for transfer fee");
 
-		expect(senderWalletTransactionListAfterSend.length).to.eq(
-			senderWalletTransactionListBeforeSend.length + 2,
-			"Sender should have two extra transaction records",
-		);
-		const senderWalletSecondLastTransaction = getSecondLastElementOfArray(
-			senderWalletTransactionListAfterSend,
-		);
-		const senderWalletLastTransaction = getLastElementOfArray(
-			senderWalletTransactionListAfterSend,
-		);
-		expectTransactionShouldBe(
-			senderWalletSecondLastTransaction,
-			{
-				direction: TransactionDirection.OUTGOING,
-				amount: senderWalletBalanceBeforeSend,
-			},
-			"Sender should have one Outgoing transaction",
-		);
-		expectTransactionShouldBe(
-			senderWalletLastTransaction,
-			{
-				direction: TransactionDirection.INCOMING,
-				amount: new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
-			},
-			"Sender should have one Incoming transaction",
-		);
+			const senderWalletBalanceAfterSend = await withFeeClient.request(
+				"wallet_balance",
+				[senderWalletRequest],
+			);
+			expect(
+				new BigNumber(senderWalletBalanceAfterSend).isLessThan(
+					new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
+				),
+			).to.eq(
+				true,
+				"Sender balance should be deducted by transfer amount and fee",
+			);
 
-		const senderWalletBalanceAfterSend = await zeroFeeClient.request(
-			"wallet_balance",
-			[senderWalletRequest],
-		);
-		expect(senderWalletBalanceAfterSend).to.eq(
-			new BigNumber(senderWalletBalanceBeforeSend)
-				.minus(transferAmount)
-				.toString(10),
-			"Sender balance should be deducted by transfer amount",
-		);
+			const receiverWalletTransactionListAfterReceive = await withFeeClient.request(
+				"wallet_transactions",
+				[receiverWalletRequest],
+			);
+			expect(receiverWalletTransactionListAfterReceive.length).to.eq(
+				receiverWalletTransactionListBeforeReceive.length + 1,
+				"Receiver should have one extra transaction record",
+			);
 
-		const receiverWalletTransactionListAfterReceive = await zeroFeeClient.request(
-			"wallet_transactions",
-			[receiverWalletRequest],
-		);
-		expect(receiverWalletTransactionListAfterReceive.length).to.eq(
-			receiverWalletTransactionListBeforeReceive.length + 1,
-			"Receiver should have one extra transaction record",
-		);
+			const receiverWalletLastTransaction = getLastElementOfArray(
+				receiverWalletTransactionListAfterReceive,
+			);
+			expectTransactionShouldBe(
+				receiverWalletLastTransaction,
+				{
+					direction: TransactionDirection.INCOMING,
+					amount: new BigNumber(transferAmount),
+				},
+				"Receiver should have one Incoming transaction of the exact received amount",
+			);
 
-		const receiverWalletLastTransaction = getLastElementOfArray(
-			receiverWalletTransactionListAfterReceive,
-		);
-		expectTransactionShouldBe(
-			receiverWalletLastTransaction,
-			{
-				direction: TransactionDirection.INCOMING,
-				amount: new BigNumber(transferAmount),
-			},
-			"Receiver should have one Incoming transaction of the received amount",
-		);
-
-		const receiverWalletBalanceAfterReceive = await zeroFeeClient.request(
-			"wallet_balance",
-			[receiverWalletRequest],
-		);
-		expect(receiverWalletBalanceAfterReceive).to.eq(
-			new BigNumber(receiverWalletBalanceBeforeReceive)
-				.plus(transferAmount)
-				.toString(10),
-			"Receiver balance should be increased by transfer amount",
-		);
-	});
-
-	it("can transfer funds between two wallets with fee included", async function () {
-		const receiverWalletName = generateWalletName("Receive");
-		const senderWalletRequest = newWalletRequest("Default", "123456");
-		const receiverWalletRequest = newWalletRequest(receiverWalletName, "123456");
-		const transferAmount = "1000";
-
-		await withFeeClient.request("wallet_create", [receiverWalletRequest]);
-
-		const senderWalletTransactionListBeforeSend = await withFeeClient.request(
-			"wallet_transactions",
-			[senderWalletRequest],
-		);
-		const senderWalletBalanceBeforeSend = await withFeeClient.request(
-			"wallet_balance",
-			[senderWalletRequest],
-		);
-
-		const receiverWalletTransferAddress = await withFeeClient.request(
-			"wallet_createTransferAddress",
-			[receiverWalletRequest],
-		);
-		const receiverWalletTransactionListBeforeReceive = await withFeeClient.request(
-			"wallet_transactions",
-			[receiverWalletRequest],
-		);
-		const receiverWalletBalanceBeforeReceive = await withFeeClient.request(
-			"wallet_balance",
-			[receiverWalletRequest],
-		);
-
-		const txId = await withFeeClient.request("wallet_sendToAddress", [
-			senderWalletRequest,
-			receiverWalletTransferAddress,
-			transferAmount,
-			[],
-		]);
-		expect(txId.length).to.eq(
-			64,
-			"wallet_sendToAddress should return transaction id",
-		);
-
-		await sleep(2000);
-
-		await withFeeClient.request("sync", [senderWalletRequest]);
-		await withFeeClient.request("sync", [receiverWalletRequest]);
-
-		const senderWalletTransactionListAfterSend = await withFeeClient.request(
-			"wallet_transactions",
-			[senderWalletRequest],
-		);
-		expect(senderWalletTransactionListAfterSend.length).to.eq(
-			senderWalletTransactionListBeforeSend.length + 2,
-			"Sender should have two extra transaction records",
-		);
-		const senderWalletSecondLastTransaction = getSecondLastElementOfArray(
-			senderWalletTransactionListAfterSend,
-		);
-		const senderWalletLastTransaction = getLastElementOfArray(
-			senderWalletTransactionListAfterSend,
-		);
-		expectTransactionShouldBe(
-			senderWalletSecondLastTransaction,
-			{
-				direction: TransactionDirection.OUTGOING,
-				amount: senderWalletBalanceBeforeSend,
-			},
-			"Sender should have one Outgoing transaction",
-		);
-		expectTransactionShouldBe(
-			senderWalletLastTransaction,
-			{
-				direction: TransactionDirection.INCOMING,
-			},
-			"Sender should have one Incoming transaction",
-		);
-		expect(senderWalletLastTransaction.kind).to.eq(TransactionDirection.INCOMING);
-		const senderWalletIncomingAmount = senderWalletLastTransaction.amount;
-		expect(
-			new BigNumber(senderWalletIncomingAmount).isLessThan(
-				new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
-			),
-		).to.eq(true, "Sender should pay for transfer fee");
-
-		const senderWalletBalanceAfterSend = await withFeeClient.request(
-			"wallet_balance",
-			[senderWalletRequest],
-		);
-		expect(
-			new BigNumber(senderWalletBalanceAfterSend).isLessThan(
-				new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
-			),
-		).to.eq(true, "Sender balance should be deducted by transfer amount and fee");
-
-		const receiverWalletTransactionListAfterReceive = await withFeeClient.request(
-			"wallet_transactions",
-			[receiverWalletRequest],
-		);
-		expect(receiverWalletTransactionListAfterReceive.length).to.eq(
-			receiverWalletTransactionListBeforeReceive.length + 1,
-			"Receiver should have one extra transaction record",
-		);
-
-		const receiverWalletLastTransaction = getLastElementOfArray(
-			receiverWalletTransactionListAfterReceive,
-		);
-		expectTransactionShouldBe(
-			receiverWalletLastTransaction,
-			{
-				direction: TransactionDirection.INCOMING,
-				amount: new BigNumber(transferAmount),
-			},
-			"Receiver should have one Incoming transaction of the exact received amount",
-		);
-
-		const receiverWalletBalanceAfterReceive = await withFeeClient.request(
-			"wallet_balance",
-			[receiverWalletRequest],
-		);
-		expect(receiverWalletBalanceAfterReceive).to.eq(
-			new BigNumber(receiverWalletBalanceBeforeReceive)
-				.plus(transferAmount)
-				.toString(10),
-			"Receiver balance should be increased by the exact transfer amount",
-		);
+			const receiverWalletBalanceAfterReceive = await withFeeClient.request(
+				"wallet_balance",
+				[receiverWalletRequest],
+			);
+			expect(receiverWalletBalanceAfterReceive).to.eq(
+				new BigNumber(receiverWalletBalanceBeforeReceive)
+					.plus(transferAmount)
+					.toString(10),
+				"Receiver balance should be increased by the exact transfer amount",
+			);
+		});
 	});
 });
 
@@ -329,7 +340,10 @@ const expectTransactionShouldBe = (
 	if (typeof expected.height !== "undefined") {
 		expect(actual.block_height).to.eq(expected.height.toString(), message);
 	} else {
-		expect(new BigNumber(actual.block_height).isGreaterThan(0)).to.eq(true, message);
+		expect(new BigNumber(actual.block_height).isGreaterThan(0)).to.eq(
+			true,
+			message,
+		);
 	}
 	return true;
 };

--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -27,6 +27,9 @@ describe("Wallet transaction", () => {
 	});
 
 	describe("Zero Fee", () => {
+		if (!shouldTest(FEE_SCHEMA.ZERO_FEE)) {
+			return;
+		}
 		it("cannot send funds larger than wallet balance", async () => {
 			const walletRequest = newWalletRequest("Default", "123456");
 
@@ -165,6 +168,9 @@ describe("Wallet transaction", () => {
 	});
 
 	describe("With Fee", () => {
+		if (!shouldTest(FEE_SCHEMA.WITH_FEE)) {
+			return;
+		}
 		it("can transfer funds between two wallets with fee included", async function() {
 			const receiverWalletName = generateWalletName("Receive");
 			const senderWalletRequest = newWalletRequest("Default", "123456");

--- a/integration-tests/client-rpc/tsconfig.json
+++ b/integration-tests/client-rpc/tsconfig.json
@@ -19,9 +19,7 @@
     "resolveJsonModule": true
   },
   "include": [
-    "src/**/*"
-  ],
-  "exclude": [
+    "test/**/*",
     "node_modules",
   ]
 }

--- a/integration-tests/client-rpc/yarn.lock
+++ b/integration-tests/client-rpc/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.6.tgz#b8622d50557dd155e9f2f634b7d68fd38de5e94b"
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
-"@types/node@^12.0.2":
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
-  integrity sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==
+"@types/node@^12.7.2":
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
 "@types/sinon@^7.0.11":
   version "7.0.11"

--- a/integration-tests/constant-env.sh
+++ b/integration-tests/constant-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+IFS=
+
+TENDERMINT_PATH=${TENDERMINT_PATH:-tendermint}
+WALLET_PASSPHRASE=${WALLET_PASSPHRASE:-123456}
+TENDERMINT_VERSION=${TENDERMINT_VERSION:-0.32.0}
+
+# Constants (No not modify unless you are absolutely sure what you are doing)
+CHAIN_TX_ENCLAVE_DIRECTORY="docker/chain-tx-enclave"
+WALLET_STORAGE_DIRECTORY="docker/chain/wallet-storage"
+ADDRESS_STATE_PATH="address-state.json"
+DEV_CONF_WITHFEE_PATH="dev-conf-withfee.json"
+DEV_CONF_ZEROFEE_PATH="dev-conf-zerofee.json"
+TENDERMINT_TEMP_DIRECTORY="tendermint"
+TENDERMINT_WITHFEE_DIRECTORY="docker/tendermint/tendermint-withfee"
+TENDERMINT_ZEROFEE_DIRECTORY="docker/tendermint/tendermint-zerofee"
+CHAIN_ID="test-chain-y3m1e6-AB"
+
+set +e

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -2,19 +2,8 @@
 set -e
 IFS=
 
-TENDERMINT_PATH=${TENDERMINT_PATH:-tendermint}
-WALLET_PASSPHRASE=${WALLET_PASSPHRASE:-123456}
-TENDERMINT_VERSION=${TENDERMINT_VERSION:-0.32.0}
-
-# Constants (No not modify unless you are absolutely sure what you are doing)
-WALLET_STORAGE_DIRECTORY="./docker/chain/wallet-storage"
-ADDRESS_STATE_PATH="./address-state.json"
-DEV_CONF_WITHFEE_PATH="./dev-conf-withfee.json"
-DEV_CONF_ZEROFEE_PATH="./dev-conf-zerofee.json"
-TENDERMINT_TEMP_DIRECTORY="./tendermint"
-TENDERMINT_WITHFEE_DIRECTORY="./docker/tendermint/tendermint-withfee"
-TENDERMINT_ZEROFEE_DIRECTORY="./docker/tendermint/tendermint-zerofee"
-CHAIN_ID="test-chain-y3m1e6-AB"
+# Source constants
+. ./constant-env.sh
 
 # Global function return value
 RET_VALUE=0
@@ -49,6 +38,11 @@ function check_command_exist() {
         exit 1
     fi
     set -e
+}
+
+function git_clone_chain_tx_enclave() {
+    rm -rf "${CHAIN_TX_ENCLAVE_DIRECTORY}"
+    git clone https://github.com/crypto-com/chain-tx-enclave.git "${CHAIN_TX_ENCLAVE_DIRECTORY}"
 }
 
 # Create wallet
@@ -177,8 +171,14 @@ function _change_tenermint_chain_id() {
 cd "$(dirname "${0}")"
 
 check_command_exist "jq"
-check_command_exist "../target/debug/client-cli"
-check_command_exist "../target/debug/dev-utils"
+check_command_exist "git"
+check_command_exist "cargo"
+
+print_step "cargo build"
+cargo build
+
+print_step "git clone Chain Transaction Enclave"
+git_clone_chain_tx_enclave
 
 print_step "Initialize Tendermint"
 print_config "TENDERMINT_VERSION" "${TENDERMINT_VERSION}"

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -2,9 +2,6 @@
 set -e
 IFS=
 
-# Source constants
-. ./constant-env.sh
-
 # Global function return value
 RET_VALUE=0
 
@@ -169,6 +166,9 @@ function _change_tenermint_chain_id() {
 
 # Always execute at script located directory
 cd "$(dirname "${0}")"
+
+# Source constants
+. ./constant-env.sh
 
 check_command_exist "jq"
 check_command_exist "git"

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -e
+IFS=
+
+WALLET_WITHFEE_STORAGE_DIRECTORY="wallet-storage-withfee"
+WALLET_ZEROFEE_STORAGE_DIRECTORY="wallet-storage-zerofee"
+
+# Global function return value
+RET_VALUE=0
+
+# @argument message
+function print_message() {
+    echo "[$(date +"%Y-%m-%d|%T")] ${1}"
+}
+
+# @argument Description
+function print_step() {
+    print_message "${1}"
+}
+
+# @argument Key
+# @argument Value
+function print_config() {
+    print_message "[Config] ${1}=${2}"
+}
+
+# @argument Description
+function print_error() {
+    print_message "[ERROR] ${1}"
+}
+
+# @argument Command to test
+function check_command_exist() {
+    set +e
+    command -v ${1} > /dev/null
+    if [ x"$?" = "x1" ]; then
+        print_error "command not found: ${1}"
+        exit 1
+    fi
+    set -e
+}
+
+# @argument Port
+function start_chain_tx_enclave() {
+    print_config "CHAIN_TX_ENCLAVE_DIRECTORY" "${CHAIN_TX_ENCLAVE_DIRECTORY}"
+    print_config "CHAIN_HEX_ID" "${CHAIN_HEX_ID}"
+    print_config "PORT" "${1}"
+
+    cd "${CHAIN_TX_ENCLAVE_DIRECTORY}" && docker build -t chain-tx-validation \
+        -f ./tx-validation/Dockerfile . \
+        --build-arg SGX_MODE=SW \
+        --build-arg NETWORK_ID="${CHAIN_HEX_ID}"
+    
+    docker run --rm \
+        -p "${1}:25933" \
+        chain-tx-validation
+}
+
+# @argument Tendermint folder path
+# @argument Tendermint Port
+# @argument chain-abci Port
+function start_tendermint() {
+    print_config "CHAIN_ID" "${CHAIN_ID}"
+    print_config "TENDERMINT_FOLDER_PATH" "${1}"
+    print_config "TENDERMINT_PORT" "${2}"
+    print_config "CHAIN_ABCI_PORT" "${3}"
+
+    docker run -v "$(pwd)/${1}:/tendermint" \
+        --env TMHOME=/tendermint \
+        -p "${2}:26657" \
+        "tendermint/tendermint:v${TENDERMINT_VERSION}" \
+        node \
+            --proxy_app="tcp://host.docker.internal:${3}" \
+            --rpc.laddr=tcp://0.0.0.0:26657 \
+            --consensus.create_empty_blocks=false
+}
+
+# @argument App Hash
+# @argument Chain ABCI Port
+# @argument Enclave Port
+function start_chain_abci() {
+    print_config "CHAIN_ID" "${CHAIN_ID}"
+    print_config "GENESIS_APP_HASH" "${1}"
+    print_config "PORT" "${2}"
+    print_config "ENCLAVE_PORT" "${3}"
+
+    RUST_BACKTRACE=1 && RUST_LOG=info cargo run \
+        --bin chain-abci -- \
+            --port "${1}" \
+            --chain_id "${CHAIN_ID}" \
+            --genesis_app_hash ${1} \
+            --enclave_server "tcp://127.0.0.1:${3}"
+}
+
+# @argument Wallet Storage directory
+# @argument ClientRPC Port
+# @argument Tendermint Port
+function start_client_rpc() {
+    print_config "CHAIN_HEX_ID" "${CHAIN_HEX_ID}"
+    print_config "WALLET_STORAGE_DIRECTORY" "${WALLET_STORAGE_DIRECTORY}"
+    print_config "PORT" "${1}"
+    print_config "TENDERMINT_PORT" "${2}"
+
+    rm -rf "/tmp/${2}"
+    mkdir -p  "/tmp/${2}"
+    cp -r "${WALLET_STORAGE_DIRECTORY}" "/tmp/${2}"
+
+    RUST_BACKTRACE=1 && RUST_LOG=info cargo run \
+        --bin client-rpc -- \
+            --port "${2}" \
+            --network_id "${CHAIN_HEX_ID}" \
+            --storage-dir "${1}" \
+            --tendermint-url "http://127.0.0.1:${3}"
+}
+
+# Always execute at script located directory
+cd "$(dirname "${0}")"
+
+# Source constants
+. ./constant-env.sh
+. ./env.sh
+
+check_command_exist "tendermint"
+check_command_exist "cargo"
+check_command_exist "docker"
+
+if [ x"${1}" == "xchain-tx-enclave-zerofee" ]; then
+    start_chain_tx_enclave 15933
+elif [ x"${1}" == "xchain-tx-enclave" ]; then
+    start_chain_tx_enclave 25933
+elif [ x"${1}" == "xtendermint-zerofee" ]; then
+    start_tendermint "${TENDERMINT_ZEROFEE_DIRECTORY}" 16657 16658
+elif [ x"${1}" == "xtendermint" ]; then
+    start_tendermint "${TENDERMINT_WITHFEE_DIRECTORY}" 26657 26658
+elif [ x"${1}" == "xchain-abci-zerofee" ]; then
+    start_chain_abci "${ZEROFEE_APP_HASH}" 16658 15933
+elif [ x"${1}" == "xchain-abci" ]; then
+    start_chain_abci "${WITHFEE_APP_HASH}" 26658 25933
+elif [ x"${1}" == "xclient-rpc-zerofee" ]; then
+    start_client_rpc "${WALLET_WITHFEE_STORAGE_DIRECTORY}" 16659 26657
+elif [ x"${1}" == "xclient-rpc" ]; then
+    start_client_rpc "${WALLET_ZEROFEE_STORAGE_DIRECTORY}" 26659 26657
+fi

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -2,9 +2,6 @@
 set -e
 IFS=
 
-WALLET_WITHFEE_STORAGE_DIRECTORY="wallet-storage-withfee"
-WALLET_ZEROFEE_STORAGE_DIRECTORY="wallet-storage-zerofee"
-
 # Global function return value
 RET_VALUE=0
 
@@ -41,6 +38,7 @@ function check_command_exist() {
 }
 
 # @argument Port
+# @argument Docker name
 function start_chain_tx_enclave() {
     print_config "CHAIN_TX_ENCLAVE_DIRECTORY" "${CHAIN_TX_ENCLAVE_DIRECTORY}"
     print_config "CHAIN_HEX_ID" "${CHAIN_HEX_ID}"
@@ -48,19 +46,26 @@ function start_chain_tx_enclave() {
 
     cd "${CHAIN_TX_ENCLAVE_DIRECTORY}" && docker build -t chain-tx-validation \
         -f ./tx-validation/Dockerfile . \
-        --env RUST_BACKTRACE=1 \
-        --env RUST_LOG=debug \
         --build-arg SGX_MODE=SW \
         --build-arg NETWORK_ID="${CHAIN_HEX_ID}"
+
+    print_step "Trying to kill previous docker instance ${4}"
+    set +e
+    docker kill "${2}"
+    set -e
     
     docker run --rm \
         -p "${1}:25933" \
+        --name "${2}" \
+        --env RUST_BACKTRACE=1 \
+        --env RUST_LOG=debug \
         chain-tx-validation
 }
 
 # @argument Tendermint folder path
 # @argument Tendermint Port
 # @argument chain-abci Port
+# @argument Docker name
 function start_tendermint() {
     print_config "CHAIN_ID" "${CHAIN_ID}"
     print_config "TENDERMINT_FOLDER_PATH" "${1}"
@@ -70,20 +75,25 @@ function start_tendermint() {
     TENDERMINT_GENESIS_APP_HASH="$(cat "${1}/config/genesis.json" | jq -r .app_hash)"
     print_config "TENDERMINT_GENESIS_APP_HASH" "${TENDERMINT_GENESIS_APP_HASH}"
 
-    # docker run -v "$(pwd)/${1}:/tendermint" \
-    #     --env TMHOME=/tendermint \
-    #     -p "${2}:26657" \
-    #     "tendermint/tendermint:v${TENDERMINT_VERSION}" \
-    #     node \
-    #         --proxy_app="tcp://host.docker.internal:${3}" \
-    #         --rpc.laddr=tcp://0.0.0.0:26657 \
-    #         --consensus.create_empty_blocks=false
+    print_step "Trying to kill previous docker instance ${4}"
+    set +e
+    docker kill "${4}"
+    set -e
 
-    tendermint node \
-        --home "${1}" \
-        --proxy_app="tcp://127.0.0.1:${3}" \
-        --rpc.laddr="tcp://0.0.0.0:${2}" \
-        --consensus.create_empty_blocks=false
+    STORAGE=$(mktemp -d)    
+    cp -r "${1}/." "${STORAGE}"
+    print_config "STORAGE" "${STORAGE}"
+
+    docker run --rm \
+        -v "$(pwd)/${1}:/tendermint" \
+        -p "${2}:26657" \
+        --name "${4}" \
+        --env TMHOME=/tendermint \
+        "tendermint/tendermint:v${TENDERMINT_VERSION}" \
+        node \
+            --proxy_app="tcp://host.docker.internal:${3}" \
+            --rpc.laddr=tcp://0.0.0.0:26657 \
+            --consensus.create_empty_blocks=false
 }
 
 # @argument App Hash
@@ -116,16 +126,16 @@ function start_client_rpc() {
     print_config "PORT" "${1}"
     print_config "TENDERMINT_PORT" "${2}"
 
-    rm -rf "/tmp/${1}"
-    mkdir -p  "/tmp/${1}"
-    cp -r "${WALLET_STORAGE_DIRECTORY}" "/tmp/${1}"
+    STORAGE=$(mktemp -d)    
+    cp -r "${WALLET_STORAGE_DIRECTORY}/." "${STORAGE}"
+    print_config "STORAGE" "${STORAGE}"
 
     RUST_BACKTRACE=1 && RUST_LOG=info cargo run \
         --bin client-rpc -- \
-            --port "${2}" \
-            --network_id "${CHAIN_HEX_ID}" \
-            --storage-dir "/tmp/${1}" \
-            --tendermint-url "http://127.0.0.1:${3}"
+            --port "${1}" \
+            --network-id "${CHAIN_HEX_ID}" \
+            --storage-dir "${STORAGE}" \
+            --tendermint-url "http://127.0.0.1:${2}"
 }
 
 # Always execute at script located directory
@@ -140,19 +150,21 @@ check_command_exist "cargo"
 check_command_exist "docker"
 
 if [ x"${1}" == "xchain-tx-enclave-zerofee" ]; then
-    start_chain_tx_enclave 15933
+    start_chain_tx_enclave 15933 "chain-tx-enclave-zerofee"
 elif [ x"${1}" == "xchain-tx-enclave" ]; then
-    start_chain_tx_enclave 25933
+    start_chain_tx_enclave 25933 "chain-tx-enclave"
 elif [ x"${1}" == "xtendermint-zerofee" ]; then
-    start_tendermint "${TENDERMINT_ZEROFEE_DIRECTORY}" 16657 16658
+    start_tendermint "${TENDERMINT_ZEROFEE_DIRECTORY}" 16657 16658 "tendermint-zerofee"
 elif [ x"${1}" == "xtendermint" ]; then
-    start_tendermint "${TENDERMINT_WITHFEE_DIRECTORY}" 26657 26658
+    start_tendermint "${TENDERMINT_WITHFEE_DIRECTORY}" 26657 26658 "tendermint"
 elif [ x"${1}" == "xchain-abci-zerofee" ]; then
     start_chain_abci "${ZEROFEE_APP_HASH}" 16658 15933
 elif [ x"${1}" == "xchain-abci" ]; then
     start_chain_abci "${WITHFEE_APP_HASH}" 26658 25933
 elif [ x"${1}" == "xclient-rpc-zerofee" ]; then
-    start_client_rpc "${WALLET_WITHFEE_STORAGE_DIRECTORY}" 16659 26657
+    start_client_rpc 16659 16657
 elif [ x"${1}" == "xclient-rpc" ]; then
-    start_client_rpc "${WALLET_ZEROFEE_STORAGE_DIRECTORY}" 26659 26657
+    start_client_rpc 26659 26657
+else
+    print_error "Unknown command ${1}"
 fi


### PR DESCRIPTION
### Problem in details
The integration tests use docker to build and run the test environment. When you are under active development, you have to rebuild from scratch again on every code changes because the docker always rebuild from scratch

### Solution
Refactor integration tests to allow starting the test environment using local build (from `cargo build`)

### Quick steps to run a local integration test environment:
```bash
# Prepare wallet, Tendermint genesis etc
$ ./integration-tests/prepare.sh

# Start different components
$ ./integration-tests/start-local.sh <chain-tx-enclave|chain-tx-enclave-zerofee>
$ ./integration-tests/start-local.sh <tendermint|tendermint-zerofee>
$ ./integration-tests/start-local.sh <chain-abci|chain-abci-zerofee>
$ ./integration-tests/start-local.sh <client-rpc|client-rpc-zerofee>
```

### ClientRPC Integration test now supports testing only "normal" or "zero-fee" mode
```bash
$ cd integration-tests/client-cli
$ TEST_ONY=<WITH_FEE|ZERO_FEE> yarn test
```

For details, please refer to README in integration tests folder