### PR TITLE
Problem: (CRO-359) Batch size for tendermint RPC calls is not configurable

### DIFF
--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -42,7 +42,7 @@ where
             self.prepare_synchronized_parameters(&request)?;
 
         self.synchronizer
-            .sync(&staking_addresses, &view_key, &private_key)
+            .sync(&staking_addresses, &view_key, &private_key, None)
             .map_err(to_rpc_error)
     }
 
@@ -51,7 +51,7 @@ where
             self.prepare_synchronized_parameters(&request)?;
 
         self.synchronizer
-            .sync_all(&staking_addresses, &view_key, &private_key)
+            .sync_all(&staking_addresses, &view_key, &private_key, None)
             .map_err(to_rpc_error)
     }
 }


### PR DESCRIPTION
Solution: Added a cli option to configure batch size. Default is 20.