### PR TITLE
Problem: no way to send encryption request from tx-query enclave (CRO-478)

### DIFF
--- a/chain-tx-enclave/tx-query/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-query/app/src/test/mod.rs
@@ -137,10 +137,10 @@ pub fn test_integration() {
     let txid = &tx0.id();
     let witness0 = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &txid, &secret_key));
     let withdrawtx = TxAux::WithdrawUnbondedStakeTx {
-        txid: tx0.id(),
         no_of_outputs: tx0.outputs.len() as TxoIndex,
         witness: witness0,
         payload: TxObfuscated {
+            txid: tx0.id(),
             key_from: 0,
             init_vector: [0u8; 12],
             txpayload: PlainTxAux::WithdrawUnbondedStakeTx(tx0).encode(),

--- a/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
@@ -147,7 +147,7 @@ fn construct_response(
         Err(e) => Ok(Err(e)),
         Ok(_) => {
             let otx = encrypt(to_obfuscate_tx);
-            Ok(Ok(IntraEnclaveResponseOk::Encrypt(Box::new(otx))))
+            Ok(Ok(IntraEnclaveResponseOk::Encrypt(otx)))
         }
     }
 }


### PR DESCRIPTION
Solution: extended the enclave protocol by one more variant + handling (chain info is stored locally from the validated transactions)
TODO: changes to tx-query