### PR TITLE
Problem: auto-sync broken in 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+*September 12, 2019*
+
+A quick bug fix on top of 0.0.2
+
+## v0.0.3
+
+### Bug fixes
+* [373](https://github.com/crypto-com/chain/pull/373) client-index auto-sync didn't work correctly
+
 *September 11, 2019*
 
 A small patches (mainly dependency bumps) to the released version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,17 +253,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chain-abci"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "abci 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-core 0.0.2",
- "chain-tx-filter 0.0.2",
- "chain-tx-validation 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-filter 0.0.3",
+ "chain-tx-validation 0.0.3",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "enclave-protocol 0.0.2",
+ "enclave-protocol 0.0.3",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "chain-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "chain-tx-filter"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
- "chain-core 0.0.2",
+ "chain-core 0.0.3",
  "ethbloom 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "chain-tx-validation"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
- "chain-core 0.0.2",
+ "chain-core 0.0.3",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
 ]
@@ -349,14 +349,14 @@ dependencies = [
 
 [[package]]
 name = "client-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
- "chain-core 0.0.2",
+ "chain-core 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "client-common 0.0.2",
- "client-core 0.0.2",
- "client-index 0.0.2",
- "client-network 0.0.2",
+ "client-common 0.0.3",
+ "client-core 0.0.3",
+ "client-index 0.0.3",
+ "client-network 0.0.3",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -368,12 +368,12 @@ dependencies = [
 
 [[package]]
 name = "client-common"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-core 0.0.2",
- "chain-tx-filter 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-filter 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,14 +390,14 @@ dependencies = [
 
 [[package]]
 name = "client-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-core 0.0.2",
- "chain-tx-validation 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-validation 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "client-common 0.0.2",
- "client-index 0.0.2",
+ "client-common 0.0.3",
+ "client-index 0.0.3",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -409,15 +409,15 @@ dependencies = [
 
 [[package]]
 name = "client-index"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-core 0.0.2",
- "chain-tx-filter 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-filter 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "client-common 0.0.2",
- "enclave-protocol 0.0.2",
+ "client-common 0.0.3",
+ "enclave-protocol 0.0.3",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -439,15 +439,15 @@ dependencies = [
 
 [[package]]
 name = "client-network"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-core 0.0.2",
- "chain-tx-validation 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-validation 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "client-common 0.0.2",
- "client-core 0.0.2",
- "client-index 0.0.2",
+ "client-common 0.0.3",
+ "client-core 0.0.3",
+ "client-index 0.0.3",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
@@ -456,15 +456,15 @@ dependencies = [
 
 [[package]]
 name = "client-rpc"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
- "chain-core 0.0.2",
- "chain-tx-filter 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-filter 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "client-common 0.0.2",
- "client-core 0.0.2",
- "client-index 0.0.2",
- "client-network 0.0.2",
+ "client-common 0.0.3",
+ "client-core 0.0.3",
+ "client-index 0.0.3",
+ "client-network 0.0.3",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -632,15 +632,15 @@ dependencies = [
 
 [[package]]
 name = "dev-utils"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
- "chain-abci 0.0.2",
- "chain-core 0.0.2",
+ "chain-abci 0.0.3",
+ "chain-core 0.0.3",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "client-common 0.0.2",
- "client-core 0.0.2",
- "client-index 0.0.2",
- "client-network 0.0.2",
+ "client-common 0.0.3",
+ "client-core 0.0.3",
+ "client-index 0.0.3",
+ "client-network 0.0.3",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -704,10 +704,10 @@ dependencies = [
 
 [[package]]
 name = "enclave-protocol"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
- "chain-core 0.0.2",
- "chain-tx-validation 0.0.2",
+ "chain-core 0.0.3",
+ "chain-tx-validation 0.0.3",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
 ]

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-abci"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Pre-alpha version prototype of Crypto.com Chain node (Tendermint ABCI application)"
 readme = "README.md"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-core"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library with core types and serialization for the use in external tools"
 readme = "../README.md"

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-tx-filter"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library that captures the fuctionality related to block-level public view key-based transaction filtering."
 readme = "../README.md"

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-tx-validation"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library with functions that verify, given current chain state's data, if a transaction is valid."
 readme = "../README.md"

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-cli"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-common"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-core"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 description = "This crate exposes following functionalities for interacting with Crypto.com Chain."
 edition = "2018"

--- a/client-index/Cargo.toml
+++ b/client-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-index"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-network"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-rpc"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Calvin Lau <calvin@crypto.com>"]
 edition = "2018"
 

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dev-utils"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Basic CLI for development purposes (e.g. generation of genesis.json parameters)"
 edition = "2018"

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-protocol"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Requests and responses exchanges over ZMQ between chain-abci app "
 readme = "../README.md"


### PR DESCRIPTION
Solution: a hotfix in 0.0.3

--
Note that commits will be cherry-picked on the release/v0.0 branch and then 0.0.3 will be tagged