### PR TITLE
Problem: unrestricted drone exec pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,6 +39,14 @@ steps:
   - cd chain-tx-enclave/tx-validation && make clean && SGX_TEST=1 make
   - cd bin && ./tx-validation-app
 
+trigger:
+  branch:
+  - master
+  - staging
+  - trying
+  event:
+  - push
+
 ---
 
 kind: pipeline
@@ -80,6 +88,6 @@ trigger:
   - push
 ---
 kind: signature
-hmac: 21e4a81d9785eeaa92154bda9daa8cc6cda13169e459849e919b473e0e2be725
+hmac: bdc2684e182cf00ebf7a8a2e7971884e5ff9ee193d16398aec745bcd1260cf6f
 
 ...


### PR DESCRIPTION
Solution: added trigger conditions, such that
"exec" pipelines are only executed after bors actions