### PR TITLE
Problem: (CRO-495) no way for client to unjail account

### DIFF
--- a/client-common/src/transaction.rs
+++ b/client-common/src/transaction.rs
@@ -63,8 +63,6 @@ pub enum SignedTransaction {
     TransferTransaction(Tx, TxWitness),
     /// Deposit stake transaction
     DepositStakeTransaction(DepositBondTx, TxWitness),
-    /// Unbound stake transaction
-    UnbondStakeTransaction(UnbondTx, StakedStateOpWitness),
     /// Withdraw unbounded stake transaction
     ///
     /// NOTE: `StakedState` is needed because this type is primarily for encryption of transaction where we need
@@ -77,7 +75,6 @@ impl TransactionId for SignedTransaction {
         match self {
             SignedTransaction::TransferTransaction(ref transaction, _) => transaction.id(),
             SignedTransaction::DepositStakeTransaction(ref transaction, _) => transaction.id(),
-            SignedTransaction::UnbondStakeTransaction(ref transaction, _) => transaction.id(),
             SignedTransaction::WithdrawUnbondedStakeTransaction(ref transaction, _, _) => {
                 transaction.id()
             }

--- a/client-core/src/cipher/default.rs
+++ b/client-core/src/cipher/default.rs
@@ -161,9 +161,7 @@ impl TransactionObfuscation for DefaultTransactionObfuscation {
             SignedTransaction::DepositStakeTransaction(tx, witness) => {
                 TxQueryInitRequest::Encrypt(Box::new(EncryptionRequest::DepositStake(tx, witness)))
             }
-            SignedTransaction::UnbondStakeTransaction(tx, witness) => {
-                return Ok(TxAux::UnbondStakeTx(tx, witness));
-            }
+
             SignedTransaction::WithdrawUnbondedStakeTransaction(tx, state, witness) => {
                 TxQueryInitRequest::Encrypt(Box::new(EncryptionRequest::WithdrawStake(
                     tx, state, witness,

--- a/client-core/src/cipher/mock_abci_transaction_obfuscation.rs
+++ b/client-core/src/cipher/mock_abci_transaction_obfuscation.rs
@@ -101,9 +101,7 @@ where
             SignedTransaction::DepositStakeTransaction(tx, witness) => {
                 self.encrypt_request(EncryptionRequest::DepositStake(tx, witness))
             }
-            SignedTransaction::UnbondStakeTransaction(tx, witness) => {
-                Ok(TxAux::UnbondStakeTx(tx, witness))
-            }
+
             SignedTransaction::WithdrawUnbondedStakeTransaction(tx, state, witness) => {
                 self.encrypt_request(EncryptionRequest::WithdrawStake(tx, state, witness))
             }

--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -56,6 +56,15 @@ pub trait NetworkOpsClient: Send + Sync {
         attributes: TxAttributes,
     ) -> Result<TxAux>;
 
+    /// Creates a unjail transaction for unjailing
+    fn create_unjail_transaction(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        from_address: &StakedStateAddress,
+        attributes: StakedStateOpAttributes,
+    ) -> Result<TxAux>;
+
     /// Returns staked stake corresponding to given address
     fn get_staked_state(
         &self,

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -381,7 +381,6 @@ pub mod tests {
                         },
                     }))
                 }
-                SignedTransaction::UnbondStakeTransaction(_, _) => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
add unjail-tx to default network client


fix un-covered match


fix un-covered match in wallet-rpc


fix argument


add unit test


rename

