### PR TITLE
Problem: (CRO-512) Cargo tools and build intermediates are not cached in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,24 @@
+clean_cache: &clean_cache
+  language: rust
+  sudo: required
+  dist: trusty
+  if: type = cron
+  cache:
+    directories: # cargo caching from https://docs.travis-ci.com/user/caching/#rust-cargo-cache
+      - $HOME/.cargo
+      - $TRAVIS_BUILD_DIR/target
+      - $HOME/.rustup/toolchains
+      - $HOME/lib
+      - $HOME/include
+      - $HOME/bin
+      - /usr/local/bin # kcov
+  install:
+  script:
+    echo "Cleaning cargo cache ..."
+    rm -rf $HOME/.cargo/registry
+    rm -rf $HOME/.rustup/toolchains
+    cargo clean
+
 rust: &rust
   language: rust
   sudo: required
@@ -14,14 +35,17 @@ rust: &rust
         - binutils-dev
         - libc6-dev
   cache:
-    directories:
-      - /home/travis/.cargo
-      - /home/travis/lib
-      - /home/travis/include
-      - /home/travis/bin
-      - /usr/local/bin/
+    directories: # cargo caching from https://docs.travis-ci.com/user/caching/#rust-cargo-cache
+      - $HOME/.cargo
+      - $TRAVIS_BUILD_DIR/target
+      - $HOME/.rustup/toolchains
+      - $HOME/lib
+      - $HOME/include
+      - $HOME/bin
+      - /usr/local/bin # kcov
   before_cache:
-    - rm -rf /home/travis/.cargo/registry
+    - du -sh $HOME/.cargo $TRAVIS_BUILD_DIR/target $HOME/.rustup/toolchains $HOME/lib $HOME/include $HOME/bin
+    - rm -rf $HOME/.cargo/registry/src
   env:
     - RUST_BACKTRACE=1
     - RUSTFLAGS=-Ctarget-feature=+aes,+ssse3
@@ -30,25 +54,27 @@ rust: &rust
     - PKG_CONFIG_PATH=$HOME/lib/pkgconfig
   before_install: # versions from https://github.com/erickt/rust-zmq/blob/master/.travis.yml
     - ./install_zeromq.sh
+    - |
+      if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
+        ./install_kcov.sh 
+        cargo-kcov --version || cargo install cargo-kcov;
+      fi
 
   script:
-    - cargo clean
     - cargo build
     - cargo test
     - |
       if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-        (rustfmt --version || rustup component add rustfmt) &&
-        cargo fmt -- --check --color=auto &&
-        (cargo-clippy --version || rustup component add clippy) &&
-        cargo clippy -- -D warnings &&
-        (cargo-audit -h || cargo install cargo-audit) &&
-        cargo audit       
+        (rustfmt --version || rustup component add rustfmt)
+        cargo fmt -- --check --color=auto
+        (cargo-clippy --version || rustup component add clippy)
+        cargo clippy -- -D warnings
+        (cargo-audit -h || cargo install cargo-audit)
+        cargo audit
       fi
 
   after_success: |
     if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-      ./install_kcov.sh 
-      cargo-kcov --version || cargo install cargo-kcov;
       travis_wait 30 cargo kcov --all;
       bash <(curl -s https://codecov.io/bash);
     fi
@@ -59,25 +85,19 @@ jobs:
   include:
     - <<: *rust
       rust: stable
-      if: (branch != staging.tmp) AND (branch != trying.tmp)
+      if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
     - <<: *rust
       rust: beta
-      if: (branch = staging) OR (branch = trying)
+      if: (type != cron) AND ((branch = staging) OR (branch = trying))
     - <<: *rust
       rust: nightly
-      if: (branch != staging.tmp) AND (branch != trying.tmp)
+      if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
     - name: Integration Test
       language: node_js
       node_js: 10
       sudo: required
       dist: trusty
-      if: (branch = staging) OR (branch = trying)
-      cache:
-        directories:
-          - /home/travis/lib
-          - /home/travis/include
-          - /home/travis/bin
-          - /usr/local/bin/
+      if: (type != cron) AND ((branch = staging) OR (branch = trying))
       script:
         - cd integration-tests
         - ./prepare.sh || travis_terminate 1;
@@ -89,3 +109,10 @@ jobs:
           cd client-rpc
           yarn
           yarn test || (docker-compose ps && docker-compose logs -t --tail="all" && travis_terminate 1);
+
+    - <<: *clean_cache
+      rust: stable
+    - <<: *clean_cache
+      rust: beta
+    - <<: *clean_cache
+      rust: nightly

--- a/install_kcov.sh
+++ b/install_kcov.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
-FILE=/usr/local/bin/kcov
-if [ ! -f "$FILE" ]; then
-    echo "$FILE does not exist"
+#!/usr/bin/env bash
+
+CARGO_KCOV_FILE="${HOME}/.cargo/bin/cargo-kcov"
+KCOV_FILE="/usr/local/bin/kcov"
+if [ ! -f "${CARGO_KCOV_FILE}" ] || [ ! -f "${KCOV_FILE}" ]; then
+    echo "kcov is not installed"
     wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
     tar xzf master.tar.gz
     cd kcov-master


### PR DESCRIPTION
Solution: Add more aggressive caching of re-usable resources

---
Remarks:
- With more aggressive caching task time has reduced ~10mins, with the tradeoff of a much bigger cache size
- Hence a cron job is need to run on master maybe every week to keep the master branch cache to be slim
