### PR TITLE
Problem: (CRO-461) ABCI app does not store jailing configuration

### DIFF
--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -13,7 +13,7 @@ use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::init::config::AccountType;
 use chain_core::init::config::InitConfig;
-use chain_core::init::config::InitNetworkParameters;
+use chain_core::init::config::{InitNetworkParameters, JailingParameters};
 use chain_core::state::account::{StakedState, StakedStateAddress};
 use chain_core::state::tendermint::{BlockHeight, TendermintVotePower};
 use chain_core::state::CouncilNode;
@@ -47,6 +47,8 @@ pub struct ChainNodeState {
     pub unbonding_period: u32,
     /// (minimal?) amount required to be bonded in validator-associated accounts
     pub required_council_node_stake: Coin,
+    /// Jailing configuration
+    pub jailing_config: JailingParameters,
     /// council nodes metadata
     pub council_nodes: Vec<CouncilNode>,
 }
@@ -69,6 +71,7 @@ impl ChainNodeState {
             fee_policy: network_params.initial_fee_policy,
             unbonding_period: network_params.unbonding_period,
             required_council_node_stake: network_params.required_council_node_stake,
+            jailing_config: network_params.jailing_config,
             council_nodes,
         }
     }

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -150,6 +150,11 @@ fn get_dummy_app_state(app_hash: H256) -> ChainNodeState {
         council_nodes: vec![],
         required_council_node_stake: Coin::unit(),
         unbonding_period: 1,
+        jailing_config: JailingParameters {
+            jail_duration: 86400,
+            block_signing_window: 100,
+            missed_block_threshold: 50,
+        },
     }
 }
 

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -1,3 +1,4 @@
+use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -29,7 +30,7 @@ pub struct InitNetworkParameters {
     pub jailing_config: JailingParameters,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct JailingParameters {
     /// Minimum jailing time for punished accounts (in seconds)


### PR DESCRIPTION
Solution: Added `jailing_config` in `ChainNodeState`