### PR TITLE
Problem: no error code returned from tx validation enclave (CRO-373)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ name = "chain-tx-validation"
 version = "0.1.0"
 dependencies = [
  "chain-core 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=ac9843a361114b42178acc119ab77d5a149985f5)",
 ]
 

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ac9843a361114b42178acc119ab77d5a149985f5", features = ["recovery", "endomorphism"] }
+parity-scale-codec = { version = "1.0", features = ["derive"] }

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -27,13 +27,14 @@ use chain_core::tx::witness::TxWitness;
 use chain_core::tx::TransactionId;
 pub use chain_core::tx::TxWithOutputs;
 pub use chain_core::ChainInfo;
+use parity_scale_codec::{Decode, Encode};
 use std::collections::BTreeSet;
 use std::convert::From;
 use std::fmt;
 use witness::verify_tx_address;
 
 /// All possible TX validation errors
-#[derive(Debug)]
+#[derive(Debug, Encode, Decode)]
 pub enum Error {
     /// chain hex ID does not match
     WrongChainHexId,

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -16,7 +16,7 @@ extern crate sgx_tstd as std;
 
 use std::prelude::v1::Vec;
 
-use chain_core::init::coin::{Coin, CoinError};
+use chain_core::init::coin::Coin;
 use chain_core::state::account::{DepositBondTx, StakedState, UnbondTx, WithdrawUnbondedTx};
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
@@ -27,9 +27,9 @@ use chain_core::tx::witness::TxWitness;
 use chain_core::tx::TransactionId;
 pub use chain_core::tx::TxWithOutputs;
 pub use chain_core::ChainInfo;
-use secp256k1;
 use std::collections::BTreeSet;
-use std::{fmt, io};
+use std::convert::From;
+use std::fmt;
 use witness::verify_tx_address;
 
 /// All possible TX validation errors
@@ -46,7 +46,8 @@ pub enum Error {
     /// output with no credited value
     ZeroCoin,
     /// input or output summation error
-    InvalidSum(CoinError),
+    /// FIXME: InvalidSum(CoinError),
+    InvalidSum,
     /// transaction has more witnesses than inputs
     UnexpectedWitnesses,
     /// transaction has more inputs than witnesses
@@ -60,9 +61,11 @@ pub enum Error {
     /// output transaction is in timelock that hasn't passed
     OutputInTimelock,
     /// cryptographic library error
-    EcdsaCrypto(secp256k1::Error),
+    /// FIXME: EcdsaCrypto(secp256k1::Error),
+    EcdsaCrypto,
     /// DB read error
-    IoError(io::Error),
+    /// FIXME: IoError(io::Error),
+    IoError,
     /// enclave error or invalid TX,
     EnclaveRejected,
     /// staked state not found
@@ -73,6 +76,34 @@ pub enum Error {
     AccountWithdrawOutputNotLocked,
     /// incorrect nonce supplied in staked state operation
     AccountIncorrectNonce,
+}
+
+/// FIXME: this will go away with simplified intra-enclave FFI calls
+impl From<i32> for Error {
+    fn from(v: i32) -> Self {
+        match v {
+            x if x == Error::WrongChainHexId as i32 => Error::WrongChainHexId,
+            x if x == Error::NoInputs as i32 => Error::NoInputs,
+            x if x == Error::NoOutputs as i32 => Error::NoOutputs,
+            x if x == Error::DuplicateInputs as i32 => Error::DuplicateInputs,
+            x if x == Error::ZeroCoin as i32 => Error::ZeroCoin,
+            x if x == Error::UnexpectedWitnesses as i32 => Error::UnexpectedWitnesses,
+            x if x == Error::MissingWitnesses as i32 => Error::MissingWitnesses,
+            x if x == Error::InvalidInput as i32 => Error::InvalidInput,
+            x if x == Error::InputSpent as i32 => Error::InputSpent,
+            x if x == Error::InputOutputDoNotMatch as i32 => Error::InputOutputDoNotMatch,
+            x if x == Error::OutputInTimelock as i32 => Error::OutputInTimelock,
+            x if x == Error::EcdsaCrypto as i32 => Error::EcdsaCrypto,
+            x if x == Error::IoError as i32 => Error::IoError,
+            x if x == Error::AccountNotFound as i32 => Error::AccountNotFound,
+            x if x == Error::AccountNotUnbonded as i32 => Error::AccountNotUnbonded,
+            x if x == Error::AccountWithdrawOutputNotLocked as i32 => {
+                Error::AccountWithdrawOutputNotLocked
+            }
+            x if x == Error::AccountIncorrectNonce as i32 => Error::AccountIncorrectNonce,
+            _ => Error::EnclaveRejected,
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -86,7 +117,11 @@ impl fmt::Display for Error {
             NoInputs => write!(f, "transaction has no inputs"),
             NoOutputs => write!(f, "transaction has no outputs"),
             ZeroCoin => write!(f, "output with no credited value"),
-            InvalidSum(ref err) => write!(f, "input or output sum error: {}", err),
+            // FIXME: InvalidSum(ref err) => write!(f, "input or output sum error: {}", err),
+            InvalidSum => write!(
+                f,
+                "input or output sum error (summation more than the total supply)"
+            ),
             InvalidInput => write!(f, "transaction spends an invalid input"),
             InputSpent => write!(f, "transaction spends an input that was already spent"),
             InputOutputDoNotMatch => write!(
@@ -94,8 +129,13 @@ impl fmt::Display for Error {
                 "transaction input output coin (plus fee) sums don't match"
             ),
             OutputInTimelock => write!(f, "output transaction is in timelock"),
-            EcdsaCrypto(ref err) => write!(f, "ECDSA crypto error: {}", err),
-            IoError(ref err) => write!(f, "IO error: {}", err),
+            // FIXME: EcdsaCrypto(ref err) => write!(f, "ECDSA crypto error: {}", err),
+            EcdsaCrypto => write!(
+                f,
+                "cryptographic error (signature verification or public key recovery failed)"
+            ),
+            // FIXME: IoError(ref err) => write!(f, "IO error: {}", err),
+            IoError => write!(f, "database lookup error"),
             EnclaveRejected => write!(f, "enclave error or invalid TX"),
             AccountNotFound => write!(f, "account not found"),
             AccountNotUnbonded => write!(f, "account not unbonded for withdrawal"),
@@ -171,12 +211,12 @@ fn check_inputs(
             }
         }
         let wv = verify_tx_address(&in_witness, main_txid, &txout.address);
-        if let Err(e) = wv {
-            return Err(Error::EcdsaCrypto(e));
+        if let Err(_e) = wv {
+            return Err(Error::EcdsaCrypto); // FIXME: Err(Error::EcdsaCrypto(e));
         }
         let sum = incoins + txout.value;
-        if let Err(e) = sum {
-            return Err(Error::InvalidSum(e));
+        if let Err(_e) = sum {
+            return Err(Error::InvalidSum); // FIXME: Err(Error::InvalidSum(e));
         } else {
             incoins = sum.unwrap();
         }
@@ -210,8 +250,8 @@ fn check_input_output_sums(
     // check sum(input amounts) >= sum(output amounts) + minimum fee
     let min_fee: Coin = extra_info.min_fee_computed.to_coin();
     let total_outsum = outcoins + min_fee;
-    if let Err(coin_err) = total_outsum {
-        return Err(Error::InvalidSum(coin_err));
+    if let Err(_coin_err) = total_outsum {
+        return Err(Error::InvalidSum); // FIXME: Err(Error::InvalidSum(coin_err));
     }
     if incoins < total_outsum.unwrap() {
         return Err(Error::InputOutputDoNotMatch);
@@ -239,8 +279,8 @@ pub fn verify_transfer(
         transaction_inputs,
     )?;
     let outcoins = maintx.get_output_total();
-    if let Err(coin_err) = outcoins {
-        return Err(Error::InvalidSum(coin_err));
+    if let Err(_coin_err) = outcoins {
+        return Err(Error::InvalidSum); // FIXME: Err(Error::InvalidSum(coin_err));
     }
     check_input_output_sums(incoins, outcoins.unwrap(), &extra_info)
 }
@@ -353,8 +393,8 @@ pub fn verify_unbonded_withdraw_core(
         return Err(Error::AccountWithdrawOutputNotLocked);
     }
     let outcoins = maintx.get_output_total();
-    if let Err(coin_err) = outcoins {
-        return Err(Error::InvalidSum(coin_err));
+    if let Err(_coin_err) = outcoins {
+        return Err(Error::InvalidSum); // FIXME: Err(Error::InvalidSum(coin_err));
     }
     check_input_output_sums(account.unbonded, outcoins.unwrap(), &extra_info)
 }

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -75,7 +75,7 @@ pub enum EnclaveResponse {
     /// returns OK if chain_hex_id matches the one embedded in enclave and last_app_hash matches (returns the last app hash if any)
     CheckChain(Result<(), Option<H256>>),
     /// returns the affected (account) state (if any) and paid fee if the TX is valid
-    VerifyTx(Result<(Fee, Option<StakedState>), ()>),
+    VerifyTx(Result<(Fee, Option<StakedState>), chain_tx_validation::Error>),
     /// returns if the data was sucessfully persisted in the enclave's local storage
     CommitBlock(Result<(), ()>),
     /// returns a stored launch token if any


### PR DESCRIPTION
Solution:
(WIP -- tx validation enclave needs patching)
- tx validation error cannot be easily passed as C FFI error code => temporarily removed the nested variants
- tx validation error not returned by the enclave protocol => added encode-decode derivation to the tx validation error data type
and extended the enclave protocol