### PR TITLE
Problem: (CRO-359) Client does not fast forward when app hash is same

### DIFF
--- a/chain-tx-filter/src/lib.rs
+++ b/chain-tx-filter/src/lib.rs
@@ -5,7 +5,7 @@ use secp256k1::key::PublicKey;
 use std::convert::TryFrom;
 
 /// Probabilistic fixed-size filter wrapper
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct BlockFilter {
     // may be replaced with GCS, e.g. https://github.com/dac-gmbh/golomb-set
     bloom: Bloom,

--- a/client-common/src/block_header.rs
+++ b/client-common/src/block_header.rs
@@ -6,7 +6,10 @@ use chain_tx_filter::BlockFilter;
 use crate::Transaction;
 
 /// Structure for representing a block header on Crypto.com Chain
+#[derive(Debug)]
 pub struct BlockHeader {
+    /// App hash of block
+    pub app_hash: String,
     /// Block height
     pub block_height: u64,
     /// Block time

--- a/client-common/src/tendermint/types/block.rs
+++ b/client-common/src/tendermint/types/block.rs
@@ -28,6 +28,7 @@ pub struct Data {
 
 #[derive(Debug, Deserialize)]
 pub struct Header {
+    pub app_hash: String,
     pub height: String,
     pub time: DateTime<Utc>,
 }
@@ -76,8 +77,15 @@ impl Block {
     }
 
     /// Returns time of this block
+    #[inline]
     pub fn time(&self) -> DateTime<Utc> {
         self.block.header.time
+    }
+
+    /// Returns app hash of this block
+    #[inline]
+    pub fn app_hash(&self) -> String {
+        self.block.header.app_hash.clone()
     }
 }
 
@@ -136,6 +144,8 @@ mod tests {
         let block = Block {
             block: BlockInner {
                 header: Header {
+                    app_hash: "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                        .to_owned(),
                     height: "1".to_owned(),
                     time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
                 },
@@ -165,6 +175,8 @@ mod tests {
         let block = Block {
             block: BlockInner {
                 header: Header {
+                    app_hash: "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                        .to_owned(),
                     height: "1".to_owned(),
                     time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
                 },
@@ -180,6 +192,8 @@ mod tests {
         let block = Block {
             block: BlockInner {
                 header: Header {
+                    app_hash: "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                        .to_owned(),
                     height: "a".to_owned(),
                     time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
                 },

--- a/client-common/src/tendermint/types/status.rs
+++ b/client-common/src/tendermint/types/status.rs
@@ -13,6 +13,7 @@ pub struct Status {
 #[derive(Debug, Deserialize)]
 pub struct SyncInfo {
     pub latest_block_height: String,
+    pub latest_app_hash: String,
 }
 
 impl Status {
@@ -23,6 +24,12 @@ impl Status {
             .latest_block_height
             .parse::<u64>()
             .context(ErrorKind::DeserializationError)?)
+    }
+
+    /// Returns last app hash
+    #[inline]
+    pub fn last_app_hash(&self) -> String {
+        self.sync_info.latest_app_hash.clone()
     }
 }
 
@@ -35,9 +42,15 @@ mod tests {
         let status = Status {
             sync_info: SyncInfo {
                 latest_block_height: "1".to_owned(),
+                latest_app_hash: "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                    .to_string(),
             },
         };
         assert_eq!(1, status.last_block_height().unwrap());
+        assert_eq!(
+            "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C".to_string(),
+            status.last_app_hash()
+        );
     }
 
     #[test]
@@ -45,9 +58,15 @@ mod tests {
         let status = Status {
             sync_info: SyncInfo {
                 latest_block_height: "a".to_owned(),
+                latest_app_hash: "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                    .to_string(),
             },
         };
 
         assert!(status.last_block_height().is_err());
+        assert_eq!(
+            "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C".to_string(),
+            status.last_app_hash()
+        );
     }
 }

--- a/client-index/src/handler/default_block_handler.rs
+++ b/client-index/src/handler/default_block_handler.rs
@@ -93,8 +93,12 @@ where
             }
         }
 
-        self.global_state_service
-            .set_last_block_height(view_key, block_header.block_height)
+        // TODO: Set current block's app hash
+        self.global_state_service.set_global_state(
+            view_key,
+            block_header.block_height,
+            block_header.app_hash,
+        )
     }
 }
 
@@ -184,6 +188,8 @@ mod tests {
         block_filter.add_view_key(&view_key.into());
 
         BlockHeader {
+            app_hash: "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                .to_string(),
             block_height: 1,
             block_time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
             transaction_ids,

--- a/client-index/src/synchronizer.rs
+++ b/client-index/src/synchronizer.rs
@@ -108,7 +108,7 @@ where
         self.sync(staking_addresses, view_key, private_key, batch_size)
     }
 
-    /// Fast forwards state to given status state if app hashes match
+    /// Fast forwards state to given status if app hashes match
     fn fast_forward_status(
         &self,
         staking_addresses: &[StakedStateAddress],

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -372,6 +372,9 @@ pub mod tests {
             Ok(Status {
                 sync_info: SyncInfo {
                     latest_block_height: "1".to_string(),
+                    latest_app_hash:
+                        "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                            .to_string(),
                 },
             })
         }
@@ -380,6 +383,9 @@ pub mod tests {
             Ok(Block {
                 block: BlockInner {
                     header: Header {
+                        app_hash:
+                            "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                                .to_string(),
                         height: "1".to_string(),
                         time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
                     },
@@ -395,6 +401,9 @@ pub mod tests {
             Ok(vec![Block {
                 block: BlockInner {
                     header: Header {
+                        app_hash:
+                            "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
+                                .to_string(),
                         height: "1".to_string(),
                         time: DateTime::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
                     },


### PR DESCRIPTION
**Solution**:
1. Client will now fast forward if current app hash matches last app hash stored in client.
2. Client will fast forward each batch of requests (default is 20) if the batch does not change app hash (it will still make `block` RPC call).

**Note**: Because this PR changes internal storage structure of `last_block_height` and `last_app_hash`, every client will have to do a `sync --force`.