### PR TITLE
Problem: Client synchronization fails when storage does not contain input transaction details

### DIFF
--- a/client-common/src/error.rs
+++ b/client-common/src/error.rs
@@ -65,6 +65,9 @@ pub enum ErrorKind {
     /// Transaction not found
     #[fail(display = "Transaction not found")]
     TransactionNotFound,
+    /// Output not found
+    #[fail(display = "Output not found")]
+    OutputNotFound,
     /// Private key not found
     #[fail(display = "Private key not found")]
     PrivateKeyNotFound,

--- a/client-index/src/handler/default_transaction_handler.rs
+++ b/client-index/src/handler/default_transaction_handler.rs
@@ -127,21 +127,23 @@ where
     ) -> Result<()> {
         let output = self.transaction_service.get_output(&input)?;
 
-        let change = TransactionChange {
-            transaction_id,
-            address: output.address,
-            balance_change: BalanceChange::Outgoing(output.value),
-            block_height,
-            block_time,
-        };
+        if let Some(output) = output {
+            let change = TransactionChange {
+                transaction_id,
+                address: output.address,
+                balance_change: BalanceChange::Outgoing(output.value),
+                block_height,
+                block_time,
+            };
 
-        let address = change.address.clone();
+            let address = change.address.clone();
 
-        // Update transaction history and balance
-        memento.add_transaction_change(&address, change);
+            // Update transaction history and balance
+            memento.add_transaction_change(&address, change);
 
-        // Update unspent transactions
-        memento.remove_unspent_transaction(&address, input);
+            // Update unspent transactions
+            memento.remove_unspent_transaction(&address, input);
+        }
 
         Ok(())
     }

--- a/client-index/src/index/default_index.rs
+++ b/client-index/src/index/default_index.rs
@@ -4,7 +4,7 @@ use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::TxId;
 use client_common::tendermint::types::BroadcastTxResult;
 use client_common::tendermint::Client;
-use client_common::{Result, Storage, Transaction};
+use client_common::{Error, ErrorKind, Result, Storage, Transaction};
 
 use crate::service::*;
 use crate::Index;
@@ -56,7 +56,9 @@ where
 
     #[inline]
     fn output(&self, input: &TxoPointer) -> Result<TxOut> {
-        self.transaction_service.get_output(input)
+        self.transaction_service
+            .get_output(input)?
+            .ok_or_else(|| Error::from(ErrorKind::TransactionNotFound))
     }
 
     #[inline]

--- a/client-index/src/service/transaction_service.rs
+++ b/client-index/src/service/transaction_service.rs
@@ -127,6 +127,7 @@ mod tests {
             transaction_service
                 .get_output(&TxoPointer::new(transaction_id, 0))
                 .unwrap()
+                .unwrap()
                 .value
         );
 

--- a/client-index/src/service/transaction_service.rs
+++ b/client-index/src/service/transaction_service.rs
@@ -53,27 +53,29 @@ where
     }
 
     /// Retrieves transaction output corresponding to given pointer
-    pub fn get_output(&self, input: &TxoPointer) -> Result<TxOut> {
-        let transaction = self
-            .get(&input.id)?
-            .ok_or_else(|| Error::from(ErrorKind::TransactionNotFound))?;
+    pub fn get_output(&self, input: &TxoPointer) -> Result<Option<TxOut>> {
+        let transaction = self.get(&input.id)?;
 
-        let outputs = match transaction {
-            Transaction::TransferTransaction(transfer_transaction) => {
-                Ok(transfer_transaction.outputs)
-            }
-            Transaction::WithdrawUnbondedStakeTransaction(withdraw_transaction) => {
-                Ok(withdraw_transaction.outputs)
-            }
-            _ => Err(Error::from(ErrorKind::InvalidTransaction)),
-        }?;
+        transaction
+            .map(|transaction| {
+                let outputs = match transaction {
+                    Transaction::TransferTransaction(transfer_transaction) => {
+                        Ok(transfer_transaction.outputs)
+                    }
+                    Transaction::WithdrawUnbondedStakeTransaction(withdraw_transaction) => {
+                        Ok(withdraw_transaction.outputs)
+                    }
+                    _ => Err(Error::from(ErrorKind::InvalidTransaction)),
+                }?;
 
-        let output = outputs
-            .into_iter()
-            .nth(input.index.try_into().unwrap())
-            .ok_or_else(|| Error::from(ErrorKind::TransactionNotFound))?;
+                let output = outputs
+                    .into_iter()
+                    .nth(input.index.try_into().unwrap())
+                    .ok_or_else(|| Error::from(ErrorKind::OutputNotFound))?;
 
-        Ok(output)
+                Ok(output)
+            })
+            .transpose()
     }
 
     /// Clears all storage


### PR DESCRIPTION
Solution: Ignore a transaction input when its details are not available (this means that current wallet's view key was not present in that transaction).