### PR TITLE
Problem: integration test CI fails with "logs"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,11 +68,13 @@ jobs:
   include:
     - <<: *rust
       rust: stable
+      if: (branch != staging.tmp) AND (branch != trying.tmp)
     - <<: *rust
       rust: beta
       if: (branch = staging) OR (branch = trying)
     - <<: *rust
       rust: nightly
+      if: (branch != staging.tmp) AND (branch != trying.tmp)
     - name: Integration Test
       language: rust
       sudo: required
@@ -124,4 +126,4 @@ jobs:
           yarn test
         - |
           docker-compose ps
-          docker-compose logs -t --tail="all"
+          docker-compose logs -t --tail="all" || travis_terminate 0;


### PR DESCRIPTION
Solution: ignore docker compose log's return code