### PR TITLE
Problem: (CRO-454) Cannot unjail a jailed account

### DIFF
--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -113,6 +113,11 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                             &BitVec::from_elem(*no_of_outputs as usize, false).to_bytes(),
                         );
                     }
+                    TxAux::UnjailTx(tx, witness) => {
+                        inittx.put(COL_BODIES, &txid[..], &tx.encode());
+                        inittx.put(COL_WITNESS, &txid[..], &witness.encode());
+                        // account should be already unjailed in deliver_tx
+                    }
                 }
             }
             new_state.rewards_pool.last_block_height = new_state.last_block_height;

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -165,6 +165,11 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
                     &self.uncommitted_account_root_hash,
                     &mut self.accounts,
                 ),
+                TxAux::UnjailTx(_, _) => update_account(
+                    fee_acc.1.expect("account returned in unjail verification"),
+                    &self.uncommitted_account_root_hash,
+                    &mut self.accounts,
+                ),
             };
             let mut event = Event::new();
             event.field_type = TendermintEventType::ValidTransactions.to_string();

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -418,6 +418,40 @@ impl fmt::Display for WithdrawUnbondedTx {
     }
 }
 
+/// Unjails an account
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct UnjailTx {
+    pub nonce: Nonce,
+    pub address: StakedStateAddress,
+    pub attributes: StakedStateOpAttributes,
+}
+
+impl TransactionId for UnjailTx {}
+
+impl UnjailTx {
+    #[inline]
+    pub fn new(
+        nonce: Nonce,
+        address: StakedStateAddress,
+        attributes: StakedStateOpAttributes,
+    ) -> Self {
+        Self {
+            nonce,
+            address,
+            attributes,
+        }
+    }
+}
+
+#[cfg(feature = "hex")]
+impl fmt::Display for UnjailTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "unjailed: {} (nonce: {})", self.address, self.nonce)?;
+        write!(f, "")
+    }
+}
+
 /// A witness for StakedState operations
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Solution: Created an `UnjailTx` which unjails a jailed account

Note: Currently, there is no logic to add unjailed accounts back to validator set. That'll be a part of future PRs.