### PR TITLE
Problem: failing CI on stable (on audit command)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ rust: &rust
       cargo fmt -- --check --color=auto &&
       (cargo-clippy --version || rustup component add clippy) &&
       cargo clippy -- -D warnings &&
-      (cargo-audit --version || cargo install cargo-audit) &&
+      (cargo-audit -h || cargo install cargo-audit) &&
       cargo audit       
     fi
 


### PR DESCRIPTION
Solution: audit didn't have a version arg/command (for testing the executable presence) => switched to the help arg/command