### PR TITLE
Problem: no in-enclave decryption/encryption functionality (CRO-451)

### DIFF
--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -81,8 +81,8 @@ impl fmt::Display for PlainTxAux {
 
 /// plqin TX payload to be obfuscated
 pub struct TxToObfuscate {
-    txpayload: Vec<u8>,
-    txid: TxId,
+    pub txpayload: Vec<u8>,
+    pub txid: TxId,
 }
 
 impl TxToObfuscate {

--- a/chain-tx-enclave/enclave-macro/Cargo.toml
+++ b/chain-tx-enclave/enclave-macro/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [lib]
 proc-macro = true
+
+[dependencies]
+rand = "0.7.2"

--- a/chain-tx-enclave/enclave-macro/src/lib.rs
+++ b/chain-tx-enclave/enclave-macro/src/lib.rs
@@ -1,8 +1,13 @@
 extern crate proc_macro;
 	
 use proc_macro::TokenStream;
-
 #[proc_macro]
 pub fn get_network_id(_input: TokenStream) -> TokenStream {
     format!("0x{}", env! {"NETWORK_ID"}).parse().unwrap()
+}
+
+#[proc_macro]
+pub fn mock_key(_input: TokenStream) -> TokenStream {
+    let random_bytes: [u8; 16] = rand::random();
+    format!("{:?}", random_bytes).parse().unwrap()
 }

--- a/chain-tx-enclave/tx-validation/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/enclave/Cargo.toml
@@ -30,3 +30,6 @@ enclave-protocol   = { path = "../../../enclave-protocol", default-features = fa
 chain-tx-filter   = { path = "../../../chain-tx-filter", default-features = false, features = ["mesalock_sgx"] }
 lazy_static  = { version = "1.4", features = ["spin_no_std"] }
 enclave-t-common = { path = "../../enclave-t-common" }
+aes-gcm-siv = "0.1"
+aead = "0.1"
+zeroize = { version = "0.10", default-features = false }

--- a/chain-tx-enclave/tx-validation/enclave/src/lib.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/lib.rs
@@ -8,35 +8,16 @@
 #[macro_use]
 extern crate sgx_tstd as std;
 
-use chain_core::init::coin::Coin;
-use chain_core::tx::data::TxId;
-use chain_core::tx::fee::Fee;
-use chain_core::tx::TransactionId;
-use chain_core::tx::{data::input::TxoIndex, PlainTxAux, TxAux, TxObfuscated};
-use chain_tx_filter::BlockFilter;
-use chain_tx_validation::witness::verify_tx_recover_address;
-use chain_tx_validation::{
-    verify_bonded_deposit_core, verify_transfer, verify_unbonded_withdraw_core, TxWithOutputs,
-};
+mod obfuscate;
+mod validate;
+
 use enclave_macro::get_network_id;
-use enclave_protocol::{
-    is_basic_valid_tx_request, IntraEnclaveRequest, IntraEnclaveResponse, IntraEnclaveResponseOk,
-    VerifyTxRequest,
-};
-use enclave_t_common::check_unseal;
-use lazy_static::lazy_static;
-use parity_scale_codec::{Decode, Encode};
-use sgx_tseal::SgxSealedData;
-use sgx_types::{sgx_sealed_data_t, sgx_status_t};
-use std::prelude::v1::{Box, Vec};
+use enclave_protocol::IntraEnclaveRequest;
+use parity_scale_codec::Decode;
+use sgx_types::sgx_status_t;
 use std::slice;
-use std::sync::SgxMutex;
 
-lazy_static! {
-    static ref FILTER: SgxMutex<BlockFilter> = SgxMutex::new(BlockFilter::default());
-}
-
-const NETWORK_HEX_ID: u8 = get_network_id!();
+pub const NETWORK_HEX_ID: u8 = get_network_id!();
 
 /// FIXME: genesis app_hash etc.
 #[no_mangle]
@@ -45,196 +26,6 @@ pub extern "C" fn ecall_initchain(chain_hex_id: u8) -> sgx_status_t {
         sgx_status_t::SGX_SUCCESS
     } else {
         sgx_status_t::SGX_ERROR_INVALID_PARAMETER
-    }
-}
-
-#[inline]
-fn add_view_keys(wraptx: &TxWithOutputs) {
-    let mut filter = FILTER
-        .lock()
-        .expect("poisoned lock: failed to get block tx filter");
-    match wraptx {
-        TxWithOutputs::Transfer(tx) => {
-            for view in tx.attributes.allowed_view.iter() {
-                filter.add_view_key(&view.view_key);
-            }
-        }
-        TxWithOutputs::StakeWithdraw(tx) => {
-            for view in tx.attributes.allowed_view.iter() {
-                filter.add_view_key(&view.view_key);
-            }
-        }
-    }
-}
-
-#[inline]
-fn construct_sealed_response(
-    result: Result<Fee, chain_tx_validation::Error>,
-    txid: &TxId,
-    to_seal_tx: TxWithOutputs,
-) -> Result<IntraEnclaveResponse, sgx_status_t> {
-    let to_seal = to_seal_tx.encode();
-    match result {
-        Err(e) => Ok(Err(e)),
-        Ok(fee) => {
-            let sealing_result = SgxSealedData::<[u8]>::seal_data(txid, &to_seal);
-            let sealed_data = match sealing_result {
-                Ok(x) => x,
-                Err(ret) => {
-                    return Err(ret);
-                }
-            };
-            let sealed_log_size = SgxSealedData::<[u8]>::calc_raw_sealed_data_size(
-                sealed_data.get_add_mac_txt_len(),
-                sealed_data.get_encrypt_txt_len(),
-            ) as usize;
-            let mut sealed_log: Vec<u8> = vec![0u8; sealed_log_size];
-
-            unsafe {
-                let sealed_r = sealed_data.to_raw_sealed_data_t(
-                    sealed_log.as_mut_ptr() as *mut sgx_sealed_data_t,
-                    sealed_log_size as u32,
-                );
-                if sealed_r.is_none() {
-                    return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER);
-                }
-            }
-            add_view_keys(&to_seal_tx);
-            Ok(Ok(IntraEnclaveResponseOk::TxWithOutputs {
-                paid_fee: fee,
-                sealed_tx: sealed_log,
-            }))
-        }
-    }
-}
-
-#[inline]
-fn construct_simple_response(
-    result: Result<Coin, chain_tx_validation::Error>,
-) -> Result<IntraEnclaveResponse, sgx_status_t> {
-    match result {
-        Err(e) => Ok(Err(e)),
-        Ok(input_coins) => Ok(Ok(IntraEnclaveResponseOk::DepositStakeTx { input_coins })),
-    }
-}
-
-#[inline]
-fn write_back_response(
-    response: Result<IntraEnclaveResponse, sgx_status_t>,
-    response_buf: *mut u8,
-    max_response_len: u32,
-) -> sgx_status_t {
-    match response {
-        Ok(r) => {
-            let to_copy = r.encode();
-            let resp_len = to_copy.len() as u32;
-            if resp_len > 0 && resp_len <= max_response_len {
-                unsafe {
-                    std::ptr::copy_nonoverlapping(to_copy.as_ptr(), response_buf, to_copy.len());
-                }
-                sgx_status_t::SGX_SUCCESS
-            } else {
-                sgx_status_t::SGX_ERROR_INVALID_PARAMETER
-            }
-        }
-        Err(e) => e,
-    }
-}
-
-#[inline]
-fn handle_validate_tx(
-    request: Box<VerifyTxRequest>,
-    tx_inputs: Option<Vec<Vec<u8>>>,
-    response_buf: *mut u8,
-    response_len: u32,
-) -> sgx_status_t {
-    if is_basic_valid_tx_request(&request, &tx_inputs, NETWORK_HEX_ID).is_err() {
-        return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-    }
-    match (tx_inputs, request.tx) {
-        (
-            Some(sealed_inputs),
-            TxAux::TransferTx {
-                payload: TxObfuscated { txid, txpayload, .. },
-                no_of_outputs,
-                inputs,
-            },
-        ) => {
-            // FIXME: decrypting
-            let plaintx = PlainTxAux::decode(&mut txpayload.as_slice());
-            let unsealed_inputs =
-                check_unseal(None, false, inputs.iter().map(|x| x.id), sealed_inputs);
-            match (plaintx, unsealed_inputs) {
-                (Ok(PlainTxAux::TransferTx(tx, witness)), Some(inputs)) => {
-                    if tx.id() != txid || tx.outputs.len() as TxoIndex != no_of_outputs {
-                        return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                    }
-                    let result = verify_transfer(&tx, &witness, request.info, inputs);
-                    let response =
-                        construct_sealed_response(result, &txid, TxWithOutputs::Transfer(tx));
-                    write_back_response(response, response_buf, response_len)
-                }
-                _ => {
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                }
-            }
-        }
-        (
-            Some(sealed_inputs),
-            TxAux::DepositStakeTx {
-                tx,
-                payload: TxObfuscated { txpayload, .. },
-            },
-        ) => {
-            // FIXME: decrypting
-            let plaintx = PlainTxAux::decode(&mut txpayload.as_slice());
-            let inputs = check_unseal(None, false, tx.inputs.iter().map(|x| x.id), sealed_inputs);
-            match (plaintx, inputs) {
-                (Ok(PlainTxAux::DepositStakeTx(witness)), Some(inputs)) => {
-                    let result = verify_bonded_deposit_core(&tx, &witness, request.info, inputs);
-                    let response = construct_simple_response(result);
-                    write_back_response(response, response_buf, response_len)
-                }
-                _ => {
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                }
-            }
-        }
-        (
-            None,
-            TxAux::WithdrawUnbondedStakeTx {
-                no_of_outputs,
-                payload: TxObfuscated { txid, txpayload, .. },
-                witness,
-            },
-        ) => {
-            let address = verify_tx_recover_address(&witness, &txid);
-            if address.is_err() {
-                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-            }
-            // FIXME: decrypting
-            let plaintx = PlainTxAux::decode(&mut txpayload.as_slice());
-            match (plaintx, request.account) {
-                (Ok(PlainTxAux::WithdrawUnbondedStakeTx(tx)), Some(account)) => {
-                    if tx.id() != txid
-                        || no_of_outputs != tx.outputs.len() as TxoIndex
-                        || account.address != address.unwrap()
-                    {
-                        return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                    }
-                    let result = verify_unbonded_withdraw_core(&tx, request.info, &account);
-                    let response =
-                        construct_sealed_response(result, &txid, TxWithOutputs::StakeWithdraw(tx));
-                    write_back_response(response, response_buf, response_len)
-                }
-                _ => {
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                }
-            }
-        }
-        (_, _) => {
-            return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-        }
     }
 }
 
@@ -248,19 +39,11 @@ pub extern "C" fn ecall_check_tx(
     let mut tx_request_slice = unsafe { slice::from_raw_parts(tx_request, tx_request_len) };
     match IntraEnclaveRequest::decode(&mut tx_request_slice) {
         Ok(IntraEnclaveRequest::ValidateTx { request, tx_inputs }) => {
-            handle_validate_tx(request, tx_inputs, response_buf, response_len)
+            validate::handle_validate_tx(request, tx_inputs, response_buf, response_len)
         }
-        Ok(IntraEnclaveRequest::EndBlock) => {
-            let mut filter = FILTER
-                .lock()
-                .expect("poisoned lock: failed to get block tx filter");
-            let payload: [u8; 256] = filter.get_raw();
-            filter.reset();
-            write_back_response(
-                Ok(Ok(IntraEnclaveResponseOk::EndBlock(Box::new(payload)))),
-                response_buf,
-                response_len,
-            )
+        Ok(IntraEnclaveRequest::EndBlock) => validate::handle_end_block(response_buf, response_len),
+        Ok(IntraEnclaveRequest::Encrypt(request)) => {
+            obfuscate::handle_encrypt_request(request, response_buf, response_len)
         }
         _ => {
             return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;

--- a/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
@@ -1,0 +1,155 @@
+use crate::validate::write_back_response;
+use aead::{generic_array::GenericArray, Aead, NewAead};
+use aes_gcm_siv::Aes128GcmSiv;
+use chain_core::tx::TransactionId;
+use chain_core::tx::{PlainTxAux, TxObfuscated, TxToObfuscate};
+use chain_tx_validation::{
+    verify_bonded_deposit_core, verify_transfer, verify_unbonded_withdraw_core,
+    witness::verify_tx_recover_address,
+};
+use enclave_macro::mock_key;
+use enclave_protocol::{EncryptionRequest, IntraEncryptRequest};
+use enclave_protocol::{IntraEnclaveResponse, IntraEnclaveResponseOk};
+use enclave_t_common::check_unseal;
+use parity_scale_codec::Decode;
+use sgx_rand::{os::SgxRng, Rng};
+use sgx_tseal::SgxSealedData;
+use sgx_types::{sgx_sealed_data_t, sgx_status_t};
+use std::prelude::v1::Box;
+use zeroize::Zeroize;
+
+const MOCK_KEY: [u8; 16] = mock_key!();
+
+pub(crate) fn encrypt(tx: TxToObfuscate) -> TxObfuscated {
+    let mut init_vector = [0u8; 12];
+    let mut os_rng = SgxRng::new().unwrap();
+    os_rng.fill_bytes(&mut init_vector);
+    let key = GenericArray::clone_from_slice(&MOCK_KEY);
+    let aead = Aes128GcmSiv::new(key);
+    let nonce = GenericArray::from_slice(&init_vector);
+    let ciphertext = aead.encrypt(nonce, &tx).expect("encryption failure!");
+    TxObfuscated {
+        key_from: -1,
+        init_vector,
+        txpayload: ciphertext,
+        txid: tx.txid,
+    }
+}
+
+pub(crate) fn decrypt(tx: &TxObfuscated) -> Result<PlainTxAux, ()> {
+    let key = GenericArray::clone_from_slice(&MOCK_KEY);
+    let aead = Aes128GcmSiv::new(key);
+    let nonce = GenericArray::from_slice(&tx.init_vector);
+    let plaintext = aead.decrypt(nonce, tx).map_err(|_| ())?;
+    let result = PlainTxAux::decode(&mut plaintext.as_ref());
+    result.map_err(|_| ())
+}
+
+#[inline]
+fn unseal_request(request: &mut IntraEncryptRequest) -> Option<EncryptionRequest> {
+    let opt = unsafe {
+        SgxSealedData::<[u8]>::from_raw_sealed_data_t(
+            request.sealed_enc_request.as_mut_ptr() as *mut sgx_sealed_data_t,
+            request.sealed_enc_request.len() as u32,
+        )
+    };
+    let sealed_data = match opt {
+        Some(x) => x,
+        None => {
+            return None;
+        }
+    };
+    let result = sealed_data.unseal_data();
+    let mut unsealed_data = match result {
+        Ok(x) => x,
+        Err(_) => {
+            return None;
+        }
+    };
+    if unsealed_data.get_additional_txt() != request.txid {
+        unsealed_data.decrypt.zeroize();
+        return None;
+    }
+    let otx = EncryptionRequest::decode(&mut unsealed_data.get_decrypt_txt());
+    match otx {
+        Ok(o) => Some(o),
+        Err(_) => None,
+    }
+}
+
+#[inline]
+fn construct_response(
+    result: Result<(), chain_tx_validation::Error>,
+    to_obfuscate_tx: TxToObfuscate,
+) -> Result<IntraEnclaveResponse, sgx_status_t> {
+    match result {
+        Err(e) => Ok(Err(e)),
+        Ok(_) => {
+            let otx = encrypt(to_obfuscate_tx);
+            Ok(Ok(IntraEnclaveResponseOk::Encrypt(Box::new(otx))))
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn handle_encrypt_request(
+    mut request: Box<IntraEncryptRequest>,
+    response_buf: *mut u8,
+    response_len: u32,
+) -> sgx_status_t {
+    match (unseal_request(&mut request), request.tx_inputs) {
+        (Some(EncryptionRequest::TransferTx(tx, witness)), Some(sealed_inputs)) => {
+            let unsealed_inputs =
+                check_unseal(None, false, tx.inputs.iter().map(|x| x.id), sealed_inputs);
+            if let Some(inputs) = unsealed_inputs {
+                let result = verify_transfer(&tx, &witness, request.info, inputs);
+                let txid = tx.id();
+                let response = construct_response(
+                    result.map(|_| ()),
+                    TxToObfuscate::from(PlainTxAux::TransferTx(tx, witness), txid)
+                        .expect("construct plain payload"),
+                );
+                write_back_response(response, response_buf, response_len)
+            } else {
+                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+            }
+        }
+        (Some(EncryptionRequest::DepositStake(tx, witness)), Some(sealed_inputs)) => {
+            let unsealed_inputs =
+                check_unseal(None, false, tx.inputs.iter().map(|x| x.id), sealed_inputs);
+            if let Some(inputs) = unsealed_inputs {
+                let result = verify_bonded_deposit_core(&tx, &witness, request.info, inputs);
+                let txid = tx.id();
+                let response = construct_response(
+                    result.map(|_| ()),
+                    TxToObfuscate::from(PlainTxAux::DepositStakeTx(witness), txid)
+                        .expect("construct plain payload"),
+                );
+                write_back_response(response, response_buf, response_len)
+            } else {
+                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+            }
+        }
+        (Some(EncryptionRequest::WithdrawStake(tx, account, witness)), None) => {
+            let txid = tx.id();
+            let maddress = verify_tx_recover_address(&witness, &txid);
+            match maddress {
+                Ok(address) if address == account.address => {
+                    let result = verify_unbonded_withdraw_core(&tx, request.info, &account);
+                    let response = construct_response(
+                        result.map(|_| ()),
+                        TxToObfuscate::from(PlainTxAux::WithdrawUnbondedStakeTx(tx), txid)
+                            .expect("construct plain payload"),
+                    );
+                    write_back_response(response, response_buf, response_len)
+                }
+                _ => {
+                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                }
+            }
+        }
+        (_, _) => {
+            return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+        }
+    }
+}

--- a/chain-tx-enclave/tx-validation/enclave/src/validate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/validate.rs
@@ -1,0 +1,234 @@
+use chain_core::init::coin::Coin;
+use chain_core::tx::data::TxId;
+use chain_core::tx::fee::Fee;
+use chain_core::tx::TransactionId;
+use chain_core::tx::{data::input::TxoIndex, PlainTxAux, TxAux, TxObfuscated};
+use chain_tx_filter::BlockFilter;
+use chain_tx_validation::witness::verify_tx_recover_address;
+use chain_tx_validation::{
+    verify_bonded_deposit_core, verify_transfer, verify_unbonded_withdraw_core, TxWithOutputs,
+};
+use enclave_protocol::{
+    is_basic_valid_tx_request, IntraEnclaveResponse, IntraEnclaveResponseOk, VerifyTxRequest,
+};
+use enclave_t_common::check_unseal;
+use lazy_static::lazy_static;
+use parity_scale_codec::{Decode, Encode};
+use sgx_tseal::SgxSealedData;
+use sgx_types::{sgx_sealed_data_t, sgx_status_t};
+use std::prelude::v1::{Box, Vec};
+use std::sync::SgxMutex;
+
+lazy_static! {
+    static ref FILTER: SgxMutex<BlockFilter> = SgxMutex::new(BlockFilter::default());
+}
+
+#[inline]
+pub(crate) fn handle_end_block(response_buf: *mut u8, response_len: u32) -> sgx_status_t {
+    let mut filter = FILTER
+        .lock()
+        .expect("poisoned lock: failed to get block tx filter");
+    let payload: [u8; 256] = filter.get_raw();
+    filter.reset();
+    write_back_response(
+        Ok(Ok(IntraEnclaveResponseOk::EndBlock(Box::new(payload)))),
+        response_buf,
+        response_len,
+    )
+}
+
+#[inline]
+fn add_view_keys(wraptx: &TxWithOutputs) {
+    let mut filter = FILTER
+        .lock()
+        .expect("poisoned lock: failed to get block tx filter");
+    match wraptx {
+        TxWithOutputs::Transfer(tx) => {
+            for view in tx.attributes.allowed_view.iter() {
+                filter.add_view_key(&view.view_key);
+            }
+        }
+        TxWithOutputs::StakeWithdraw(tx) => {
+            for view in tx.attributes.allowed_view.iter() {
+                filter.add_view_key(&view.view_key);
+            }
+        }
+    }
+}
+
+#[inline]
+fn construct_sealed_response(
+    result: Result<Fee, chain_tx_validation::Error>,
+    txid: &TxId,
+    to_seal_tx: TxWithOutputs,
+) -> Result<IntraEnclaveResponse, sgx_status_t> {
+    let to_seal = to_seal_tx.encode();
+    match result {
+        Err(e) => Ok(Err(e)),
+        Ok(fee) => {
+            let sealing_result = SgxSealedData::<[u8]>::seal_data(txid, &to_seal);
+            let sealed_data = match sealing_result {
+                Ok(x) => x,
+                Err(ret) => {
+                    return Err(ret);
+                }
+            };
+            let sealed_log_size = SgxSealedData::<[u8]>::calc_raw_sealed_data_size(
+                sealed_data.get_add_mac_txt_len(),
+                sealed_data.get_encrypt_txt_len(),
+            ) as usize;
+            let mut sealed_log: Vec<u8> = vec![0u8; sealed_log_size];
+
+            unsafe {
+                let sealed_r = sealed_data.to_raw_sealed_data_t(
+                    sealed_log.as_mut_ptr() as *mut sgx_sealed_data_t,
+                    sealed_log_size as u32,
+                );
+                if sealed_r.is_none() {
+                    return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER);
+                }
+            }
+            add_view_keys(&to_seal_tx);
+            Ok(Ok(IntraEnclaveResponseOk::TxWithOutputs {
+                paid_fee: fee,
+                sealed_tx: sealed_log,
+            }))
+        }
+    }
+}
+
+#[inline]
+fn construct_simple_response(
+    result: Result<Coin, chain_tx_validation::Error>,
+) -> Result<IntraEnclaveResponse, sgx_status_t> {
+    match result {
+        Err(e) => Ok(Err(e)),
+        Ok(input_coins) => Ok(Ok(IntraEnclaveResponseOk::DepositStakeTx { input_coins })),
+    }
+}
+
+/// writes back the result (if no enclave error happened)
+#[inline]
+pub(crate) fn write_back_response(
+    response: Result<IntraEnclaveResponse, sgx_status_t>,
+    response_buf: *mut u8,
+    max_response_len: u32,
+) -> sgx_status_t {
+    match response {
+        Ok(r) => {
+            let to_copy = r.encode();
+            let resp_len = to_copy.len() as u32;
+            if resp_len > 0 && resp_len <= max_response_len {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(to_copy.as_ptr(), response_buf, to_copy.len());
+                }
+                sgx_status_t::SGX_SUCCESS
+            } else {
+                sgx_status_t::SGX_ERROR_INVALID_PARAMETER
+            }
+        }
+        Err(e) => e,
+    }
+}
+
+#[inline]
+fn decrypt(payload: &TxObfuscated) -> Result<PlainTxAux, ()> {
+    // FIXME: decrypting
+    let _ = crate::obfuscate::decrypt(payload);
+    PlainTxAux::decode(&mut payload.txpayload.as_slice()).map_err(|_| ())
+}
+
+/// takes a request to verify transaction and writes back the result
+#[inline]
+pub(crate) fn handle_validate_tx(
+    request: Box<VerifyTxRequest>,
+    tx_inputs: Option<Vec<Vec<u8>>>,
+    response_buf: *mut u8,
+    response_len: u32,
+) -> sgx_status_t {
+    if is_basic_valid_tx_request(&request, &tx_inputs, crate::NETWORK_HEX_ID).is_err() {
+        return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+    }
+    match (tx_inputs, request.tx) {
+        (
+            Some(sealed_inputs),
+            TxAux::TransferTx {
+                payload,
+                no_of_outputs,
+                inputs,
+            },
+        ) => {
+            let plaintx = decrypt(&payload);
+            let unsealed_inputs =
+                check_unseal(None, false, inputs.iter().map(|x| x.id), sealed_inputs);
+            match (plaintx, unsealed_inputs) {
+                (Ok(PlainTxAux::TransferTx(tx, witness)), Some(inputs)) => {
+                    if tx.id() != payload.txid || tx.outputs.len() as TxoIndex != no_of_outputs {
+                        return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                    }
+                    let result = verify_transfer(&tx, &witness, request.info, inputs);
+                    let response = construct_sealed_response(
+                        result,
+                        &payload.txid,
+                        TxWithOutputs::Transfer(tx),
+                    );
+                    write_back_response(response, response_buf, response_len)
+                }
+                _ => {
+                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                }
+            }
+        }
+        (Some(sealed_inputs), TxAux::DepositStakeTx { tx, payload }) => {
+            let plaintx = decrypt(&payload);
+            let inputs = check_unseal(None, false, tx.inputs.iter().map(|x| x.id), sealed_inputs);
+            match (plaintx, inputs) {
+                (Ok(PlainTxAux::DepositStakeTx(witness)), Some(inputs)) => {
+                    let result = verify_bonded_deposit_core(&tx, &witness, request.info, inputs);
+                    let response = construct_simple_response(result);
+                    write_back_response(response, response_buf, response_len)
+                }
+                _ => {
+                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                }
+            }
+        }
+        (
+            None,
+            TxAux::WithdrawUnbondedStakeTx {
+                no_of_outputs,
+                payload,
+                witness,
+            },
+        ) => {
+            let address = verify_tx_recover_address(&witness, &payload.txid);
+            if address.is_err() {
+                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+            }
+            let plaintx = decrypt(&payload);
+            match (plaintx, request.account) {
+                (Ok(PlainTxAux::WithdrawUnbondedStakeTx(tx)), Some(account)) => {
+                    if tx.id() != payload.txid
+                        || no_of_outputs != tx.outputs.len() as TxoIndex
+                        || account.address != address.unwrap()
+                    {
+                        return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                    }
+                    let result = verify_unbonded_withdraw_core(&tx, request.info, &account);
+                    let response = construct_sealed_response(
+                        result,
+                        &payload.txid,
+                        TxWithOutputs::StakeWithdraw(tx),
+                    );
+                    write_back_response(response, response_buf, response_len)
+                }
+                _ => {
+                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                }
+            }
+        }
+        (_, _) => {
+            return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+        }
+    }
+}

--- a/client-common/src/tendermint/types/block.rs
+++ b/client-common/src/tendermint/types/block.rs
@@ -102,9 +102,7 @@ mod tests {
 
     use base64::encode;
     use parity_scale_codec::Encode;
-    use secp256k1::key::{PublicKey, SecretKey};
     use secp256k1::recovery::{RecoverableSignature, RecoveryId};
-    use secp256k1::Secp256k1;
 
     use chain_core::init::address::RedeemAddress;
     use chain_core::init::coin::Coin;

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -22,6 +22,7 @@ use chain_core::state::account::StakedStateOpWitness;
 use chain_core::state::account::WithdrawUnbondedTx;
 use chain_core::tx::data::{txid_hash, Tx, TxId};
 use chain_core::tx::witness::TxWitness;
+use chain_core::tx::TxObfuscated;
 use chain_core::tx::{fee::Fee, TxAux};
 use chain_core::ChainInfo;
 use chain_tx_validation::TxWithOutputs;
@@ -39,6 +40,19 @@ type SealedLog = Vec<u8>;
 /// tx filter
 type TxFilter = [u8; 256];
 
+/// Internal encryption request
+#[derive(Encode, Decode)]
+pub struct IntraEncryptRequest {
+    /// transaction ID
+    pub txid: TxId,
+    /// EncryptionRequest
+    pub sealed_enc_request: SealedLog,
+    /// transaction inputs (if any)
+    pub tx_inputs: Option<Vec<SealedLog>>,
+    /// last chain info
+    pub info: ChainInfo,
+}
+
 /// variable length request passed to the tx-validation enclave
 #[derive(Encode, Decode)]
 pub enum IntraEnclaveRequest {
@@ -47,6 +61,7 @@ pub enum IntraEnclaveRequest {
         tx_inputs: Option<Vec<SealedLog>>,
     },
     EndBlock,
+    Encrypt(Box<IntraEncryptRequest>),
 }
 
 /// helper method to validate basic assumptions
@@ -87,6 +102,8 @@ pub enum IntraEnclaveResponseOk {
     DepositStakeTx { input_coins: Coin },
     /// transaction filter
     EndBlock(Box<TxFilter>),
+    /// encryption response
+    Encrypt(Box<TxObfuscated>),
 }
 
 /// variable length response returned from the tx-validation enclave


### PR DESCRIPTION
Solution: (WIP) added a mock compile-time key generation + encryption/decryption using AES-GCM-SIV crate (should be fast + safe for multiple encryptors with random nonce generation which is our case)
- added a new request type in protocol (will be generated / passed from tx-query -- TODO)
- split tx-validation enclave's functionality into modules
TODO: extend tx-validation enclave tests