### PR TITLE
Problem: (CRO-463) Integration tests relies on unreliable timeout for state changes

### DIFF
--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -23,7 +23,7 @@ pub trait StakingRpc: Send + Sync {
         request: WalletRequest,
         to_address: String,
         inputs: Vec<TxoPointer>,
-    ) -> Result<()>;
+    ) -> Result<String>;
 
     #[rpc(name = "staking_state")]
     fn state(&self, request: WalletRequest, address: StakedStateAddress) -> Result<StakedState>;
@@ -34,7 +34,7 @@ pub trait StakingRpc: Send + Sync {
         request: WalletRequest,
         staking_address: String,
         amount: Coin,
-    ) -> Result<()>;
+    ) -> Result<String>;
 
     #[rpc(name = "staking_withdrawAllUnbondedStake")]
     fn withdraw_all_unbonded_stake(
@@ -43,7 +43,7 @@ pub trait StakingRpc: Send + Sync {
         from_address: String,
         to_address: String,
         view_keys: Vec<String>,
-    ) -> Result<()>;
+    ) -> Result<String>;
 }
 
 pub struct StakingRpcImpl<T, N>
@@ -80,7 +80,7 @@ where
         request: WalletRequest,
         to_address: String,
         inputs: Vec<TxoPointer>,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let addr = StakedStateAddress::from_str(&to_address)
             .chain(|| {
                 (
@@ -105,7 +105,7 @@ where
             .broadcast_transaction(&transaction)
             .map_err(to_rpc_error)?;
 
-        Ok(())
+        Ok(hex::encode(transaction.tx_id()))
     }
 
     fn state(&self, request: WalletRequest, address: StakedStateAddress) -> Result<StakedState> {
@@ -119,7 +119,7 @@ where
         request: WalletRequest,
         staking_address: String,
         amount: Coin,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let attr = StakedStateOpAttributes::new(self.network_id);
         let addr = StakedStateAddress::from_str(&staking_address)
             .chain(|| {
@@ -142,7 +142,7 @@ where
             .broadcast_transaction(&transaction)
             .map_err(to_rpc_error)?;
 
-        Ok(())
+        Ok(hex::encode(transaction.tx_id()))
     }
 
     fn withdraw_all_unbonded_stake(
@@ -151,7 +151,7 @@ where
         from_address: String,
         to_address: String,
         view_keys: Vec<String>,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let from_address = StakedStateAddress::from_str(&from_address)
             .chain(|| {
                 (
@@ -208,6 +208,6 @@ where
             .broadcast_transaction(&transaction)
             .map_err(to_rpc_error)?;
 
-        Ok(())
+        Ok(hex::encode(transaction.tx_id()))
     }
 }

--- a/integration-tests/client-rpc/test/core/rpc.ts
+++ b/integration-tests/client-rpc/test/core/rpc.ts
@@ -1,11 +1,32 @@
 import { RpcClient } from "./rpc-client";
-import { WalletRequest, sleep } from "./utils";
+import { WalletRequest, sleep, asyncMiddleman } from "./utils";
+import { TendermintClient } from "./tendermint-client";
 
 export const syncWallet = async (
 	rpcClient: RpcClient,
 	walletRequest: WalletRequest,
 ): Promise<void> => {
-	console.log(`[Log] Synchronizaing wallet "${walletRequest.name}"`);
+	console.log(`[Log] Synchronizing wallet "${walletRequest.name}"`);
 	await rpcClient.request("sync", [walletRequest]);
-	await sleep(1000);
+};
+
+// Continuously check for TxId existence until found
+export const waitTxIdConfirmed = async (
+	tendermintClient: TendermintClient,
+	txId: string,
+	retryTimeout: number = 1000,
+): Promise<boolean> => {
+	while (true) {
+		console.log("[Log] Checking transaction confirmation on chain");
+		const exists = await asyncMiddleman(
+			tendermintClient.isTxIdExists(txId),
+			"Error when retrieving transaction confirmation",
+		);
+		if (exists) {
+			break;
+		}
+		await sleep(retryTimeout);
+	}
+
+	return true;
 };

--- a/integration-tests/client-rpc/test/core/setup.ts
+++ b/integration-tests/client-rpc/test/core/setup.ts
@@ -1,14 +1,19 @@
 import BigNumber from "bignumber.js";
 import { RpcClient } from "./rpc-client";
 import * as addressState from "../../../address-state.json";
-import { syncWallet } from "./rpc";
+import { syncWallet, waitTxIdConfirmed } from "./rpc";
 import {
 	shouldTest,
 	FEE_SCHEMA,
-	newRpcClient,
 	newWalletRequest,
 	sleep,
+	newZeroFeeRpcClient,
+	newWithFeeRpcClient,
+	asyncMiddleman,
+	newZeroFeeTendermintClient,
+	newWithFeeTendermintClient,
 } from "./utils";
+import { TendermintClient } from "./tendermint-client";
 
 export const WALLET_STAKING_ADDRESS = (<any>addressState).staking;
 export const WALLET_TRANSFER_ADDRESS_1 = (<any>addressState).transfer[0];
@@ -16,22 +21,39 @@ export const WALLET_TRANSFER_ADDRESS_2 = (<any>addressState).transfer[1];
 
 export const unbondAndWithdrawStake = async () => {
 	if (shouldTest(FEE_SCHEMA.ZERO_FEE)) {
-		const zeroFeeClient: RpcClient = newRpcClient();
-		await unbondAndWithdrawStakeFromClient(zeroFeeClient);
+		const zeroFeeRpcClient = newZeroFeeRpcClient();
+		const zeroFeeTendermintClient = newZeroFeeTendermintClient();
+		await unbondAndWithdrawStakeFromClient(
+			zeroFeeRpcClient,
+			zeroFeeTendermintClient,
+		);
 	}
 
 	if (shouldTest(FEE_SCHEMA.WITH_FEE)) {
-		const withFeeClient: RpcClient = newRpcClient("localhost", 26659);
-		await unbondAndWithdrawStakeFromClient(withFeeClient);
+		const withFeeRpcClient = newWithFeeRpcClient();
+		const withFeeTendermintClient = newWithFeeTendermintClient();
+		await unbondAndWithdrawStakeFromClient(
+			withFeeRpcClient,
+			withFeeTendermintClient,
+		);
 	}
 };
 
-const unbondAndWithdrawStakeFromClient = async (client: RpcClient) => {
+const unbondAndWithdrawStakeFromClient = async (
+	rpcClient: RpcClient,
+	tendermintClient: TendermintClient,
+) => {
 	const walletRequest = newWalletRequest("Default", "123456");
 
-	await syncWallet(client, walletRequest);
+	await asyncMiddleman(
+		syncWallet(rpcClient, walletRequest),
+		"Error when synchronizing Default wallet",
+	);
 
-	const walletBalance = await client.request("wallet_balance", [walletRequest]);
+	const walletBalance = await asyncMiddleman(
+		rpcClient.request("wallet_balance", [walletRequest]),
+		"Error when retrieving Default wallet balance",
+	);
 	console.info(`[Info] Wallet balance: ${walletBalance}`);
 	if (new BigNumber(walletBalance).isGreaterThan("0")) {
 		console.info("[Init] Bonded funds already withdrew");
@@ -42,15 +64,24 @@ const unbondAndWithdrawStakeFromClient = async (client: RpcClient) => {
 	console.log(
 		`[Init] Withdrawing bonded genesis funds from "${WALLET_STAKING_ADDRESS}" to "${WALLET_TRANSFER_ADDRESS_1}"`,
 	);
-	await client.request("staking_withdrawAllUnbondedStake", [
-		walletRequest,
-		WALLET_STAKING_ADDRESS,
-		WALLET_TRANSFER_ADDRESS_1,
-		[],
-	]);
-	await sleep(1000);
+	const withdrawTxId = await asyncMiddleman(
+		rpcClient.request("staking_withdrawAllUnbondedStake", [
+			walletRequest,
+			WALLET_STAKING_ADDRESS,
+			WALLET_TRANSFER_ADDRESS_1,
+			[],
+		]),
+		"Error when withdrawing all unbonded stake",
+	);
+	await asyncMiddleman(
+		waitTxIdConfirmed(tendermintClient, withdrawTxId),
+		"Error when retrieving transaction confirmation",
+	);
 
-	await syncWallet(client, walletRequest);
+	await asyncMiddleman(
+		syncWallet(rpcClient, walletRequest),
+		"Error when synchronizing Default wallet",
+	);
 };
 
 if (!shouldTest(FEE_SCHEMA.ZERO_FEE)) {

--- a/integration-tests/client-rpc/test/core/tendermint-client.ts
+++ b/integration-tests/client-rpc/test/core/tendermint-client.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+import BigNumber from "bignumber.js";
+
+export class TendermintClient {
+	constructor(private url: string) {}
+
+	public isTxIdExists(txId: string): Promise<boolean> {
+		console.log(txId);
+		return axios
+			.get(`${this.url}/tx_search?query="valid_txs.txid='${txId}'"`)
+			.then((res) => {
+				console.dir(res.data, { depth: null });
+				return new BigNumber(res.data["result"].total_count).isGreaterThanOrEqualTo(
+					1,
+				);
+			});
+	}
+}

--- a/integration-tests/client-rpc/test/core/transaction-utils.ts
+++ b/integration-tests/client-rpc/test/core/transaction-utils.ts
@@ -1,0 +1,68 @@
+import "mocha";
+import { expect } from "chai";
+import BigNumber from "bignumber.js";
+
+export enum TransactionDirection {
+	INCOMING = "Incoming",
+	OUTGOING = "Outgoing",
+}
+export interface TransactionAssertion {
+	address?: string;
+	direction: TransactionDirection;
+	amount?: BigNumber;
+	height?: number;
+}
+
+export const expectTransactionShouldBe = (
+	actual: any,
+	expected: TransactionAssertion,
+	message?: string,
+): boolean => {
+	expect(actual).to.contain.keys(["kind"]);
+
+	expect(actual.kind).to.eq(expected.direction);
+
+	if (expected.direction === TransactionDirection.INCOMING) {
+		expect(actual).to.contain.keys([
+			"value",
+			"inputs",
+			"outputs",
+			"block_height",
+			"kind",
+			"transaction_id",
+			"transaction_type",
+			"block_time",
+		]);
+	} else {
+		expect(actual).to.contain.keys([
+			"value",
+			"fee",
+			"inputs",
+			"outputs",
+			"block_height",
+			"kind",
+			"transaction_id",
+			"transaction_type",
+			"block_time",
+		]);
+	}
+
+	expect(actual.kind).to.eq(expected.direction);
+	if (typeof expected.amount !== "undefined") {
+		expect(actual.value).to.eq(expected.amount.toString(10), message);
+	}
+
+	if (typeof expected.height !== "undefined") {
+		expect(actual.block_height).to.eq(expected.height.toString(), message);
+	} else {
+		expect(new BigNumber(actual.block_height).isGreaterThan(0)).to.eq(
+			true,
+			message,
+		);
+	}
+	return true;
+};
+
+export const getFirstElementOfArray = (arr: any[]) => {
+	return arr[0];
+};

--- a/integration-tests/client-rpc/test/core/utils.ts
+++ b/integration-tests/client-rpc/test/core/utils.ts
@@ -1,11 +1,10 @@
 import { RpcClient } from "./rpc-client";
 import * as addressState from "../../../address-state.json";
+import { TendermintClient } from "./tendermint-client";
 
 export const WALLET_STAKING_ADDRESS = (<any>addressState).staking;
 export const WALLET_TRANSFER_ADDRESS_1 = (<any>addressState).transfer[0];
 export const WALLET_TRANSFER_ADDRESS_2 = (<any>addressState).transfer[1];
-
-const clientRpcPort = Number(process.env.CLIENT_RPC_ZERO_FEE_PORT) || 16659;
 
 export const newZeroFeeRpcClient = (): RpcClient => {
 	return newRpcClient("localhost", 16659);
@@ -17,9 +16,24 @@ export const newWithFeeRpcClient = (): RpcClient => {
 
 export const newRpcClient = (
 	host: string = "localhost",
-	port: number = clientRpcPort,
+	port: number = 26659,
 ): RpcClient => {
 	return new RpcClient(`http://${host}:${port}`);
+};
+
+export const newZeroFeeTendermintClient = (): TendermintClient => {
+	return newTendermintClient("localhost", 16657);
+};
+
+export const newWithFeeTendermintClient = (): TendermintClient => {
+	return newTendermintClient("localhost", 26657);
+};
+
+export const newTendermintClient = (
+	host: string = "localhost",
+	port: number = 26657,
+): TendermintClient => {
+	return new TendermintClient(`http://${host}:${port}`);
 };
 
 export const sleep = (ms: number = 1000) => {
@@ -56,3 +70,14 @@ export enum FEE_SCHEMA {
 	ZERO_FEE = "ZERO_FEE",
 	WITH_FEE = "WITH_FEE",
 }
+
+export const asyncMiddleman = async (
+	promise: Promise<any>,
+	errorMessage: String,
+): Promise<any> => {
+	try {
+		return await promise;
+	} catch (err) {
+		throw Error(`${errorMessage}: ${err.message}`);
+	}
+};

--- a/integration-tests/client-rpc/test/wallet-management.test.ts
+++ b/integration-tests/client-rpc/test/wallet-management.test.ts
@@ -33,16 +33,24 @@ describe("Wallet management", () => {
 
 		await expect(
 			client.request("wallet_listStakingAddresses", [nonExistingWalletRequest]),
-		).to.eventually.rejectedWith(`Invalid input: Wallet with name (${nonExistingWalletName}) not found`);
+		).to.eventually.rejectedWith(
+			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
+		);
 		await expect(
 			client.request("wallet_listTransferAddresses", [nonExistingWalletRequest]),
-		).to.eventually.rejectedWith(`Invalid input: Wallet with name (${nonExistingWalletName}) not found`);
+		).to.eventually.rejectedWith(
+			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
+		);
 		await expect(
 			client.request("wallet_balance", [nonExistingWalletRequest]),
-		).to.eventually.rejectedWith(`Invalid input: Wallet with name (${nonExistingWalletName}) not found`);
+		).to.eventually.rejectedWith(
+			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
+		);
 		await expect(
 			client.request("wallet_transactions", [nonExistingWalletRequest]),
-		).to.eventually.rejectedWith(`Invalid input: Wallet with name (${nonExistingWalletName}) not found`);
+		).to.eventually.rejectedWith(
+			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
+		);
 	});
 
 	it("can create wallet with specified name", async () => {
@@ -93,7 +101,9 @@ describe("Wallet management", () => {
 
 		return expect(
 			client.request("wallet_create", [walletRequest]),
-		).to.eventually.rejectedWith(`Invalid input: Wallet with name (${walletName}) already exists`);
+		).to.eventually.rejectedWith(
+			`Invalid input: Wallet with name (${walletName}) already exists`,
+		);
 	});
 
 	it("User cannot access wallet with incorrect passphrase", async () => {

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -140,7 +140,7 @@ DEV_CONF=$(cat << EOF
         "0x3ae55c16800dc4bd0e3397a9d7806fb1f11639de": "1250000000000000000",
         "0x71507ee19cbc0c87ff2b5e05d161efe2aac4ee07": "1250000000000000000"
     },
-    "unbonding_period": 5,
+    "unbonding_period": 15,
     "required_council_node_stake": "1250000000000000000",
     "jailing_config": {
         "jail_duration": 86400,


### PR DESCRIPTION
Solution: Used more reliable mechanism to check for state changes and improved error message

- Transaction: Pull Tendermint for the new transaction
  - Changed staking RPCs to return txid
- Staking state: Pull staking state until expected result
- Added contextual error message to all RPC calls by introducing `asyncMiddleman()`
- Refactored Staking test cases and added unbond txid duplication check