### PR TITLE
Problem: (CRO-391) Two transport layers for tendermint JSON-RPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miscreant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -386,6 +387,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -15,7 +15,7 @@ use structopt::StructOpt;
 use chain_core::init::coin::Coin;
 use chain_core::state::account::StakedStateAddress;
 use client_common::storage::SledStorage;
-use client_common::tendermint::{Client, RpcClient};
+use client_common::tendermint::{Client, WebsocketRpcClient};
 use client_common::{Result, Storage};
 use client_core::cipher::MockAbciTransactionObfuscation;
 use client_core::handler::{DefaultBlockHandler, DefaultTransactionHandler};
@@ -130,7 +130,7 @@ impl Command {
                 transaction_command,
             } => {
                 let storage = SledStorage::new(storage_path())?;
-                let tendermint_client = RpcClient::new(&tendermint_url());
+                let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
                 let signer = DefaultSigner::new(storage.clone());
                 let fee_algorithm = tendermint_client.genesis()?.fee_policy();
                 let transaction_obfuscation =
@@ -157,7 +157,7 @@ impl Command {
             }
             Command::StakedState { name, address } => {
                 let storage = SledStorage::new(storage_path())?;
-                let tendermint_client = RpcClient::new(&tendermint_url());
+                let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
                 let signer = DefaultSigner::new(storage.clone());
                 let fee_algorithm = tendermint_client.genesis()?.fee_policy();
                 let transaction_obfuscation =
@@ -188,7 +188,7 @@ impl Command {
                 force,
             } => {
                 let storage = SledStorage::new(storage_path())?;
-                let tendermint_client = RpcClient::new(&tendermint_url());
+                let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
 
                 let transaction_handler = DefaultTransactionHandler::new(storage.clone());
                 let transaction_obfuscation =

--- a/client-cli/src/main.rs
+++ b/client-cli/src/main.rs
@@ -51,7 +51,7 @@ pub(crate) fn storage_path() -> String {
 #[inline]
 pub(crate) fn tendermint_url() -> String {
     std::env::var("CRYPTO_CLIENT_TENDERMINT")
-        .unwrap_or_else(|_| "http://localhost:26657/websocket".to_owned())
+        .unwrap_or_else(|_| "ws://localhost:26657/websocket".to_owned())
 }
 
 #[inline]

--- a/client-cli/src/main.rs
+++ b/client-cli/src/main.rs
@@ -51,7 +51,7 @@ pub(crate) fn storage_path() -> String {
 #[inline]
 pub(crate) fn tendermint_url() -> String {
     std::env::var("CRYPTO_CLIENT_TENDERMINT")
-        .unwrap_or_else(|_| "http://localhost:26657/".to_owned())
+        .unwrap_or_else(|_| "http://localhost:26657/websocket".to_owned())
 }
 
 #[inline]

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -9,6 +9,7 @@ chain-core = { path = "../chain-core" }
 chain-tx-filter = { path = "../chain-tx-filter" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d78ae81a598a5ceead03aa1ddf04067f6340f223", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 rand = "0.7"
+log = "0.4"
 miscreant = "0.4"
 blake2 = "0.8"
 hex = "0.4"
@@ -21,7 +22,9 @@ sled = { version = "0.28", optional = true }
 jsonrpc = { version = "0.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 parity-scale-codec = { features = ["derive"], version = "1.0" }
+websocket = { version = "0.23", default-features = false, features = ["sync"], optional = true }
 
 [features]
-default = ["sled", "rpc"]
-rpc = ["jsonrpc", "serde_json"]
+default = ["sled", "websocket-rpc"]
+http-rpc = ["jsonrpc", "serde_json"]
+websocket-rpc = ["websocket", "serde_json"]

--- a/client-common/src/tendermint.rs
+++ b/client-common/src/tendermint.rs
@@ -1,12 +1,16 @@
 //! Tendermint client operations
 mod client;
-#[cfg(feature = "rpc")]
-mod rpc_client;
+#[cfg(feature = "http-rpc")]
+mod http_rpc_client;
 mod unauthorized_client;
+#[cfg(feature = "websocket-rpc")]
+mod websocket_rpc_client;
 
 pub mod types;
 
 pub use client::Client;
-#[cfg(feature = "rpc")]
-pub use rpc_client::RpcClient;
+#[cfg(feature = "http-rpc")]
+pub use http_rpc_client::RpcClient;
 pub use unauthorized_client::UnauthorizedClient;
+#[cfg(feature = "websocket-rpc")]
+pub use websocket_rpc_client::WebsocketRpcClient;

--- a/client-common/src/tendermint/http_rpc_client.rs
+++ b/client-common/src/tendermint/http_rpc_client.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rpc")]
+#![cfg(feature = "http-rpc")]
 
 use jsonrpc::client::Client as JsonRpcClient;
 use jsonrpc::Request;

--- a/client-common/src/tendermint/websocket_rpc_client.rs
+++ b/client-common/src/tendermint/websocket_rpc_client.rs
@@ -1,0 +1,377 @@
+#![cfg(feature = "websocket-rpc")]
+mod types;
+mod websocket_rpc_loop;
+
+pub use types::ConnectionState;
+
+use std::collections::HashMap;
+use std::iter;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use websocket::sender::Writer;
+use websocket::stream::sync::TcpStream;
+use websocket::OwnedMessage;
+
+use self::types::*;
+use crate::tendermint::types::*;
+use crate::tendermint::Client;
+use crate::{Error, ErrorKind, Result, ResultExt};
+
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+const WAIT_FOR_CONNECTION_SLEEP_INTERVAL: Duration = Duration::from_millis(200);
+const WAIT_FOR_CONNECTION_COUNT: u16 = 50;
+
+/// Tendermint RPC Client (uses websocket in transport layer)
+#[derive(Clone)]
+pub struct WebsocketRpcClient {
+    handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+    connection_state: Arc<Mutex<ConnectionState>>,
+    websocket_writer: Arc<Mutex<Writer<TcpStream>>>,
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+}
+
+impl WebsocketRpcClient {
+    /// Creates a new instance of `WebsocketRpcClient`
+    //
+    // # How it works
+    //
+    // - Spawns `websocket_rpc_loop`.
+    // - Spawns `websocket_rpc_loop` monitor.
+    pub fn new(url: &str) -> Result<Self> {
+        let channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>> =
+            Default::default();
+
+        let (websocket_reader, websocket_writer) = websocket_rpc_loop::new_connection(url)?;
+        let websocket_writer = Arc::new(Mutex::new(websocket_writer));
+
+        let loop_handle = websocket_rpc_loop::spawn(
+            channel_map.clone(),
+            websocket_reader,
+            websocket_writer.clone(),
+        );
+
+        let (handle, connection_state) = websocket_rpc_loop::monitor(
+            url.to_owned(),
+            channel_map.clone(),
+            loop_handle,
+            websocket_writer.clone(),
+        );
+
+        Ok(Self {
+            handle: Arc::new(Mutex::new(Some(handle))),
+            connection_state,
+            websocket_writer,
+            channel_map,
+        })
+    }
+
+    /// Returns current connection state of websocket connection
+    pub fn connection_state(&self) -> ConnectionState {
+        *self
+            .connection_state
+            .lock()
+            .expect("Unable to acquire lock on connection state")
+    }
+
+    /// Sends a RPC request
+    //
+    // # How it works
+    //
+    // - Prepares JSON-RPC request from `method` and `params` (generates a random `request_id`).
+    // - Creates a `sync_channel` pair
+    // - Inserts `channel_sender` to `channel_map` corresponding to generated `request_id`.
+    // - Ensure that the `websocket_rpc_loop` is in `Connected` state.
+    // - Send request websocket message.
+    // - Receive response on `channel_receiver`.
+    fn request(&self, method: &str, params: &[Value]) -> Result<Value> {
+        let (id, channel_receiver) = self.send_request(method, params)?;
+        self.receive_response(method, params, &id, channel_receiver)
+    }
+
+    /// Sends RPC requests for a batch.
+    ///
+    /// # Note
+    ///
+    /// This does not use batch JSON-RPC requests but makes multiple single JSON-RPC requests in parallel.
+    fn request_batch(&self, batch_params: Vec<(&str, Vec<Value>)>) -> Result<Vec<Value>> {
+        let mut receivers = Vec::with_capacity(batch_params.len());
+
+        for (method, params) in batch_params.iter() {
+            let (id, channel_receiver) = self.send_request(method, &params)?;
+            receivers.push((id, channel_receiver));
+        }
+
+        receivers
+            .into_iter()
+            .zip(batch_params.into_iter())
+            .map(|((id, channel_receiver), (method, params))| {
+                self.receive_response(method, &params, &id, channel_receiver)
+            })
+            .collect()
+    }
+
+    /// Sends a JSON-RPC request and returns `request_id` and `response_channel`
+    fn send_request(
+        &self,
+        method: &str,
+        params: &[Value],
+    ) -> Result<(String, Receiver<JsonRpcResponse>)> {
+        let (message, id) = prepare_message(method, params)?;
+        let (channel_sender, channel_receiver) = sync_channel::<JsonRpcResponse>(1);
+
+        self.channel_map
+            .lock()
+            .expect("Unable to acquire lock on websocket request map: Lock is poisoned")
+            .insert(id.clone(), channel_sender);
+
+        self.ensure_connected()?;
+
+        self.websocket_writer
+            .lock()
+            .expect("Unable to acquire lock on websocket writer: Lock is poisoned")
+            .send_message(&message)
+            .chain(|| {
+                (
+                    ErrorKind::InternalError,
+                    "Unable to send message to websocket writer",
+                )
+            })
+            .map_err(|err| {
+                self.channel_map
+                    .lock()
+                    .expect("Unable to acquire lock on websocket request map: Lock is poisoned")
+                    .remove(&id);
+                err
+            })?;
+
+        Ok((id, channel_receiver))
+    }
+
+    /// Receives response from websocket for given id.
+    fn receive_response(
+        &self,
+        method: &str,
+        params: &[Value],
+        id: &str,
+        receiver: Receiver<JsonRpcResponse>,
+    ) -> Result<Value> {
+        let response = receiver
+            .recv_timeout(RESPONSE_TIMEOUT)
+            .chain(|| {
+                (
+                    ErrorKind::InternalError,
+                    "Unable to receive message from channel receiver",
+                )
+            })
+            .map_err(|err| {
+                self.channel_map
+                    .lock()
+                    .expect("Unable to acquire lock on websocket request map: Lock is poisoned")
+                    .remove(id);
+                err
+            })?;
+
+        if let Some(err) = response.error {
+            Err(Error::new_with_source(
+                ErrorKind::TendermintRpcError,
+                format!(
+                    "Error response from tendermint RPC for request method ({}) and params ({:?})",
+                    method, params
+                ),
+                Box::new(err),
+            ))
+        } else {
+            Ok(response.result.unwrap_or_default())
+        }
+    }
+
+    /// Ensures that the websocket is connected.
+    fn ensure_connected(&self) -> Result<()> {
+        let mut wait_count = 0;
+
+        while ConnectionState::Disconnected
+            == *self
+                .connection_state
+                .lock()
+                .expect("Unable to acquire lock on connection state")
+            && wait_count < WAIT_FOR_CONNECTION_COUNT
+        {
+            wait_count += 1;
+            thread::sleep(WAIT_FOR_CONNECTION_SLEEP_INTERVAL);
+        }
+
+        if ConnectionState::Disconnected
+            == *self
+                .connection_state
+                .lock()
+                .expect("Unable to acquire lock on connection state")
+        {
+            Err(Error::new(
+                ErrorKind::InternalError,
+                "Websocket connection disconnected",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Makes an RPC call and deserializes response
+    fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
+    where
+        for<'de> T: Deserialize<'de>,
+    {
+        let response_value = self.request(method, params)?;
+        serde_json::from_value(response_value).chain(|| {
+            (
+                ErrorKind::DeserializationError,
+                format!(
+                    "Unable to deserialize `{}` from JSON-RPC response for params: {:?}",
+                    method, params
+                ),
+            )
+        })
+    }
+
+    /// Makes RPC call in batch and deserializes responses
+    fn call_batch<T>(&self, params: Vec<(&str, Vec<Value>)>) -> Result<Vec<T>>
+    where
+        for<'de> T: Deserialize<'de>,
+    {
+        if params.is_empty() {
+            // Do not send empty batch requests
+            return Ok(Default::default());
+        }
+
+        if params.len() == 1 {
+            // Do not send batch request when there is only one set of params
+            self.call::<T>(params[0].0, &params[0].1)
+                .map(|value| vec![value])
+        } else {
+            let response_values = self.request_batch(params.clone())?;
+
+            response_values
+                .into_iter()
+                .zip(params.into_iter())
+                .map(|(response_value, (method, params))| {
+                    serde_json::from_value(response_value).chain(|| {
+                        (
+                            ErrorKind::DeserializationError,
+                            format!(
+                                "Unable to deserialize `{}` from JSON-RPC response for params: {:?}",
+                                method, params
+                            ),
+                        )
+                    })
+                })
+                .collect()
+        }
+    }
+}
+
+impl Client for WebsocketRpcClient {
+    #[inline]
+    fn genesis(&self) -> Result<Genesis> {
+        self.call("genesis", Default::default())
+    }
+
+    #[inline]
+    fn status(&self) -> Result<Status> {
+        self.call("status", Default::default())
+    }
+
+    #[inline]
+    fn block(&self, height: u64) -> Result<Block> {
+        let params = [json!(height.to_string())];
+        self.call("block", &params)
+    }
+
+    #[inline]
+    fn block_batch<'a, T: Iterator<Item = &'a u64>>(&self, heights: T) -> Result<Vec<Block>> {
+        let params = heights
+            .map(|height| ("block", vec![json!(height.to_string())]))
+            .collect::<Vec<(&str, Vec<Value>)>>();
+        self.call_batch::<Block>(params)
+    }
+
+    #[inline]
+    fn block_results(&self, height: u64) -> Result<BlockResults> {
+        let params = [json!(height.to_string())];
+        self.call("block_results", &params)
+    }
+
+    #[inline]
+    fn block_results_batch<'a, T: Iterator<Item = &'a u64>>(
+        &self,
+        heights: T,
+    ) -> Result<Vec<BlockResults>> {
+        let params = heights
+            .map(|height| ("block_results", vec![json!(height.to_string())]))
+            .collect::<Vec<(&str, Vec<Value>)>>();
+        self.call_batch::<BlockResults>(params)
+    }
+
+    fn broadcast_transaction(&self, transaction: &[u8]) -> Result<BroadcastTxResult> {
+        let params = [json!(transaction)];
+        let broadcast_tx_result: BroadcastTxResult = self.call("broadcast_tx_sync", &params)?;
+
+        if broadcast_tx_result.code != 0 {
+            Err(Error::new(
+                ErrorKind::TendermintRpcError,
+                broadcast_tx_result.log,
+            ))
+        } else {
+            Ok(broadcast_tx_result)
+        }
+    }
+
+    fn query(&self, path: &str, data: &[u8]) -> Result<QueryResult> {
+        let params = [
+            json!(path),
+            json!(hex::encode(data)),
+            json!(null),
+            json!(null),
+        ];
+        let result: QueryResult = self.call("abci_query", &params)?;
+
+        if result.code() != 0 {
+            return Err(Error::new(ErrorKind::TendermintRpcError, result.log()));
+        }
+
+        Ok(result)
+    }
+}
+
+fn prepare_message(method: &str, params: &[Value]) -> Result<(OwnedMessage, String)> {
+    let mut rng = thread_rng();
+
+    let id: String = iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .take(7)
+        .collect();
+
+    let request = JsonRpcRequest {
+        id: &id,
+        jsonrpc: "2.0",
+        method,
+        params,
+    };
+
+    let request_json = serde_json::to_string(&request).chain(|| {
+        (
+            ErrorKind::SerializationError,
+            "Unable to serialize RPC request to json",
+        )
+    })?;
+
+    let message = OwnedMessage::Text(request_json);
+
+    Ok((message, id))
+}

--- a/client-common/src/tendermint/websocket_rpc_client/types.rs
+++ b/client-common/src/tendermint/websocket_rpc_client/types.rs
@@ -1,0 +1,46 @@
+#![cfg(feature = "websocket-rpc")]
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Websocket connection state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// Websocket is connected
+    Connected,
+    /// Websocket is disconnected
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcRequest<'a, 'b> {
+    pub id: &'a str,
+    pub jsonrpc: &'static str,
+    pub method: &'a str,
+    pub params: &'b [Value],
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcResponse {
+    pub id: String,
+    pub jsonrpc: String,
+    pub error: Option<JsonRpcError>,
+    pub result: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    pub data: Option<Value>,
+}
+
+impl std::error::Error for JsonRpcError {}
+
+impl fmt::Display for JsonRpcError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RPC error response: {:?}", self)
+    }
+}

--- a/client-common/src/tendermint/websocket_rpc_client/websocket_rpc_loop.rs
+++ b/client-common/src/tendermint/websocket_rpc_client/websocket_rpc_loop.rs
@@ -46,7 +46,6 @@ pub fn new_connection(url: &str) -> Result<(Reader<TcpStream>, Writer<TcpStream>
 ///   - Parse the message into JSON-RPC response.
 ///   - Pop the response channel from `channel_map` corresponding to response's `request_id`.
 ///   - Send the response to the channel.
-#[allow(clippy::type_complexity)]
 pub fn spawn(
     channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
     mut websocket_reader: Reader<TcpStream>,

--- a/client-common/src/tendermint/websocket_rpc_client/websocket_rpc_loop.rs
+++ b/client-common/src/tendermint/websocket_rpc_client/websocket_rpc_loop.rs
@@ -38,12 +38,6 @@ pub fn new_connection(url: &str) -> Result<(Reader<TcpStream>, Writer<TcpStream>
 
 /// Spawns websocket rpc loop in a new thread
 ///
-/// # Arguments
-///
-/// - `url`: URL of websocket server to connect
-/// - `channel_map`: A hashmap of JSON-RPC `request_id` to response channel. Whenever user makes a JSON-RPC request, the
-///   requestor should add a response channel to this map before sending websocket message.
-///
 /// # How it works
 ///
 /// - Connects to websocket server at given `url` and splits the connection in `reader` and `writer`.
@@ -93,11 +87,11 @@ pub fn monitor(
     channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
     loop_handle: JoinHandle<()>,
     websocket_writer: Arc<Mutex<Writer<TcpStream>>>,
-) -> (JoinHandle<()>, Arc<Mutex<ConnectionState>>) {
+) -> Arc<Mutex<ConnectionState>> {
     let connection_state = Arc::new(Mutex::new(ConnectionState::Connected));
     let connection_state_clone = connection_state.clone();
 
-    let monitor_handle = thread::spawn(move || {
+    thread::spawn(move || {
         let mut connection_handle = Some(loop_handle);
 
         loop {
@@ -146,7 +140,7 @@ pub fn monitor(
         }
     });
 
-    (monitor_handle, connection_state)
+    connection_state
 }
 
 /// Deserializes message from websocket into `JsonRpcResponse`

--- a/client-common/src/tendermint/websocket_rpc_client/websocket_rpc_loop.rs
+++ b/client-common/src/tendermint/websocket_rpc_client/websocket_rpc_loop.rs
@@ -1,0 +1,235 @@
+#![cfg(feature = "websocket-rpc")]
+use std::collections::HashMap;
+use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use websocket::receiver::Reader;
+use websocket::sender::Writer;
+use websocket::stream::sync::TcpStream;
+use websocket::{ClientBuilder, OwnedMessage};
+
+use crate::{ErrorKind, Result, ResultExt};
+
+use super::{ConnectionState, JsonRpcResponse};
+
+const MONITOR_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Creates a new websocket connection with given url
+pub fn new_connection(url: &str) -> Result<(Reader<TcpStream>, Writer<TcpStream>)> {
+    ClientBuilder::new(url)
+        .chain(|| (ErrorKind::InvalidInput, format!("Malformed url: {}", url)))?
+        .connect_insecure()
+        .chain(|| {
+            (
+                ErrorKind::InitializationError,
+                format!("Unable to connect to websocket RPC at: {}", url),
+            )
+        })?
+        .split()
+        .chain(|| {
+            (
+                ErrorKind::InternalError,
+                "Unable to split websocket reader and writer",
+            )
+        })
+}
+
+/// Spawns websocket rpc loop in a new thread
+///
+/// # Arguments
+///
+/// - `url`: URL of websocket server to connect
+/// - `channel_map`: A hashmap of JSON-RPC `request_id` to response channel. Whenever user makes a JSON-RPC request, the
+///   requestor should add a response channel to this map before sending websocket message.
+///
+/// # How it works
+///
+/// - Connects to websocket server at given `url` and splits the connection in `reader` and `writer`.
+/// - Spawns a thread and runs `websocket_rpc_loop` in the thread which continues until the thread panics.
+/// - For each websocket message received:
+///   - Parse the message into JSON-RPC response.
+///   - Pop the response channel from `channel_map` corresponding to response's `request_id`.
+///   - Send the response to the channel.
+#[allow(clippy::type_complexity)]
+pub fn spawn(
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+    mut websocket_reader: Reader<TcpStream>,
+    websocket_writer: Arc<Mutex<Writer<TcpStream>>>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        for message in websocket_reader.incoming_messages() {
+            match message {
+                Ok(message) => match message {
+                    OwnedMessage::Text(ref message) => handle_text(message, channel_map.clone()),
+                    OwnedMessage::Binary(ref message) => handle_slice(message, channel_map.clone()),
+                    OwnedMessage::Ping(data) => send_pong(websocket_writer.clone(), data),
+                    _ => {
+                        log::trace!("Received unknown message: {:?}", message);
+                    }
+                },
+                Err(err) => {
+                    log::error!("Websocket error message: {}", err);
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Monitors websocket connection and retries if websocket is disconnected
+///
+/// # How it works
+///
+/// - Websocket connection has two possible states:
+///   - `Connected`: `websocket_rpc_loop` is connected to websocket server
+///   - `Disconnected`: `websocket_rpc_loop` is disconnected from websocket server. Connection should be retried.
+/// - This function spawns a thread and runs connection state machine in a loop.
+///   - If current state is `Disconnected`: Spawns `websocket_rpc_loop` and sets state to `Connected`.
+///   - If current state is `Connected`: Waits for `websocket_rpc_loop` thread to end and sets state to `Disconnected`.
+pub fn monitor(
+    url: String,
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+    loop_handle: JoinHandle<()>,
+    websocket_writer: Arc<Mutex<Writer<TcpStream>>>,
+) -> (JoinHandle<()>, Arc<Mutex<ConnectionState>>) {
+    let connection_state = Arc::new(Mutex::new(ConnectionState::Connected));
+    let connection_state_clone = connection_state.clone();
+
+    let monitor_handle = thread::spawn(move || {
+        let mut connection_handle = Some(loop_handle);
+
+        loop {
+            let connection_state = *connection_state_clone
+                .lock()
+                .expect("Unable to acquire lock on connection state");
+
+            let (new_connection_state, new_connection_handle) = match connection_state {
+                ConnectionState::Disconnected => {
+                    log::warn!("Websocket RPC is disconnected. Trying to reconnect");
+
+                    match new_connection(&url) {
+                        Err(err) => {
+                            log::warn!("Websocket RPC reconnection failure: {:?}", err);
+                            (ConnectionState::Disconnected, None)
+                        }
+                        Ok((new_websocket_reader, new_websocket_writer)) => {
+                            log::info!("Websocket RPC successfully reconnected");
+
+                            *websocket_writer
+                                .lock()
+                                .expect("Unable to acquire lock on websocket writer while reconnecting: Lock is poisoned") = new_websocket_writer;
+
+                            let new_handle = spawn(
+                                channel_map.clone(),
+                                new_websocket_reader,
+                                websocket_writer.clone(),
+                            );
+
+                            (ConnectionState::Connected, Some(new_handle))
+                        }
+                    }
+                }
+                ConnectionState::Connected => {
+                    let _ = connection_handle.unwrap().join();
+                    (ConnectionState::Disconnected, None)
+                }
+            };
+
+            *connection_state_clone
+                .lock()
+                .expect("Unable to acquire lock on connection state") = new_connection_state;
+            connection_handle = new_connection_handle;
+
+            thread::sleep(MONITOR_RETRY_INTERVAL);
+        }
+    });
+
+    (monitor_handle, connection_state)
+}
+
+/// Deserializes message from websocket into `JsonRpcResponse`
+#[inline]
+fn parse_text(message: &str) -> Result<JsonRpcResponse> {
+    serde_json::from_str(&message).chain(|| {
+        (
+            ErrorKind::DeserializationError,
+            format!("Unable to deserialize websocket message: {}", message),
+        )
+    })
+}
+
+/// Deserializes message from websocket into `JsonRpcResponse`
+#[inline]
+fn parse_slice(message: &[u8]) -> Result<JsonRpcResponse> {
+    serde_json::from_slice(message).chain(|| {
+        (
+            ErrorKind::DeserializationError,
+            format!("Unable to deserialize websocket message: {:?}", message),
+        )
+    })
+}
+
+/// Handles websocket text message
+#[inline]
+fn handle_text(
+    message: &str,
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+) {
+    log::trace!("Received text websocket message: {}", message);
+    handle_json_response(parse_text(message), channel_map)
+}
+
+/// Handles websocket binary message
+#[inline]
+fn handle_slice(
+    message: &[u8],
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+) {
+    log::trace!("Received binary websocket message: {:?}", message);
+    handle_json_response(parse_slice(message), channel_map)
+}
+
+/// Handles parsed json response
+fn handle_json_response(
+    response: Result<JsonRpcResponse>,
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+) {
+    match response {
+        Ok(response) => send_response(response, channel_map.clone()),
+        Err(err) => {
+            log::error!("{:?}", err);
+        }
+    }
+}
+
+/// Sends json response to appropriate channel
+fn send_response(
+    response: JsonRpcResponse,
+    channel_map: Arc<Mutex<HashMap<String, SyncSender<JsonRpcResponse>>>>,
+) {
+    let sender = channel_map
+        .lock()
+        .expect("Unable to acquire lock on websocket channel map: Lock is poisoned")
+        .remove(&response.id);
+
+    if let Some(sender) = sender {
+        log::debug!("Sending JSON-RPC response to channel");
+        sender
+            .send(response)
+            .expect("Unable to send message on channel sender");
+    } else {
+        log::warn!("Received a websocket message with no configured handler");
+    }
+}
+
+/// Silently sends pong message on websocket (does nothing in case of error)
+fn send_pong(websocket_writer: Arc<Mutex<Writer<TcpStream>>>, data: Vec<u8>) {
+    let pong = websocket_writer
+        .lock()
+        .expect("Unable to acquire lock on websocket writer")
+        .send_message(&OwnedMessage::Pong(data));
+
+    log::trace!("Received ping, sending pong: {:?}", pong);
+}

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -38,6 +38,7 @@ tokio="0.1.22"
 chain-tx-validation = { path = "../chain-tx-validation" }
 
 [features]
-default = ["sled", "rpc"]
+default = ["sled"]
 sled = ["client-common/sled"]
-rpc = ["client-common/rpc"]
+http-rpc = ["client-common/http-rpc"]
+websocket-rpc = ["client-common/websocket-rpc"]

--- a/client-rpc/src/program.rs
+++ b/client-rpc/src/program.rs
@@ -55,15 +55,6 @@ pub struct Options {
     pub storage_dir: String,
 
     #[structopt(
-        name = "tendermint-url",
-        short,
-        long,
-        default_value = "http://localhost:26657/",
-        help = "Url for connecting with tendermint RPC"
-    )]
-    pub tendermint_url: String,
-
-    #[structopt(
         name = "websocket-url",
         short,
         long,
@@ -107,9 +98,6 @@ pub fn run_electron() {
 
     if let Some(a) = find_string(&args, "--storage-dir") {
         options.storage_dir = args[a + 1].clone()
-    }
-    if let Some(a) = find_string(&args, "--tendermint-url") {
-        options.tendermint_url = args[a + 1].clone()
     }
 
     if let Some(a) = find_string(&args, "--websocket-url") {

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -10,7 +10,7 @@ use chain_core::init::network::{get_network, get_network_id, init_chain_id};
 use chain_core::tx::fee::LinearFee;
 use client_common::storage::SledStorage;
 use client_common::tendermint::{Client, WebsocketRpcClient};
-use client_common::{Error, ErrorKind, Result, ResultExt};
+use client_common::{Error, Result};
 use client_core::cipher::MockAbciTransactionObfuscation;
 use client_core::handler::{DefaultBlockHandler, DefaultTransactionHandler};
 use client_core::signer::DefaultSigner;

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     image: integration-tests-chain
     depends_on:
       - chain-abci
-    command: /usr/bin/wait-for-it.sh tendermint:26657 --strict -- /usr/bin/client-rpc --host 0.0.0.0 --port 26659 --network-id ${CHAIN_HEX_ID} --storage-dir wallet-storage --tendermint-url http://tendermint:26657
+    command: /usr/bin/wait-for-it.sh tendermint:26657 --strict -- /usr/bin/client-rpc --host 0.0.0.0 --port 26659 --network-id ${CHAIN_HEX_ID} --storage-dir wallet-storage --websocket-url ws://tendermint:26657/websocket
     environment:
       RUST_BACKTRACE: 1
     ports:
@@ -73,7 +73,7 @@ services:
     image: integration-tests-chain
     depends_on:
       - chain-abci
-    command: /usr/bin/wait-for-it.sh tendermint-zerofee:26657 --strict -- /usr/bin/client-rpc --host 0.0.0.0 --port 26659 --network-id ${CHAIN_HEX_ID} --storage-dir wallet-storage --tendermint-url http://tendermint-zerofee:26657
+    command: /usr/bin/wait-for-it.sh tendermint-zerofee:26657 --strict -- /usr/bin/client-rpc --host 0.0.0.0 --port 26659 --network-id ${CHAIN_HEX_ID} --storage-dir wallet-storage --websocket-url ws://tendermint-zerofee:26657/websocket
     environment:
       RUST_BACKTRACE: 1
     ports:

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -136,7 +136,6 @@ function start_client_rpc() {
             --port "${1}" \
             --network-id "${CHAIN_HEX_ID}" \
             --storage-dir "${STORAGE}" \
-            --tendermint-url "http://127.0.0.1:${2}" \
             --websocket-url "ws://127.0.0.1:${2}/websocket"
 }
 


### PR DESCRIPTION
Solution: Use websocket for JSON-RPC everywhere

Note: Currently, `AutoSynchronizer` creates its own websocket connection with tendermint. So, there'll be two separate websocket connections with tendermint.