### PR TITLE
Problem: incorrect tx payload for in-enclave encryption (CRO-451)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_tstd 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
- "static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2362,7 +2362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "static_assertions"
-version = "0.3.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3324,7 +3324,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum starling 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8023c1cc199d7f8d04d994a1e28535fbc4eeee48d4b137c8692915a42ecfd994"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
-"checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+"checksum static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fa13613355688665b68639b1c378a62dbedea78aff0fc59a4fa656cbbdec657"
 "checksum stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -21,7 +21,7 @@ blake2 = { version = "0.8", default-features = false }
 parity-scale-codec = { features = ["derive"], default-features = false, version = "1.0" }
 base64 = { version = "0.10", optional = true }
 sgx_tstd = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-sdk.git", optional = true }
-static_assertions = { version = "0.3.4", default-features = false}
+static_assertions = { version = "1.0.0", default-features = false}
 bech32 = { version = "0.7.1", optional = true }
 aead = "0.1.1"
 

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -89,9 +89,9 @@ pub struct TxToObfuscate {
 
 impl TxToObfuscate {
     pub fn from(tx: PlainTxAux, txid: TxId) -> Option<Self> {
-        match tx {
-            PlainTxAux::TransferTx(tx, _) => {
-                if tx.id() == txid {
+        match &tx {
+            PlainTxAux::TransferTx(itx, _) => {
+                if itx.id() == txid {
                     Some(TxToObfuscate {
                         txpayload: tx.encode(),
                         txid,
@@ -104,8 +104,8 @@ impl TxToObfuscate {
                 txpayload: tx.encode(),
                 txid,
             }),
-            PlainTxAux::WithdrawUnbondedStakeTx(tx) => {
-                if tx.id() == txid {
+            PlainTxAux::WithdrawUnbondedStakeTx(itx) => {
+                if itx.id() == txid {
                     Some(TxToObfuscate {
                         txpayload: tx.encode(),
                         txid,

--- a/chain-tx-enclave/tx-validation/Makefile
+++ b/chain-tx-enclave/tx-validation/Makefile
@@ -86,8 +86,10 @@ Enclave_EDL_Files := enclave/Enclave_t.c enclave/Enclave_t.h app/Enclave_u.c app
 
 ifeq ($(SGX_TEST), 1)
 	App_Rust_Flags := $(CARGO_TARGET) --features "sgx-test"
+	Enclave_Rust_Flags := $(CARGO_TARGET) --features "sgx-test"
 else
 	App_Rust_Flags := $(CARGO_TARGET)
+	Enclave_Rust_Flags := $(CARGO_TARGET)
 endif
 
 App_SRC_Files := $(shell find app/ -type f -name '*.rs') $(shell find app/ -type f -name 'Cargo.toml')
@@ -174,7 +176,7 @@ $(Signed_RustEnclave_Name): $(RustEnclave_Name)
 
 .PHONY: enclave
 enclave:
-	@cd ./enclave/ && cargo build ${CARGO_TARGET}
+	@cd ./enclave/ && cargo build ${Enclave_Rust_Flags}
 	cp ./enclave/target/$(OUTPUT_PATH)/libtxvalidationenclave.a ./lib/libenclave.a
 
 .PHONY: compiler-rt

--- a/chain-tx-enclave/tx-validation/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/enclave/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["staticlib"]
 
 [features]
 default = []
+sgx-test = []
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_tse       = { rev = "v1.0.9", git = "https://github.com/baidu/rust-sgx-sdk" }

--- a/chain-tx-enclave/tx-validation/enclave/Enclave.edl
+++ b/chain-tx-enclave/tx-validation/enclave/Enclave.edl
@@ -11,6 +11,11 @@ enclave {
         public sgx_status_t ecall_check_tx(
                 [in, size=tx_request_len] const uint8_t* tx_request, size_t tx_request_len,
                 [out, size=response_len] uint8_t* response_buf, uint32_t response_len);
+
+        public sgx_status_t ecall_test_encrypt(
+                [in, size=enc_request_len] const uint8_t* enc_request, size_t enc_request_len,
+                [out, size=response_len] uint8_t* response_buf, uint32_t response_len);
+
     };
 
     untrusted {

--- a/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
@@ -12,6 +12,8 @@ use enclave_protocol::{EncryptionRequest, IntraEncryptRequest};
 use enclave_protocol::{IntraEnclaveResponse, IntraEnclaveResponseOk};
 use enclave_t_common::check_unseal;
 use parity_scale_codec::Decode;
+#[cfg(feature = "sgx-test")]
+use parity_scale_codec::Encode;
 use sgx_rand::{os::SgxRng, Rng};
 use sgx_tseal::SgxSealedData;
 use sgx_types::{sgx_sealed_data_t, sgx_status_t};
@@ -36,12 +38,71 @@ pub(crate) fn encrypt(tx: TxToObfuscate) -> TxObfuscated {
     }
 }
 
+#[cfg(not(feature = "sgx-test"))]
+#[no_mangle]
+pub extern "C" fn ecall_test_encrypt(
+    _enc_request: *const u8,
+    _enc_request_len: usize,
+    _response_buf: *mut u8,
+    _response_len: u32,
+) -> sgx_status_t {
+    // only for testing
+    sgx_status_t::SGX_ERROR_INVALID_FUNCTION
+}
+
+#[cfg(feature = "sgx-test")]
+#[no_mangle]
+pub extern "C" fn ecall_test_encrypt(
+    enc_request: *const u8,
+    enc_request_len: usize,
+    response_buf: *mut u8,
+    response_len: u32,
+) -> sgx_status_t {
+    // direct encryption (without any checks) for testing only
+    let mut payload = unsafe { std::slice::from_raw_parts(enc_request, enc_request_len) };
+    let req = EncryptionRequest::decode(&mut payload);
+    let otx = match req {
+        Ok(EncryptionRequest::TransferTx(tx, witness)) => {
+            let txid = tx.id();
+            encrypt(
+                TxToObfuscate::from(PlainTxAux::TransferTx(tx, witness), txid)
+                    .expect("construct plain payload"),
+            )
+        }
+        Ok(EncryptionRequest::DepositStake(tx, witness)) => {
+            let txid = tx.id();
+            encrypt(
+                TxToObfuscate::from(PlainTxAux::DepositStakeTx(witness), txid)
+                    .expect("construct plain payload"),
+            )
+        }
+        Ok(EncryptionRequest::WithdrawStake(tx, _account, witness)) => {
+            let txid = tx.id();
+            encrypt(
+                TxToObfuscate::from(PlainTxAux::WithdrawUnbondedStakeTx(tx), txid)
+                    .expect("construct plain payload"),
+            )
+        }
+        _ => panic!("test input"),
+    };
+    let to_copy = otx.encode();
+    let resp_len = to_copy.len() as u32;
+    if resp_len > 0 && resp_len <= response_len {
+        unsafe {
+            std::ptr::copy_nonoverlapping(to_copy.as_ptr(), response_buf, to_copy.len());
+        }
+        sgx_status_t::SGX_SUCCESS
+    } else {
+        sgx_status_t::SGX_ERROR_INVALID_PARAMETER
+    }
+}
+
 pub(crate) fn decrypt(tx: &TxObfuscated) -> Result<PlainTxAux, ()> {
     let key = GenericArray::clone_from_slice(&MOCK_KEY);
     let aead = Aes128GcmSiv::new(key);
     let nonce = GenericArray::from_slice(&tx.init_vector);
     let plaintext = aead.decrypt(nonce, tx).map_err(|_| ())?;
-    let result = PlainTxAux::decode(&mut plaintext.as_ref());
+    let result = PlainTxAux::decode(&mut plaintext.as_slice());
     result.map_err(|_| ())
 }
 

--- a/chain-tx-enclave/tx-validation/enclave/src/validate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/validate.rs
@@ -131,11 +131,18 @@ pub(crate) fn write_back_response(
     }
 }
 
+#[cfg(not(feature = "sgx-test"))]
 #[inline]
 fn decrypt(payload: &TxObfuscated) -> Result<PlainTxAux, ()> {
-    // FIXME: decrypting
+    // FIXME: decrypting -- currently it's done in tests, but should be the default once the client can work with it
     let _ = crate::obfuscate::decrypt(payload);
     PlainTxAux::decode(&mut payload.txpayload.as_slice()).map_err(|_| ())
+}
+
+#[cfg(feature = "sgx-test")]
+#[inline]
+fn decrypt(payload: &TxObfuscated) -> Result<PlainTxAux, ()> {
+    crate::obfuscate::decrypt(payload)
 }
 
 /// takes a request to verify transaction and writes back the result

--- a/chain-tx-filter/src/lib.rs
+++ b/chain-tx-filter/src/lib.rs
@@ -5,7 +5,6 @@
 )]
 
 #[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
-#[macro_use]
 extern crate sgx_tstd as std;
 mod filter;
 use chain_core::state::account::StakedStateAddress;

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -8,7 +8,6 @@
 )]
 
 #[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
-#[macro_use]
 extern crate sgx_tstd as std;
 
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};

--- a/integration-tests/docker/chain/Dockerfile
+++ b/integration-tests/docker/chain/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36.0
+FROM rust:1.38.0
 
 ENV RUSTFLAGS "-Ctarget-feature=+aes,+ssse3"
 


### PR DESCRIPTION
Solution:
- renamed the overshadowing tx
- extended the tx-validation test: enclave code has now sgx-test feature flag
which compiles extra ecall for simple (unchecked) encrypting with a mock key
(`make` with `SGX_TEST=1`)