### PR TITLE
Problem: complex transaction validation EDL (CRO-386)

### DIFF
--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -44,7 +44,8 @@ impl EnclaveProxy for MockClient {
                 }
             }
             EnclaveRequest::CommitBlock { .. } => EnclaveResponse::CommitBlock(Ok(())),
-            EnclaveRequest::VerifyTx { tx, account, info } => {
+            EnclaveRequest::VerifyTx(txrequest) => {
+                let (tx, account, info) = (txrequest.tx, txrequest.account, txrequest.info);
                 let (txpayload, inputs) = match &tx {
                     TxAux::TransferTx {
                         inputs,

--- a/chain-abci/src/storage/tx.rs
+++ b/chain-abci/src/storage/tx.rs
@@ -78,11 +78,11 @@ pub fn verify<T: EnclaveProxy>(
     let paid_fee = match txaux {
         TxAux::TransferTx { inputs, .. } => {
             check_spent_input_lookup(&inputs, db)?;
-            let response = tx_validator.process_request(EnclaveRequest::VerifyTx {
-                tx: txaux.clone(),
-                account: None,
-                info: extra_info,
-            });
+            let response = tx_validator.process_request(EnclaveRequest::new_tx_request(
+                txaux.clone(),
+                None,
+                extra_info,
+            ));
             match response {
                 EnclaveResponse::VerifyTx(Ok(r)) => r,
                 _ => {
@@ -100,11 +100,11 @@ pub fn verify<T: EnclaveProxy>(
                 }
             };
             check_spent_input_lookup(&tx.inputs, db)?;
-            let response = tx_validator.process_request(EnclaveRequest::VerifyTx {
-                tx: txaux.clone(),
+            let response = tx_validator.process_request(EnclaveRequest::new_tx_request(
+                txaux.clone(),
                 account,
-                info: extra_info,
-            });
+                extra_info,
+            ));
             match response {
                 EnclaveResponse::VerifyTx(Ok(r)) => r,
                 _ => {
@@ -126,11 +126,11 @@ pub fn verify<T: EnclaveProxy>(
                 return Err(Error::EcdsaCrypto); // FIXME: Err(Error::EcdsaCrypto(e));
             }
             let account = get_account(&account_address.unwrap(), last_account_root_hash, accounts)?;
-            let response = tx_validator.process_request(EnclaveRequest::VerifyTx {
-                tx: txaux.clone(),
-                account: Some(account),
-                info: extra_info,
-            });
+            let response = tx_validator.process_request(EnclaveRequest::new_tx_request(
+                txaux.clone(),
+                Some(account),
+                extra_info,
+            ));
             match response {
                 EnclaveResponse::VerifyTx(Ok(r)) => r,
                 _ => {


### PR DESCRIPTION
Solution: refined datatypes in enclave protocol, so that
they could be one entry point and one output point (either via two
memory buffers or a single ipc socket)

--
Note: WIP tx-validation enclave needs to be patched / this will break current enclave protocol integration