### PR TITLE
Problem: tx-filter not computed in the tx validation enclave (CRO-364)

### DIFF
--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -36,6 +36,9 @@ const TOKEN_LEN: usize = 1024;
 /// raw sgx_sealed_data_t
 type SealedLog = Vec<u8>;
 
+/// tx filter
+type TxFilter = [u8; 256];
+
 /// variable length request passed to the tx-validation enclave
 #[derive(Encode, Decode)]
 pub struct IntraEnclaveRequest {
@@ -105,6 +108,8 @@ pub enum EnclaveRequest {
     /// "stateless" transaction validation requests (sends transaction + all required information)
     /// double-spent / BitVec check done in chain-abci
     VerifyTx(Box<VerifyTxRequest>),
+    /// request to get the block's transaction filter and reset the existing one
+    EndBlock,
     /// request to flush/persist storage + store the computed app hash
     /// FIXME: enclave should be able to compute a part of app hash, so send the other parts and check the same app hash was computed
     CommitBlock { app_hash: H256 },
@@ -133,6 +138,8 @@ pub enum EnclaveResponse {
     CheckChain(Result<(), Option<H256>>),
     /// returns the affected (account) state (if any) and paid fee if the TX is valid
     VerifyTx(Result<(Fee, Option<StakedState>), chain_tx_validation::Error>),
+    /// returns if the transaction filter for the current block
+    EndBlock(Box<TxFilter>),
     /// returns if the data was sucessfully persisted in the enclave's local storage
     CommitBlock(Result<(), ()>),
     /// returns a stored launch token if any


### PR DESCRIPTION
Solution: (WIP) enhanced the enclave protocol to exchanges of tx filters + small changes in the tx filter

NOTE: the logic is not yet implemented in ABCI:
it'll first be implemented in the tx validation enclave and then abci