### PR TITLE
Problem: tx-enclaves fail to compile in v1.0.9 sgx sdk

### DIFF
--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -7,19 +7,19 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["serde", "bech32"]
+default = ["serde", "bech32", "hex", "base64"]
 
 
 [dependencies]
 digest = "0.8"
 tiny-keccak = { version = "1.5.0", default-features = false, features = ["keccak"] }
-hex = "0.3"
+hex = { version = "0.3", optional = true }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223", features = ["recovery", "endomorphism", "serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = "0.8"
 serde_json = "1.0"
 parity-scale-codec = { features = ["derive"], version = "1.0" }
-base64 = "0.10"
+base64 = { version = "0.10", optional = true }
 static_assertions = "0.3.4"
 bech32 = { version = "0.7.1", optional = true }
 

--- a/chain-core/src/init/address.rs
+++ b/chain-core/src/init/address.rs
@@ -18,6 +18,7 @@ use std::prelude::v1::{String, ToString};
 use std::str::FromStr;
 use std::{fmt, ops};
 
+#[cfg(feature = "hex")]
 use hex;
 use secp256k1::key::PublicKey;
 #[cfg(feature = "serde")]
@@ -77,6 +78,7 @@ where
 
 /// Core domain logic errors
 #[derive(Debug)]
