### PR TITLE
Problem: app hash changes even if app state didn't change (CRO-526)

### DIFF
--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -112,6 +112,8 @@ pub struct ChainNodeApp<T: EnclaveProxy> {
     pub power_changed_in_block: BTreeMap<StakedStateAddress, TendermintVotePower>,
     /// proxy for processing transaction validation requests
     pub tx_validator: T,
+    /// was rewards pool updated in the current block?
+    pub rewards_pool_updated: bool,
 }
 
 fn get_validator_key(node: &CouncilNode) -> PubKey {
@@ -271,6 +273,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             validator_pubkeys,
             power_changed_in_block: BTreeMap::new(),
             tx_validator,
+            rewards_pool_updated: false,
         }
     }
 
@@ -375,6 +378,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                 validator_pubkeys: BTreeMap::new(),
                 power_changed_in_block: BTreeMap::new(),
                 tx_validator,
+                rewards_pool_updated: false,
             }
         }
     }

--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -126,8 +126,10 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
         if !self.delivered_txs.is_empty() {
             self.process_txs(&mut inittx);
         }
-
-        new_state.rewards_pool.last_block_height = new_state.last_block_height;
+        if self.rewards_pool_updated {
+            new_state.rewards_pool.last_block_height = new_state.last_block_height;
+            self.rewards_pool_updated = false;
+        }
         new_state.last_account_root_hash = self.uncommitted_account_root_hash;
         let app_hash = compute_app_hash(
             &tree,

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -356,6 +356,7 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             let new_remaining = (rewards_pool.remaining + fee_acc.0.to_coin())
                 .expect("rewards pool + fee greater than max coin?");
             rewards_pool.remaining = new_remaining;
+            self.rewards_pool_updated = true;
             // this "buffered write" shouldn't persist (persistence done in commit)
             // but should change it in-memory -- TODO: check
             self.storage.db.write_buffered(inittx);

--- a/chain-abci/src/app/slash_accounts.rs
+++ b/chain-abci/src/app/slash_accounts.rs
@@ -68,6 +68,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             last_state.rewards_pool.remaining = (last_state.rewards_pool.remaining
                 + slashed_amount)
                 .map_err(|_| Error::InvalidSum)?;
+            self.rewards_pool_updated = true;
 
             let (new_root, _) = update_account(
                 account,


### PR DESCRIPTION
Solution: added a flag to chainabci node to signal whether rewards pool was updated
in that block (either by slashing events or transaction fees -- in the future reward distribution),
so that its "last_block_height" (which denotes when it was updated last time)
is only updated when the amount changed.
TODO: perhaps move the rewards pool update logic to rewards pool code (rather than in abci)?