### PR TITLE
Problem: client libraries cannot be compiled on their own

### DIFF
--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -13,7 +13,7 @@ miscreant = "0.4"
 blake2 = "0.8"
 hex = "0.4"
 base64 = "0.10"
-secstr = "0.3.2"
+secstr = { version = "0.3.2", features = ["serde"] }
 zeroize = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7"
 hex = "0.4"
 zeroize = "0.10"
 byteorder = "1.3"
-secstr = "0.3.2"
+secstr = { version = "0.3.2", features = ["serde"] }
 itertools = "0.8"
 base64 = "0.10"
 webpki = "0.21"

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -11,7 +11,7 @@ chain-core = { path = "../chain-core" }
 chain-tx-validation = { path = "../chain-tx-validation" }
 client-common = { path = "../client-common" }
 client-core = { path = "../client-core" }
-secstr = "0.3.2"
+secstr = { version = "0.3.2", features = ["serde"] }
 base64 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.0" }


### PR DESCRIPTION
Solution: added the required dependency feature

similar problem to #390 -- discovered with tx-query test, as it imports client-core (previously client-index) and client-common as libraries