### PR TITLE
Problem: chain-tx-enclave repo needs a subtree for small modification of cargo manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_tstd 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
  "static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -319,6 +320,7 @@ dependencies = [
  "chain-core 0.1.0",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
+ "sgx_tstd 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
 ]
 
 [[package]]
@@ -692,6 +694,7 @@ dependencies = [
  "chain-tx-validation 0.1.0",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d78ae81a598a5ceead03aa1ddf04067f6340f223)",
+ "sgx_tstd 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
 ]
 
 [[package]]

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -7,19 +7,21 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["serde", "bech32", "hex", "base64"]
+default = ["serde", "bech32", "hex", "base64", "secp256k1zkp/serde"]
+mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx"]
 
 
 [dependencies]
-digest = "0.8"
+digest = { version = "0.8", default-features = false}
 tiny-keccak = { version = "1.5.0", default-features = false, features = ["keccak"] }
 hex = { version = "0.4", optional = true }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223", features = ["recovery", "endomorphism", "serde"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223", features = ["recovery", "endomorphism"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-blake2 = "0.8"
-parity-scale-codec = { features = ["derive"], version = "1.0" }
+blake2 = { version = "0.8", default-features = false }
+parity-scale-codec = { features = ["derive"], default-features = false, version = "1.0" }
 base64 = { version = "0.10", optional = true }
-static_assertions = "0.3.4"
+sgx_tstd = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-sdk.git", optional = true }
+static_assertions = { version = "0.3.4", default-features = false}
 bech32 = { version = "0.7.1", optional = true }
 
 [dev-dependencies]

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -6,7 +6,12 @@ description = "Library with functions that verify, given current chain state's d
 readme = "../README.md"
 edition = "2018"
 
+[features]
+default = []
+mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx"]
+
 [dependencies]
-chain-core = { path = "../chain-core" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223", features = ["recovery", "endomorphism"] }
-parity-scale-codec = { version = "1.0", features = ["derive"] }
+chain-core = { path = "../chain-core", default-features = false }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223", features = ["recovery", "endomorphism"] }
+parity-scale-codec = { features = ["derive"], default-features = false, version = "1.0" }
+sgx_tstd = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-sdk.git", optional = true }

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -6,8 +6,13 @@ description = "Requests and responses exchanges over ZMQ between chain-abci app 
 readme = "../README.md"
 edition = "2018"
 
+[features]
+default = []
+mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx", "chain-tx-validation/mesalock_sgx"]
+
 [dependencies]
-chain-core = { path = "../chain-core" }
-chain-tx-validation = { path = "../chain-tx-validation" }
-parity-scale-codec = { version = "1.0", features = ["derive"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223" }
+chain-core = { path = "../chain-core", default-features = false }
+chain-tx-validation = { path = "../chain-tx-validation", default-features = false }
+parity-scale-codec = { version = "1.0", default-features = false, features = ["derive"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223" }
+sgx_tstd = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-sdk.git", optional = true }


### PR DESCRIPTION
Solution: tweaked Cargo.toml's feature set up, such that the exact same code (including Cargo.toml) can be compiled both in the enclave and in the normal environment. (hopefully we can get rid of the subtree after this)
