### PR TITLE
Problem: chain-core cannot be compiled on its own

### DIFF
--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["serde", "bech32", "hex", "base64", "secp256k1zkp/serde"]
+default = ["serde", "bech32", "hex", "base64", "secp256k1zkp/serde", "secp256k1zkp/std"]
 mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx"]
 
 


### PR DESCRIPTION
Solution: added the `std` feature for secp256k1 default compilation