+#[cfg(feature = "hex")]
 pub enum ErrorAddress {
     /// An invalid length
     InvalidLength(usize),
@@ -94,18 +96,21 @@ pub enum ErrorAddress {
     InvalidCroAddress,
 }
 
+#[cfg(feature = "hex")]
 impl From<hex::FromHexError> for ErrorAddress {
     fn from(err: hex::FromHexError) -> Self {
         ErrorAddress::UnexpectedHexEncoding(err)
     }
 }
 
+#[cfg(feature = "hex")]
 impl From<secp256k1::Error> for ErrorAddress {
     fn from(err: secp256k1::Error) -> Self {
         ErrorAddress::EcdsaCrypto(err)
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for ErrorAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -133,7 +138,7 @@ impl fmt::Display for CroAddressError {
     }
 }
 
-#[cfg(not(any(feature = "mesalock_sgx", target_env = "sgx")))]
+#[cfg(feature = "hex")]
 impl std::error::Error for ErrorAddress {
     fn description(&self) -> &str {
         "Core error"
@@ -157,6 +162,7 @@ pub type RedeemAddressRaw = [u8; REDEEM_ADDRESS_BYTES];
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 pub struct RedeemAddress(pub RedeemAddressRaw);
 
+#[cfg(feature = "hex")]
 impl RedeemAddress {
     /// Try to convert a byte vector to `RedeemAddress`.
     ///
@@ -173,7 +179,7 @@ impl RedeemAddress {
     }
 }
 
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 impl CroAddress<RedeemAddress> for RedeemAddress {
     fn to_cro(&self) -> Result<String, CroAddressError> {
         let checked_data: Vec<u5> = self.0.to_vec().to_base32();
@@ -217,6 +223,7 @@ impl From<[u8; REDEEM_ADDRESS_BYTES]> for RedeemAddress {
     }
 }
 
+#[cfg(feature = "hex")]
 impl FromStr for RedeemAddress {
     type Err = ErrorAddress;
 
@@ -235,13 +242,14 @@ impl FromStr for RedeemAddress {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for RedeemAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "0x{}", hex::encode(self.0))
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 impl Serialize for RedeemAddress {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -251,7 +259,7 @@ impl Serialize for RedeemAddress {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 impl<'de> Deserialize<'de> for RedeemAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/chain-core/src/init/mod.rs
+++ b/chain-core/src/init/mod.rs
@@ -6,9 +6,10 @@ pub mod address;
 /// Fixed supply coin/amounts
 pub mod coin;
 /// Configuration in JSON passed to InitChain
+#[cfg(feature = "base64")]
 pub mod config;
 
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 pub mod network;
 
 /// maximum total supply with a fixed decimal point

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::prelude::v1::Vec;
 use std::str::FromStr;
 // TODO: switch to normal signatures + explicit public key
+#[cfg(feature = "hex")]
 use crate::init::address::ErrorAddress;
 use secp256k1::recovery::{RecoverableSignature, RecoveryId};
 use std::convert::{From, TryFrom};
@@ -39,7 +40,7 @@ pub enum StakedStateAddress {
     BasicRedeem(RedeemAddress),
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 impl Serialize for StakedStateAddress {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -49,7 +50,7 @@ impl Serialize for StakedStateAddress {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 impl<'de> Deserialize<'de> for StakedStateAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -78,6 +79,7 @@ impl<'de> Deserialize<'de> for StakedStateAddress {
     }
 }
 
+#[cfg(feature = "hex")]
 impl TryFrom<&[u8]> for StakedStateAddress {
     type Error = ErrorAddress;
 
@@ -93,6 +95,7 @@ impl From<RedeemAddress> for StakedStateAddress {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for StakedStateAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -101,6 +104,7 @@ impl fmt::Display for StakedStateAddress {
     }
 }
 
+#[cfg(feature = "hex")]
 impl FromStr for StakedStateAddress {
     type Err = ErrorAddress;
 
@@ -111,7 +115,10 @@ impl FromStr for StakedStateAddress {
 
 /// represents the StakedState (account involved in staking)
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Deserialize, Serialize)
+)]
 pub struct StakedState {
     pub nonce: Nonce,
     pub bonded: Coin,
@@ -234,7 +241,10 @@ impl StakedStateOpAttributes {
 /// takes UTXOs inputs, deposits them in the specified StakedState's bonded amount - fee
 /// (updates StakedState's bonded + nonce)
 #[derive(Debug, PartialEq, Eq, Clone, Encode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Serialize, Deserialize)
+)]
 pub struct DepositBondTx {
     pub inputs: Vec<TxoPointer>,
     pub to_staked_account: StakedStateAddress,
@@ -279,6 +289,7 @@ impl DepositBondTx {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for DepositBondTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for input in self.inputs.iter() {
@@ -321,7 +332,10 @@ impl fmt::Display for UnbondTx {
 /// takes the StakedState (TODO: implicit from the witness?) and creates UTXOs
 /// (update's StakedState's unbonded + nonce)
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Serialize, Deserialize)
+)]
 pub struct WithdrawUnbondedTx {
     pub nonce: Nonce,
     pub outputs: Vec<TxOut>,
@@ -347,6 +361,7 @@ impl WithdrawUnbondedTx {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for WithdrawUnbondedTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "-> (unbonded) (nonce: {})", self.nonce)?;

--- a/chain-core/src/state/mod.rs
+++ b/chain-core/src/state/mod.rs
@@ -37,7 +37,10 @@ impl RewardsPoolState {
 
 /// holds state about a node responsible for transaction validation / block signing and service node whitelist management
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Serialize, Deserialize)
+)]
 pub struct CouncilNode {
     // account with the required staked amount
     pub staking_account_address: StakedStateAddress,

--- a/chain-core/src/tx/data/address.rs
+++ b/chain-core/src/tx/data/address.rs
@@ -11,7 +11,7 @@ use crate::init::address::{CroAddress, CroAddressError};
 #[cfg(feature = "bech32")]
 use bech32::{self, u5, FromBase32, ToBase32};
 
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 use crate::init::network::get_bech32_human_part;
 
 /// TODO: opaque types?
@@ -26,7 +26,7 @@ pub enum ExtendedAddr {
     OrTree(TreeRoot),
 }
 
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 impl ExtendedAddr {
     fn get_string(&self, hash: TreeRoot) -> String {
         let checked_data: Vec<u5> = hash.to_vec().to_base32();
@@ -36,7 +36,7 @@ impl ExtendedAddr {
     }
 }
 
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 impl CroAddress<ExtendedAddr> for ExtendedAddr {
     fn to_cro(&self) -> Result<String, CroAddressError> {
         match self {
@@ -59,23 +59,14 @@ impl CroAddress<ExtendedAddr> for ExtendedAddr {
     }
 }
 
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 impl fmt::Display for ExtendedAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_cro().unwrap())
     }
 }
 
-#[cfg(not(feature = "bech32"))]
-impl fmt::Display for ExtendedAddr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ExtendedAddr::OrTree(hash) => write!(f, "0x{}", hex::encode(hash)),
-        }
-    }
-}
-
-#[cfg(feature = "bech32")]
+#[cfg(all(feature = "bech32", feature = "hex"))]
 impl FromStr for ExtendedAddr {
     type Err = CroAddressError;
 

--- a/chain-core/src/tx/data/attribute.rs
+++ b/chain-core/src/tx/data/attribute.rs
@@ -13,9 +13,12 @@ use crate::tx::data::access::TxAccessPolicy;
 #[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxAttributes {
-    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_chain_hex_id"))]
     #[cfg_attr(
-        feature = "serde",
+        all(feature = "serde", feature = "hex"),
+        serde(serialize_with = "serialize_chain_hex_id")
+    )]
+    #[cfg_attr(
+        all(feature = "serde", feature = "hex"),
         serde(deserialize_with = "deserialize_chain_hex_id")
     )]
     pub chain_hex_id: u8,
@@ -23,7 +26,7 @@ pub struct TxAttributes {
     // TODO: other attributes, e.g. versioning info
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn serialize_chain_hex_id<S>(
     chain_hex_id: &u8,
@@ -35,7 +38,7 @@ where
     serializer.serialize_str(&hex::encode_upper(vec![*chain_hex_id]))
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 fn deserialize_chain_hex_id<'de, D>(deserializer: D) -> std::result::Result<u8, D::Error>
 where
     D: Deserializer<'de>,

--- a/chain-core/src/tx/data/input.rs
+++ b/chain-core/src/tx/data/input.rs
@@ -15,11 +15,17 @@ pub type TxoIndex = u16;
 /// built from a TxId (hash of the tx) and the offset in the outputs of this
 /// transaction.
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Serialize, Deserialize)
+)]
 pub struct TxoPointer {
-    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_transaction_id"))]
     #[cfg_attr(
-        feature = "serde",
+        all(feature = "serde", feature = "hex"),
+        serde(serialize_with = "serialize_transaction_id")
+    )]
+    #[cfg_attr(
+        all(feature = "serde", feature = "hex"),
         serde(deserialize_with = "deserialize_transaction_id")
     )]
     pub id: TxId,
@@ -27,7 +33,7 @@ pub struct TxoPointer {
     pub index: TxoIndex,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 fn serialize_transaction_id<S>(
     transaction_id: &TxId,
     serializer: S,
@@ -38,7 +44,7 @@ where
     serializer.serialize_str(&hex::encode(transaction_id))
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 fn deserialize_transaction_id<'de, D>(deserializer: D) -> std::result::Result<TxId, D::Error>
 where
     D: Deserializer<'de>,

--- a/chain-core/src/tx/data/mod.rs
+++ b/chain-core/src/tx/data/mod.rs
@@ -47,7 +47,10 @@ pub type TxId = H256;
 /// TODO: max input/output size?
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 #[derive(Debug, Default, PartialEq, Eq, Clone, Encode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Serialize, Deserialize)
+)]
 pub struct Tx {
     pub inputs: Vec<TxoPointer>,
     pub outputs: Vec<TxOut>,
@@ -76,6 +79,7 @@ impl Decode for Tx {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for Tx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for input in self.inputs.iter() {

--- a/chain-core/src/tx/data/output.rs
+++ b/chain-core/src/tx/data/output.rs
@@ -15,16 +15,25 @@ use crate::tx::data::address::ExtendedAddr;
 /// Tx Output composed of an address and a coin value
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "hex"),
+    derive(Serialize, Deserialize)
+)]
 pub struct TxOut {
-    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_address"))]
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_address"))]
+    #[cfg_attr(
+        all(feature = "serde", feature = "hex"),
+        serde(serialize_with = "serialize_address")
+    )]
+    #[cfg_attr(
+        all(feature = "serde", feature = "hex"),
+        serde(deserialize_with = "deserialize_address")
+    )]
     pub address: ExtendedAddr,
     pub value: Coin,
     pub valid_from: Option<Timespec>,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 fn serialize_address<S>(
     address: &ExtendedAddr,
     serializer: S,
@@ -35,7 +44,7 @@ where
     serializer.serialize_str(&address.to_string())
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "hex"))]
 fn deserialize_address<'de, D>(deserializer: D) -> std::result::Result<ExtendedAddr, D::Error>
 where
     D: Deserializer<'de>,
@@ -61,6 +70,7 @@ where
     deserializer.deserialize_str(StrVisitor)
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for TxOut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} -> {}", self.address, self.value)

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -66,6 +66,7 @@ impl PlainTxAux {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for PlainTxAux {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -174,6 +175,7 @@ fn display_tx_witness<T: fmt::Display, W: fmt::Debug>(
     writeln!(f, "witness: {:?}\n", witness)
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for TxAux {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
Solution: WIP as hex + base64 weren't upgraded yet; they are not actually used in the enclave code => their usage was feature guarded, so they could be removed in the enclave code