### PR TITLE
Problem:(CRO-424) Auto-sync doesn't work correctly after adding wallet

### DIFF
--- a/client-index/src/auto_synchronizer.rs
+++ b/client-index/src/auto_synchronizer.rs
@@ -97,12 +97,13 @@ impl AutoSynchronizer {
     fn process_text(&self, a: &str) -> std::result::Result<(), ()> {
         let j: serde_json::Value = serde_json::from_str(&a).map_err(|_e| {})?;
         if j["error"].is_null() {
-            self.close_connection();
             if let Some(core) = self.core.as_ref() {
                 core.send(OwnedMessage::Text(a.into())).map_err(|_e| {})?;
             }
+            Ok(())
+        } else {
+            Err(())
         }
-        Ok(())
     }
 
     /// activate tokio websocket


### PR DESCRIPTION
Solution:
in process_text of auto_synchronizer,
it should return Ok, Err instead of directly close_connection.
because close_connection is called in caller "process_text".