### PR TITLE
Problem: (CRO-444) auto sync doesn't work correctly after receceiving incorrect messages

### DIFF
--- a/client-core/src/synchronizer/auto_sync.rs
+++ b/client-core/src/synchronizer/auto_sync.rs
@@ -57,7 +57,7 @@ impl AutoSync {
         // set send queue
         {
             let mut data = self.data.lock().expect("auto sync lock");
-            data.send_queue = websocket_queue;
+            data.send_queue_to_core = websocket_queue;
         }
     }
 
@@ -94,7 +94,7 @@ impl AutoSync {
         let send_queue: Option<std::sync::mpsc::Sender<OwnedMessage>>;
         {
             let data = self.data.lock().expect("auto sync lock");
-            send_queue = data.send_queue.clone();
+            send_queue = data.send_queue_to_core.clone();
         }
         let tmp_queue = send_queue.expect("auto sync send queue");
         AutoSynchronizer::send_json(&tmp_queue, json);

--- a/client-core/src/synchronizer/auto_sync_data.rs
+++ b/client-core/src/synchronizer/auto_sync_data.rs
@@ -64,7 +64,7 @@ pub struct AutoSyncData {
     /// sync info
     pub info: AutoSyncInfo,
     /// send queue
-    pub send_queue: Option<std::sync::mpsc::Sender<OwnedMessage>>,
+    pub send_queue_to_core: Option<std::sync::mpsc::Sender<OwnedMessage>>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/client-core/src/synchronizer/auto_synchronizer.rs
+++ b/client-core/src/synchronizer/auto_synchronizer.rs
@@ -129,7 +129,7 @@ impl AutoSynchronizer {
             // tx, rx
             let (channel_tx, channel_rx) = channel;
             {
-                let mut data = self.send_queue.lock().unwrap();
+                let data = &mut self.send_queue.lock().unwrap();
                 data.queue = Some(channel_tx.clone());
             }
             let mut runtime = tokio::runtime::current_thread::Builder::new()


### PR DESCRIPTION
Solutoin:
update send queue after closing the session, which is the channel between core and network.
this is Arc::Mutex related bug, because it's shallow cloning,
we need to use &mut to change it
without that, mutex value is Option, it is just replaced on the stack
and destroyed after it's out of scope.