### PR TITLE
Problem: tx-filter cannot be compiled for the enclave (CRO-364)

### DIFF
--- a/chain-tx-filter/src/filter.rs
+++ b/chain-tx-filter/src/filter.rs
@@ -10,6 +10,7 @@
 use bit_vec::BitVec;
 use chain_core::init::address::keccak256;
 use std::convert::TryFrom;
+use std::prelude::v1::Vec;
 
 pub type H2048 = [u8; 256];
 

--- a/chain-tx-filter/src/lib.rs
+++ b/chain-tx-filter/src/lib.rs
@@ -14,6 +14,7 @@ use filter::H2048;
 use parity_scale_codec::Encode;
 use secp256k1::key::PublicKey;
 use std::convert::TryFrom;
+use std::prelude::v1::Vec;
 
 /// Probabilistic fixed-size filter wrapper
 #[derive(Default, Debug)]

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -41,31 +41,39 @@ type TxFilter = [u8; 256];
 
 /// variable length request passed to the tx-validation enclave
 #[derive(Encode, Decode)]
-pub struct IntraEnclaveRequest {
-    pub request: VerifyTxRequest,
-    pub tx_inputs: Option<Vec<SealedLog>>,
+pub enum IntraEnclaveRequest {
+    ValidateTx {
+        request: Box<VerifyTxRequest>,
+        tx_inputs: Option<Vec<SealedLog>>,
+    },
+    EndBlock,
 }
 
 impl IntraEnclaveRequest {
     /// helper method to validate basic assumptions
     pub fn is_basic_valid(&self, chain_hex_id: u8) -> Result<(), ()> {
-        if self.request.info.chain_hex_id != chain_hex_id {
-            return Err(());
-        }
-        match self.request.tx {
-            TxAux::DepositStakeTx { .. } => match self.tx_inputs {
-                Some(ref i) if !i.is_empty() => Ok(()),
-                _ => Err(()),
-            },
-            TxAux::TransferTx { .. } => match self.tx_inputs {
-                Some(ref i) if !i.is_empty() => Ok(()),
-                _ => Err(()),
-            },
-            TxAux::WithdrawUnbondedStakeTx { .. } => {
-                if self.request.account.is_some() {
-                    Ok(())
-                } else {
-                    Err(())
+        match self {
+            IntraEnclaveRequest::ValidateTx { request, tx_inputs } => {
+                if request.info.chain_hex_id != chain_hex_id {
+                    return Err(());
+                }
+                match request.tx {
+                    TxAux::DepositStakeTx { .. } => match tx_inputs {
+                        Some(ref i) if !i.is_empty() => Ok(()),
+                        _ => Err(()),
+                    },
+                    TxAux::TransferTx { .. } => match tx_inputs {
+                        Some(ref i) if !i.is_empty() => Ok(()),
+                        _ => Err(()),
+                    },
+                    TxAux::WithdrawUnbondedStakeTx { .. } => {
+                        if request.account.is_some() {
+                            Ok(())
+                        } else {
+                            Err(())
+                        }
+                    }
+                    _ => Err(()),
                 }
             }
             _ => Err(()),
@@ -80,6 +88,8 @@ pub enum IntraEnclaveResponseOk {
     TxWithOutputs { paid_fee: Fee, sealed_tx: SealedLog },
     /// deposit stake pays minimal fee, so this returns the sum of input amounts -- staked stake's bonded balance is added `input_coins-min_fee`
     DepositStakeTx { input_coins: Coin },
+    /// transaction filter
+    EndBlock(Box<TxFilter>),
 }
 
 /// variable length response returned from the tx-validation enclave


### PR DESCRIPTION
Solution: added explicit Vec imports + extended the intra-request reply to accommodate for endblock handling