### PR TITLE
Problem: (CRO-431) Missing WebSocket URL in Integration Tests local mode

### DIFF
--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -136,7 +136,8 @@ function start_client_rpc() {
             --port "${1}" \
             --network-id "${CHAIN_HEX_ID}" \
             --storage-dir "${STORAGE}" \
-            --tendermint-url "http://127.0.0.1:${2}"
+            --tendermint-url "http://127.0.0.1:${2}" \
+            --websocket-url "ws://127.0.0.1:${2}/websocket"
 }
 
 # Always execute at script located directory


### PR DESCRIPTION
Solution: Added WS URL option to `start-local.sh`