### PR TITLE
Problem: (CRO-461) No initial network parameters for jailing configuration

### DIFF
--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -205,7 +205,7 @@ fn init_chain_for(address: RedeemAddress) -> ChainNodeApp<MockClient> {
         required_council_node_stake: Coin::unit(),
         unbonding_period: 1,
         jail_duration: 86400,
-        max_allowed_faulty_blocks: 50,
+        missed_block_threshold: 50,
     };
     let c = InitConfig::new(
         distribution,
@@ -309,7 +309,7 @@ fn init_chain_panics_with_different_app_hash() {
         required_council_node_stake: Coin::unit(),
         unbonding_period: 1,
         jail_duration: 86400,
-        max_allowed_faulty_blocks: 50,
+        missed_block_threshold: 50,
     };
     let c = InitConfig::new(
         distribution,

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -204,6 +204,8 @@ fn init_chain_for(address: RedeemAddress) -> ChainNodeApp<MockClient> {
         initial_fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
         required_council_node_stake: Coin::unit(),
         unbonding_period: 1,
+        jail_duration: 86400,
+        max_allowed_faulty_blocks: 50,
     };
     let c = InitConfig::new(
         distribution,
@@ -306,6 +308,8 @@ fn init_chain_panics_with_different_app_hash() {
         initial_fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
         required_council_node_stake: Coin::unit(),
         unbonding_period: 1,
+        jail_duration: 86400,
+        max_allowed_faulty_blocks: 50,
     };
     let c = InitConfig::new(
         distribution,

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -17,14 +17,18 @@ use std::collections::{BTreeMap, HashSet};
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InitNetworkParameters {
-    // Initial fee setting
-    // -- TODO: perhaps change to be against T: FeeAlgorithm
-    // TBD here, the intention would be to "freeze" the genesis config, so not sure generic field is worth it
+    /// Initial fee setting
+    /// -- TODO: perhaps change to be against T: FeeAlgorithm
+    /// TBD here, the intention would be to "freeze" the genesis config, so not sure generic field is worth it
     pub initial_fee_policy: LinearFee,
-    // minimal? council node stake
+    /// minimal? council node stake
     pub required_council_node_stake: Coin,
-    // stake unbonding time (in seconds)
+    /// stake unbonding time (in seconds)
     pub unbonding_period: u32,
+    /// Minimum jailing time for accounts with faulty validations (in seconds)
+    pub jail_duration: u32,
+    /// Maximum number of faulty blocks allowed for an account before it gets jailed
+    pub max_allowed_faulty_blocks: u16,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -27,8 +27,8 @@ pub struct InitNetworkParameters {
     pub unbonding_period: u32,
     /// Minimum jailing time for accounts with faulty validations (in seconds)
     pub jail_duration: u32,
-    /// Maximum number of faulty blocks allowed for an account before it gets jailed
-    pub max_allowed_faulty_blocks: u16,
+    /// Maximum number of blocks with faulty/missed validations allowed for an account before it gets jailed
+    pub missed_block_threshold: u16,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -44,7 +44,7 @@ fn test_verify_test_example_snapshot() {
         required_council_node_stake: Coin::new(50_000_000_0000_0000).unwrap(),
         unbonding_period: 86400,
         jail_duration: 86400,
-        max_allowed_faulty_blocks: 50,
+        missed_block_threshold: 50,
     };
     let launch_incentive_from = "0x35f517cab9a37bc31091c2f155d965af84e0bc85"
         .parse::<RedeemAddress>()

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -43,6 +43,8 @@ fn test_verify_test_example_snapshot() {
         initial_fee_policy: fee_policy,
         required_council_node_stake: Coin::new(50_000_000_0000_0000).unwrap(),
         unbonding_period: 86400,
+        jail_duration: 86400,
+        max_allowed_faulty_blocks: 50,
     };
     let launch_incentive_from = "0x35f517cab9a37bc31091c2f155d965af84e0bc85"
         .parse::<RedeemAddress>()

--- a/dev-utils/example-dev-conf.json
+++ b/dev-utils/example-dev-conf.json
@@ -8,6 +8,8 @@
     },
     "unbonding_period": 60,
     "required_council_node_stake": "1250000000000000000",
+    "jail_duration": 86400,
+    "max_allowed_faulty_blocks": 50,
     "initial_fee_policy": {
         "base_fee": "1.1",
         "per_byte_fee": "1.25"

--- a/dev-utils/example-dev-conf.json
+++ b/dev-utils/example-dev-conf.json
@@ -9,7 +9,7 @@
     "unbonding_period": 60,
     "required_council_node_stake": "1250000000000000000",
     "jail_duration": 86400,
-    "max_allowed_faulty_blocks": 50,
+    "missed_block_threshold": 50,
     "initial_fee_policy": {
         "base_fee": "1.1",
         "per_byte_fee": "1.25"

--- a/dev-utils/src/commands/genesis_command.rs
+++ b/dev-utils/src/commands/genesis_command.rs
@@ -63,7 +63,7 @@ impl GenesisCommand {
             required_council_node_stake: genesis_dev.required_council_node_stake,
             unbonding_period: genesis_dev.unbonding_period,
             jail_duration: genesis_dev.jail_duration,
-            max_allowed_faulty_blocks: genesis_dev.max_allowed_faulty_blocks,
+            missed_block_threshold: genesis_dev.missed_block_threshold,
         };
         let config = InitConfig::new(
             dist,

--- a/dev-utils/src/commands/genesis_command.rs
+++ b/dev-utils/src/commands/genesis_command.rs
@@ -62,6 +62,8 @@ impl GenesisCommand {
             initial_fee_policy: fee_policy,
             required_council_node_stake: genesis_dev.required_council_node_stake,
             unbonding_period: genesis_dev.unbonding_period,
+            jail_duration: genesis_dev.jail_duration,
+            max_allowed_faulty_blocks: genesis_dev.max_allowed_faulty_blocks,
         };
         let config = InitConfig::new(
             dist,

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -11,7 +11,7 @@ pub struct GenesisDevConfig {
     pub unbonding_period: u32,
     pub required_council_node_stake: Coin,
     pub jail_duration: u32,
-    pub max_allowed_faulty_blocks: u16,
+    pub missed_block_threshold: u16,
     pub initial_fee_policy: InitialFeePolicy,
     pub council_nodes: Vec<InitialValidator>,
     pub launch_incentive_from: RedeemAddress,
@@ -28,7 +28,7 @@ impl GenesisDevConfig {
             unbonding_period: 60,
             required_council_node_stake: Coin::new(1_250_000_000_000_000_000).unwrap(),
             jail_duration: 86400,
-            max_allowed_faulty_blocks: 50,
+            missed_block_threshold: 50,
             initial_fee_policy: InitialFeePolicy {
                 base_fee: "1.1".to_string(),
                 per_byte_fee: "1.25".to_string(),

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -10,6 +10,8 @@ pub struct GenesisDevConfig {
     pub distribution: BTreeMap<RedeemAddress, Coin>,
     pub unbonding_period: u32,
     pub required_council_node_stake: Coin,
+    pub jail_duration: u32,
+    pub max_allowed_faulty_blocks: u16,
     pub initial_fee_policy: InitialFeePolicy,
     pub council_nodes: Vec<InitialValidator>,
     pub launch_incentive_from: RedeemAddress,
@@ -25,6 +27,8 @@ impl GenesisDevConfig {
             distribution: BTreeMap::new(),
             unbonding_period: 60,
             required_council_node_stake: Coin::new(1_250_000_000_000_000_000).unwrap(),
+            jail_duration: 86400,
+            max_allowed_faulty_blocks: 50,
             initial_fee_policy: InitialFeePolicy {
                 base_fee: "1.1".to_string(),
                 per_byte_fee: "1.25".to_string(),


### PR DESCRIPTION
Solution: Added network parameters for `jail_duration` and `max_allowed_faulty_blocks` in `genesis.json`