### PR TITLE
Problem: (CRO-341) No way to search for transaction id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "client-common 0.1.0",
  "enclave-protocol 0.1.0",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -200,18 +200,12 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             // TODO: most of these intermediate uncommitted tree roots aren't useful (not exposed for querying) -- prune them / the account storage?
             self.uncommitted_account_root_hash = next_account_root;
             let mut kvpair = KVPair::new();
-            kvpair.key = Vec::from(&b"txid"[..]);
-            // TODO: "Keys and values in tags must be UTF-8 encoded strings" ?
-            kvpair.value = Vec::from(&txaux.tx_id()[..]);
-
-            let mut tx_id_kevpair = KVPair::new();
-            tx_id_kevpair.key = Vec::from(&b"tx.id"[..]);
-            tx_id_kevpair.value = Vec::from(hex::encode(txaux.tx_id()).as_bytes());
+            kvpair.key = Vec::from(&b"tx.id"[..]);
+            kvpair.value = Vec::from(hex::encode(txaux.tx_id()).as_bytes());
 
             let mut event = Event::new();
             event.field_type = TendermintEventType::ValidTransactions.to_string();
             event.attributes.push(kvpair);
-            event.attributes.push(tx_id_kevpair);
             resp.events.push(event);
             self.delivered_txs.push(txaux);
             let rewards_pool = &mut self

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -200,7 +200,7 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             // TODO: most of these intermediate uncommitted tree roots aren't useful (not exposed for querying) -- prune them / the account storage?
             self.uncommitted_account_root_hash = next_account_root;
             let mut kvpair = KVPair::new();
-            kvpair.key = Vec::from(&b"tx.id"[..]);
+            kvpair.key = Vec::from(&b"txid"[..]);
             kvpair.value = Vec::from(hex::encode(txaux.tx_id()).as_bytes());
 
             let mut event = Event::new();

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -203,9 +203,15 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             kvpair.key = Vec::from(&b"txid"[..]);
             // TODO: "Keys and values in tags must be UTF-8 encoded strings" ?
             kvpair.value = Vec::from(&txaux.tx_id()[..]);
+
+            let mut tx_id_kevpair = KVPair::new();
+            tx_id_kevpair.key = Vec::from(&b"tx.id"[..]);
+            tx_id_kevpair.value = Vec::from(hex::encode(txaux.tx_id()).as_bytes());
+
             let mut event = Event::new();
             event.field_type = TendermintEventType::ValidTransactions.to_string();
             event.attributes.push(kvpair);
+            event.attributes.push(tx_id_kevpair);
             resp.events.push(event);
             self.delivered_txs.push(txaux);
             let rewards_pool = &mut self

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -496,7 +496,10 @@ fn deliver_tx_should_add_valid_tx() {
     assert_eq!(1, app.delivered_txs.len());
     assert_eq!(1, cresp.events.len());
     assert_eq!(1, cresp.events[0].attributes.len());
-    assert_eq!(&tx.id()[..], &cresp.events[0].attributes[0].value[..]);
+    assert_eq!(
+        &hex::encode(&tx.id()).as_bytes().to_vec(),
+        &cresp.events[0].attributes[0].value
+    );
 }
 
 #[test]

--- a/client-common/src/tendermint/types/block_results.rs
+++ b/client-common/src/tendermint/types/block_results.rs
@@ -59,12 +59,9 @@ impl BlockResults {
                     for event in transaction.events.iter() {
                         if event.event_type == TendermintEventType::ValidTransactions.to_string() {
                             let tx_id = find_tx_id_from_event_attributes(&event.attributes)?;
-                            match tx_id {
-                                Some(tx_id) => {
-                                    transactions.push(tx_id);
-                                }
-                                None => (),
-                            };
+                            if let Some(id) = tx_id {
+                                transactions.push(tx_id);
+                            }
                         }
                     }
                 }
@@ -101,7 +98,7 @@ impl BlockResults {
     }
 }
 
-fn find_tx_id_from_event_attributes(attributes: &Vec<Attribute>) -> Result<Option<[u8; 32]>> {
+fn find_tx_id_from_event_attributes(attributes: &[Attribute]) -> Result<Option<[u8; 32]>> {
     for attribute in attributes.iter() {
         let key = base64::decode(&attribute.key).chain(|| {
             (
@@ -109,7 +106,7 @@ fn find_tx_id_from_event_attributes(attributes: &Vec<Attribute>) -> Result<Optio
                 "Unable to decode base64 bytes of attribute key in block results",
             )
         })?;
-        if key != b"tx.id" {
+        if key != b"txid" {
             continue;
         }
 
@@ -154,7 +151,7 @@ mod tests {
                     events: vec![Event {
                         event_type: TendermintEventType::ValidTransactions.to_string(),
                         attributes: vec![Attribute {
-                            key: "dHguaWQ=".to_owned(),
+                            key: "dHhpZA==".to_owned(),
                             value: "MDc2NmQ0ZTFjMDkxMjRhZjlhZWI0YTdlZDk5ZDgxNjU0YTg0NDczZjEzMzk0OGNlYTA1MGRhYTE3ZmYwZTdmZg==".to_owned(),
                         }],
                     }],
@@ -194,7 +191,7 @@ mod tests {
                     events: vec![Event {
                         event_type: TendermintEventType::ValidTransactions.to_string(),
                         attributes: vec![Attribute {
-                            key: "dHguaWQ=".to_owned(),
+                            key: "dHhpZA==".to_owned(),
                             value: "kOzcmhZgAAaw5riwRjjKNe+foJEiDAOObTDQ=".to_owned(),
                         }],
                     }],

--- a/client-common/src/tendermint/types/block_results.rs
+++ b/client-common/src/tendermint/types/block_results.rs
@@ -60,7 +60,7 @@ impl BlockResults {
                         if event.event_type == TendermintEventType::ValidTransactions.to_string() {
                             let tx_id = find_tx_id_from_event_attributes(&event.attributes)?;
                             if let Some(id) = tx_id {
-                                transactions.push(tx_id);
+                                transactions.push(id);
                             }
                         }
                     }

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -30,6 +30,7 @@ tokio="0.1.22"
 
 [dev-dependencies]
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "ac9843a361114b42178acc119ab77d5a149985f5", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+hex = "0.3.2"
 
 [features]
 default = ["sled", "rpc"]

--- a/client-index/src/synchronizer.rs
+++ b/client-index/src/synchronizer.rs
@@ -410,7 +410,10 @@ mod tests {
                                 event_type: TendermintEventType::ValidTransactions.to_string(),
                                 attributes: vec![Attribute {
                                     key: "dHhpZA==".to_owned(),
-                                    value: encode(&unbond_transaction().tx_id()).to_owned(),
+                                    value: encode(
+                                        hex::encode(&unbond_transaction().tx_id()).as_bytes(),
+                                    )
+                                    .to_owned(),
                                 }],
                             }],
                         }]),


### PR DESCRIPTION
Solution: Store transaction id as UTF-8 string in `txid` attribute

Remarks:
to search for a particular tx id, use
```bash
curl -X GET \
  'http://localhost:16657/tx_search?query=%22valid_txs.txid=%270766d4e1c09124af9aeb4a7ed99d81654a84473f133948cea050daa17ff0e7ff%27%22&prove=true' \
  -H 'Content-Type: application/json' \
  -H 'Host: localhost:26657'
```