### PR TITLE
Problem: deprecated enclave launch token functionality (CRO-499)

### DIFF
--- a/chain-tx-enclave/tx-query/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-query/app/src/test/mod.rs
@@ -33,7 +33,7 @@ use client_core::cipher::DefaultTransactionObfuscation;
 use client_core::cipher::TransactionObfuscation;
 use enclave_protocol::FLAGS;
 use enclave_protocol::{EnclaveRequest, EnclaveResponse};
-use enclave_u_common::enclave_u::{init_enclave, VALIDATION_TOKEN_KEY};
+use enclave_u_common::enclave_u::init_enclave;
 use env_logger::{Builder, WriteStyle};
 use log::LevelFilter;
 use log::{debug, error, info, warn};

--- a/chain-tx-enclave/tx-validation/app/src/enclave_u/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/enclave_u/mod.rs
@@ -8,8 +8,6 @@ use chain_core::tx::TxAux;
 use chain_core::tx::TxObfuscated;
 use chain_tx_validation::Error;
 use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponse, IntraEnclaveResponseOk};
-use enclave_u_common::enclave_u::TOKEN_LEN;
-use log::{info, warn};
 use parity_scale_codec::{Decode, Encode};
 use sled::Tree;
 use std::mem::size_of;
@@ -30,37 +28,6 @@ extern "C" {
         response_len: u32,
     ) -> sgx_status_t;
 
-}
-
-pub fn get_token(metadb: &Tree, token_key: &[u8]) -> Option<Vec<u8>> {
-    match metadb.get(token_key) {
-        Ok(x) => x.map(|tok| tok.to_vec()),
-        _ => None,
-    }
-}
-
-pub fn get_token_arr(metadb: &Tree, token_key: &[u8]) -> Result<Option<Box<[u8; TOKEN_LEN]>>, ()> {
-    match metadb.get(token_key) {
-        Ok(x) => Ok(x.map(|tok| {
-            let mut token = [0; TOKEN_LEN];
-            token.copy_from_slice(&tok);
-            Box::new(token)
-        })),
-        _ => Err(()),
-    }
-}
-
-pub fn store_token(metadb: &mut Tree, token_key: &[u8], launch_token: Vec<u8>) -> Result<(), ()> {
-    match metadb.insert(token_key, launch_token) {
-        Ok(_) => {
-            info!("[+] Saved updated launch token!");
-            Ok(())
-        }
-        Err(_) => {
-            warn!("[-] Failed to save updated launch token!");
-            Err(())
-        }
-    }
 }
 
 pub fn check_initchain(


### PR DESCRIPTION
Solution: removed the enclave protocol parts related to them;
updated the enclave launcher to use dummy values in the meantime

--
NOTE: Rust SDK isn't updated yet, hence the need of dummy values for the moment
(launch_token and launch_token_updated are now deprecated according to https://download.01.org/intel-sgx/linux-2.6/docs/Intel_SGX_Developer_Reference_Linux_2.6_Open_Source.pdf. They are fully ignored by psw/sgx_urts.)
