### PR TITLE
Problem:(CRO-521) unbonded from custom time is ignored in genesis initconfig

### DIFF
--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -15,7 +15,7 @@ use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::init::config::InitConfig;
 use chain_core::init::config::NetworkParameters;
-use chain_core::init::config::StakedStateDestination;
+use chain_core::state::account::StakedStateDestination;
 use chain_core::state::account::{StakedState, StakedStateAddress};
 use chain_core::state::tendermint::{BlockHeight, TendermintValidatorAddress, TendermintVotePower};
 use chain_core::state::CouncilNode;

--- a/chain-abci/src/app/jail_account.rs
+++ b/chain-abci/src/app/jail_account.rs
@@ -62,8 +62,9 @@ mod tests {
     use chain_core::init::coin::Coin;
     use chain_core::init::config::{
         InitConfig, InitNetworkParameters, JailingParameters, NetworkParameters, SlashRatio,
-        SlashingParameters, StakedStateDestination, ValidatorKeyType, ValidatorPubkey,
+        SlashingParameters, ValidatorKeyType, ValidatorPubkey,
     };
+    use chain_core::state::account::StakedStateDestination;
     use chain_core::tx::fee::{LinearFee, Milli};
 
     use crate::enclave_bridge::mock::MockClient;

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -14,13 +14,12 @@ use chain_core::init::coin::Coin;
 use chain_core::init::config::InitConfig;
 use chain_core::init::config::InitNetworkParameters;
 use chain_core::init::config::NetworkParameters;
-use chain_core::init::config::StakedStateDestination;
 use chain_core::init::config::{
     JailingParameters, SlashRatio, SlashingParameters, ValidatorKeyType, ValidatorPubkey,
 };
 use chain_core::state::account::{
-    to_stake_key, DepositBondTx, StakedState, StakedStateAddress, StakedStateOpAttributes,
-    StakedStateOpWitness, UnbondTx, WithdrawUnbondedTx,
+    to_stake_key, DepositBondTx, StakedState, StakedStateAddress, StakedStateDestination,
+    StakedStateOpAttributes, StakedStateOpWitness, UnbondTx, WithdrawUnbondedTx,
 };
 use chain_core::state::tendermint::TendermintVotePower;
 use chain_core::state::RewardsPoolState;

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -3,7 +3,7 @@ use crate::init::address::RedeemAddress;
 use crate::init::coin::{sum_coins, Coin, CoinError};
 pub use crate::init::params::*;
 use crate::init::MAX_COIN;
-use crate::state::account::{StakedState, StakedStateAddress};
+use crate::state::account::{StakedState, StakedStateAddress, StakedStateDestination};
 use crate::state::tendermint::{TendermintValidatorPubKey, TendermintVotePower};
 use crate::state::CouncilNode;
 use crate::state::RewardsPoolState;
@@ -108,17 +108,11 @@ impl InitConfig {
         self.distribution
             .iter()
             .map(|(address, (destination, amount))| {
-                let bonded = match destination {
-                    StakedStateDestination::Bonded => true,
-                    StakedStateDestination::UnbondedFromGenesis => false,
-                    StakedStateDestination::UnbondedFromCustomTime(_time) => false,
-                };
-                // TODO: change the define of `new_init` and use StakedStateDestination directly
                 StakedState::new_init(
                     *amount,
-                    genesis_time,
+                    Some(genesis_time),
                     StakedStateAddress::BasicRedeem(*address),
-                    bonded,
+                    destination,
                 )
             })
             .collect()

--- a/chain-core/src/init/params.rs
+++ b/chain-core/src/init/params.rs
@@ -2,6 +2,7 @@ use crate::common::Timespec;
 use crate::common::{hash256, H256};
 use crate::init::address::RedeemAddress;
 use crate::init::coin::{Coin, CoinError};
+use crate::state::account::StakedStateDestination;
 use crate::tx::fee::{Fee, FeeAlgorithm};
 use crate::tx::fee::{LinearFee, Milli, MilliError};
 use blake2::Blake2s;
@@ -238,23 +239,6 @@ impl fmt::Display for SlashRatioError {
             }
         }
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum AccountType {
-    // vanilla -- redeemable
-    ExternallyOwnedAccount,
-    // smart contracts -- non-redeemable (moved to the initial rewards pool)
-    Contract,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum StakedStateDestination {
-    Bonded,
-    UnbondedFromGenesis,
-    UnbondedFromCustomTime(Timespec),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -2,8 +2,9 @@ use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::init::config::{
     InitConfig, InitNetworkParameters, JailingParameters, SlashRatio, SlashingParameters,
-    StakedStateDestination, ValidatorKeyType, ValidatorPubkey,
+    ValidatorKeyType, ValidatorPubkey,
 };
+use chain_core::state::account::StakedStateDestination;
 use chain_core::tx::fee::{LinearFee, Milli};
 use serde::Deserialize;
 use std::collections::BTreeMap;

--- a/chain-tx-enclave/tx-query/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-query/app/src/test/mod.rs
@@ -7,7 +7,7 @@ use chain_core::common::MerkleTree;
 use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{
-    StakedState, StakedStateAddress, StakedStateOpWitness, WithdrawUnbondedTx,
+    StakedState, StakedStateDestination, StakedStateAddress, StakedStateOpWitness, WithdrawUnbondedTx,
 };
 use chain_core::tx::fee::Fee;
 use chain_core::tx::witness::tree::RawPubkey;
@@ -62,9 +62,9 @@ pub fn get_ecdsa_witness<C: Signing>(
 fn get_account(account_address: &RedeemAddress) -> StakedState {
     StakedState::new_init(
         Coin::one(),
-        0,
+        None,
         StakedStateAddress::from(*account_address),
-        false,
+        &StakedStateDestination::UnbondedFromCustomTime(0),
     )
 }
 

--- a/chain-tx-enclave/tx-validation/app/src/enclave_u/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/enclave_u/mod.rs
@@ -3,6 +3,7 @@ use sgx_types::*;
 use chain_core::common::H256;
 use chain_core::state::account::DepositBondTx;
 use chain_core::state::account::StakedState;
+use chain_core::state::account::StakedStateDestination;
 use chain_core::tx::fee::Fee;
 use chain_core::tx::TxEnclaveAux;
 use chain_core::tx::TxObfuscated;
@@ -165,9 +166,9 @@ pub fn check_tx(
                         },
                     ) => Some(StakedState::new_init(
                         deposit_amount,
-                        request.info.previous_block_time,
+                        Some(request.info.previous_block_time),
                         to_staked_account,
-                        true,
+                        &StakedStateDestination::Bonded,
                     )),
                     (_, _) => unreachable!("one shouldn't call this with other variants"),
                 };

--- a/chain-tx-enclave/tx-validation/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/test/mod.rs
@@ -6,6 +6,7 @@ use chain_core::state::account::{
     StakedState, StakedStateAddress, StakedStateOpWitness, WithdrawUnbondedTx,
 };
 use chain_core::tx::fee::Fee;
+use chain_core::state::account::StakedStateDestination;
 use chain_core::tx::witness::tree::RawPubkey;
 use chain_core::tx::witness::EcdsaSignature;
 use chain_core::tx::PlainTxAux;
@@ -84,9 +85,9 @@ fn get_ecdsa_witness<C: Signing>(
 fn get_account(account_address: &RedeemAddress) -> StakedState {
     StakedState::new_init(
         Coin::one(),
-        0,
+        None,
         StakedStateAddress::from(*account_address),
-        false,
+        &StakedStateDestination::UnbondedFromCustomTime(0),
     )
 }
 

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -18,7 +18,7 @@ use std::prelude::v1::Vec;
 
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{
-    DepositBondTx, StakedState, UnbondTx, UnjailTx, WithdrawUnbondedTx,
+    DepositBondTx, StakedState, StakedStateDestination, UnbondTx, UnjailTx, WithdrawUnbondedTx,
 };
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
@@ -316,9 +316,9 @@ pub fn verify_bonded_deposit(
         }
         None => Some(StakedState::new_init(
             deposit_amount,
-            extra_info.previous_block_time,
+            Some(extra_info.previous_block_time),
             maintx.to_staked_account,
-            true,
+            &StakedStateDestination::Bonded,
         )),
     };
     Ok((extra_info.min_fee_computed, account))

--- a/dev-utils/src/commands/genesis_command.rs
+++ b/dev-utils/src/commands/genesis_command.rs
@@ -13,9 +13,9 @@ use chain_abci::storage::tx::StarlingFixedKey;
 use chain_abci::storage::Storage;
 use chain_core::common::MerkleTree;
 use chain_core::compute_app_hash;
-use chain_core::init::config::{InitNetworkParameters, NetworkParameters, StakedStateDestination};
+use chain_core::init::config::{InitNetworkParameters, NetworkParameters};
 use chain_core::init::{address::RedeemAddress, coin::Coin, config::InitConfig};
-use chain_core::state::account::StakedState;
+use chain_core::state::account::{StakedState, StakedStateDestination};
 use chain_core::tx::fee::{LinearFee, Milli};
 use client_common::{Error, ErrorKind, Result, ResultExt};
 


### PR DESCRIPTION
Solution: 
change the parameters of `new_init`: change `genesis_time` from `Timespec` into `Option<Timespec>`, remove the `bool` type parameter `bonded`, add a `&StakedStateDestination` type parameter.