### PR TITLE
Problem: (CRO-448) Integration tests suite in CI is unstable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ jobs:
         - . ./env.sh
         - docker-compose up -d || travis_terminate 1;
         - |
-          sleep 20
+          sleep 30
           docker-compose ps
           docker-compose logs -t --tail="all"
         - ./run-test.sh || travis_terminate 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ jobs:
         - . ./env.sh
         - docker-compose up -d || travis_terminate 1;
         - |
-          sleep 10
+          sleep 20
           docker-compose ps
           docker-compose logs -t --tail="all"
         - ./run-test.sh || travis_terminate 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,9 @@ jobs:
           cd client-rpc
           yarn
           yarn test
+        - |
+          docker-compose ps
+          docker-compose logs -t --tail="all"
 
     # - name: Integration Tests
     #   language: node_js

--- a/integration-tests/client-rpc/test/network-ops.test.ts
+++ b/integration-tests/client-rpc/test/network-ops.test.ts
@@ -25,7 +25,8 @@ describe("Staking", () => {
 	});
 
 	it("should support staking, unbonding and withdrawing", async function () {
-		this.timeout(30000);
+		this.timeout(60000);
+
 		const defaultWalletRequest = newWalletRequest("Default", "123456");
 
 		const walletName = generateWalletName();
@@ -54,7 +55,7 @@ describe("Staking", () => {
 			[viewKey],
 		]);
 		console.info(`[Info] Transaction ID: "${txId}"`);
-		await sleep(2000);
+		await sleep(5000);
 
 		await client.request("sync", [walletRequest]);
 
@@ -150,7 +151,7 @@ describe("Staking", () => {
 				[],
 			]),
 		).to.eventually.eq(null, "Withdraw unbonded stake should work");
-		await sleep(1000);
+		await sleep(5000);
 		await client.request("sync", [walletRequest]);
 		const stakingStateAfterWithdraw = await client.request("staking_state", [
 			walletRequest,

--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -46,7 +46,9 @@ describe("Wallet transaction", () => {
 			).to.eventually.rejectedWith("Insufficient balance");
 		});
 
-		it("can transfer funds between two wallets", async () => {
+		it("can transfer funds between two wallets", async function() {
+			this.timeout(30000);
+
 			const receiverWalletName = generateWalletName("Receive");
 			const senderWalletRequest = newWalletRequest("Default", "123456");
 			const receiverWalletRequest = newWalletRequest(receiverWalletName, "123456");
@@ -91,7 +93,7 @@ describe("Wallet transaction", () => {
 				"wallet_sendToAddress should return transaction id",
 			);
 
-			await sleep(2000);
+			await sleep(5000);
 
 			await zeroFeeClient.request("sync", [senderWalletRequest]);
 			await zeroFeeClient.request("sync", [receiverWalletRequest]);
@@ -168,6 +170,8 @@ describe("Wallet transaction", () => {
 			return;
 		}
 		it("can transfer funds between two wallets with fee included", async function () {
+			this.timeout(30000);
+
 			const receiverWalletName = generateWalletName("Receive");
 			const senderWalletRequest = newWalletRequest("Default", "123456");
 			const receiverWalletRequest = newWalletRequest(receiverWalletName, "123456");
@@ -212,7 +216,7 @@ describe("Wallet transaction", () => {
 				"wallet_sendToAddress should return transaction id",
 			);
 
-			await sleep(2000);
+			await sleep(5000);
 
 			await withFeeClient.request("sync", [senderWalletRequest]);
 			await withFeeClient.request("sync", [receiverWalletRequest]);

--- a/integration-tests/constant-env.sh
+++ b/integration-tests/constant-env.sh
@@ -8,6 +8,7 @@ TENDERMINT_VERSION=${TENDERMINT_VERSION:-0.32.0}
 
 # Constants (No not modify unless you are absolutely sure what you are doing)
 CHAIN_TX_ENCLAVE_DIRECTORY="docker/chain-tx-enclave"
+CHAIN_TX_ENCLAVE_DOCKER_IMAGE="local-integration-tests-chain-tx-enclave"
 WALLET_STORAGE_DIRECTORY="docker/chain/wallet-storage"
 ADDRESS_STATE_PATH="address-state.json"
 DEV_CONF_WITHFEE_PATH="dev-conf-withfee.json"
@@ -16,5 +17,6 @@ TENDERMINT_TEMP_DIRECTORY="tendermint"
 TENDERMINT_WITHFEE_DIRECTORY="docker/tendermint/tendermint-withfee"
 TENDERMINT_ZEROFEE_DIRECTORY="docker/tendermint/tendermint-zerofee"
 CHAIN_ID="test-chain-y3m1e6-AB"
+CHAIN_HEX_ID="AB"
 
 set +e

--- a/integration-tests/docker/chain/Dockerfile
+++ b/integration-tests/docker/chain/Dockerfile
@@ -13,8 +13,8 @@ COPY . .
 COPY integration-tests/docker/chain/wallet-storage ./wallet-storage
 COPY integration-tests/docker/wait-for-it.sh /usr/bin/wait-for-it.sh
 
-RUN cargo build --release
-RUN mv target/release/chain-abci /usr/bin/chain-abci
-RUN mv target/release/client-rpc /usr/bin/client-rpc
+RUN cargo build
+RUN mv target/debug/chain-abci /usr/bin/chain-abci
+RUN mv target/debug/client-rpc /usr/bin/client-rpc
 
 STOPSIGNAL SIGTERM

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -48,10 +48,12 @@ function git_clone_chain_tx_enclave() {
 }
 
 function build_chain_tx_enclave_docker_image() {
+    CWD=$(pwd)
     cd "${CHAIN_TX_ENCLAVE_DIRECTORY}" && docker build -t "${CHAIN_TX_ENCLAVE_DOCKER_IMAGE}" \
         -f ./tx-validation/Dockerfile . \
         --build-arg SGX_MODE=SW \
         --build-arg NETWORK_ID="${CHAIN_HEX_ID}"
+    cd "${CWD}"
 }
 
 function init_tendermint() {

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -47,6 +47,13 @@ function git_clone_chain_tx_enclave() {
     fi
 }
 
+function build_chain_tx_enclave_docker_image() {
+    cd "${CHAIN_TX_ENCLAVE_DIRECTORY}" && docker build -t "${CHAIN_TX_ENCLAVE_DOCKER_IMAGE}" \
+        -f ./tx-validation/Dockerfile . \
+        --build-arg SGX_MODE=SW \
+        --build-arg NETWORK_ID="${CHAIN_HEX_ID}"
+}
+
 function init_tendermint() {
     print_config "TENDERMINT_VERSION" "${TENDERMINT_VERSION}"
     rm -rf ./tendermint
@@ -212,6 +219,10 @@ cargo build
 
 print_step "git update Chain Transaction Enclave"
 git_clone_chain_tx_enclave
+if [ -z "${CI}" ]; then
+    print_step "Build Chain Transaction Enclave image"
+    build_chain_tx_enclave_docker_image
+fi
 
 print_step "Initialize Tendermint"
 init_tendermint

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -44,11 +44,6 @@ function start_chain_tx_enclave() {
     print_config "CHAIN_HEX_ID" "${CHAIN_HEX_ID}"
     print_config "PORT" "${1}"
 
-    cd "${CHAIN_TX_ENCLAVE_DIRECTORY}" && docker build -t chain-tx-validation \
-        -f ./tx-validation/Dockerfile . \
-        --build-arg SGX_MODE=SW \
-        --build-arg NETWORK_ID="${CHAIN_HEX_ID}"
-
     print_step "Trying to kill previous docker instance ${4}"
     set +e
     docker kill "${2}"
@@ -59,7 +54,7 @@ function start_chain_tx_enclave() {
         --name "${2}" \
         --env RUST_BACKTRACE=1 \
         --env RUST_LOG=debug \
-        chain-tx-validation
+        "${CHAIN_TX_ENCLAVE_DOCKER_IMAGE}"
 }
 
 # @argument Tendermint folder path

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -136,6 +136,31 @@ function start_client_rpc() {
             --websocket-url "ws://127.0.0.1:${2}/websocket"
 }
 
+# @argument Wallet Storage directory
+# @argument Tendermint Port
+function start_client_cli() {
+    print_config "CHAIN_ID" "${CHAIN_ID}"
+    print_config "WALLET_STORAGE_DIRECTORY" "${WALLET_STORAGE_DIRECTORY}"
+    print_config "TENDERMINT_PORT" "${1}"
+
+    STAKING_ADDRESS=$(cat ./address-state.json | jq -r '.staking')
+    TRANSFER_ADDRESSES=$(cat ./address-state.json | jq -r '.transfer')
+    print_config "STAKING_ADDRESS" "${STAKING_ADDRESS}"
+    print_config "TRANSFER_ADDRESSES" "${TRANSFER_ADDRESSES}"
+
+    STORAGE=$(mktemp -d)    
+    cp -r "${WALLET_STORAGE_DIRECTORY}/." "${STORAGE}"
+    print_config "STORAGE" "${STORAGE}"
+
+    echo
+    echo "CRYPTO_CHAIN_ID="${CHAIN_ID}" \\"
+    echo "CRYPTO_CLIENT_STORAGE="${STORAGE}" \\"
+    echo "CRYPTO_CLIENT_TENDERMINT="ws://127.0.0.1:${1}/websocket" \\"
+    echo "RUST_BACKTRACE=1 \\"
+    echo "RUST_LOG=info \\"
+    echo "    cargo run --bin client-cli --"
+}
+
 # Always execute at script located directory
 cd "$(dirname "${0}")"
 
@@ -163,6 +188,10 @@ elif [ x"${1}" == "xclient-rpc-zerofee" ]; then
     start_client_rpc 16659 16657
 elif [ x"${1}" == "xclient-rpc" ]; then
     start_client_rpc 26659 26657
+elif [ x"${1}" == "xclient-cli-zerofee" ]; then
+    start_client_cli 16657
+elif [ x"${1}" == "xclient-cli" ]; then
+    start_client_cli 26657
 else
     print_error "Unknown command ${1}"
 fi

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -104,7 +104,9 @@ function start_chain_abci() {
     STORAGE=$(mktemp -d)    
     print_config "STORAGE" "${STORAGE}"
 
-    RUST_BACKTRACE=1 && RUST_LOG=info cargo run \
+    export RUST_BACKTRACE=1
+    export RUST_LOG=info
+    cargo run \
         --bin chain-abci -- \
             --data "${STORAGE}" \
             --port "${2}" \


### PR DESCRIPTION
Solution:
- Lengthened the setup time for docker
- Allow more time for transaction to broadcast and be included in a block
- Use debug build to speed up build process
- Integration tests local mode - Build chain-tx-enclave at prepare phase, instead of start-up phase
- Added ClientCLI in integration tests local mode