### PR TITLE
Problem: (CRO-469) Updating validator liveness may panic if validator is not present in tracker

### DIFF
--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -339,10 +339,13 @@ fn update_validator_liveness(
             signed
         );
 
-        state
-            .validator_liveness
-            .get_mut(&address)
-            .expect("Validator not found in liveness tracker")
-            .update(block_height, signed);
+        match state.validator_liveness.get_mut(&address) {
+            Some(liveness_tracker) => {
+                liveness_tracker.update(block_height, signed);
+            }
+            None => {
+                log::warn!("Validator in `last_commit_info` not found in liveness tracker");
+            }
+        }
     }
 }

--- a/chain-abci/src/liveness.rs
+++ b/chain-abci/src/liveness.rs
@@ -11,6 +11,12 @@ pub struct LivenessTracker {
     /// Address of staking account
     address: StakedStateAddress,
     /// Holds data to measure liveness
+    ///
+    /// # Note
+    ///
+    /// - Size of this `BitVec` should be equal to `block_signing_window` in jailing parameters in genesis.
+    /// - Stores `true` at `index = height % block_signing_window`, if validator has signed that block, `false`
+    ///   otherwise.
     liveness: BitVec,
 }
 


### PR DESCRIPTION
Solution: Added a `warn!` statement if validator is not present in liveness tracker

Note: This PR is mostly addressing the review comments on earlier PR.