### PR TITLE
Problem:(CRO 266) Not using dummy values for fee calculation

### DIFF
--- a/client-core/src/signer.rs
+++ b/client-core/src/signer.rs
@@ -1,8 +1,10 @@
 //! Transaction signing
 mod default_signer;
+mod dummy_signer;
 mod unauthorized_signer;
 
 pub use default_signer::DefaultSigner;
+pub use dummy_signer::DummySigner;
 pub use unauthorized_signer::UnauthorizedSigner;
 
 use secstr::SecUtf8;
@@ -20,6 +22,6 @@ pub trait Signer: Send + Sync {
         name: &str,
         passphrase: &SecUtf8,
         message: T,
-        selected_unspent_transactions: SelectedUnspentTransactions<'_>,
+        selected_unspent_transactions: &SelectedUnspentTransactions<'_>,
     ) -> Result<TxWitness>;
 }

--- a/client-core/src/signer/default_signer.rs
+++ b/client-core/src/signer/default_signer.rs
@@ -110,7 +110,7 @@ where
         name: &str,
         passphrase: &SecUtf8,
         message: T,
-        selected_unspent_transactions: SelectedUnspentTransactions<'_>,
+        selected_unspent_transactions: &SelectedUnspentTransactions<'_>,
     ) -> Result<TxWitness> {
         selected_unspent_transactions
             .iter()
@@ -182,7 +182,7 @@ mod tests {
         let signer = DefaultSigner::new(storage);
 
         let witness = signer
-            .sign(name, passphrase, message, selected_unspent_transactions)
+            .sign(name, passphrase, message, &selected_unspent_transactions)
             .expect("Unable to sign transaction");
 
         assert!(verify_tx_address(&witness[0], &message, &tree_address).is_ok());
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(
             ErrorKind::IllegalInput,
             signer
-                .sign(name, passphrase, message, selected_unspent_transactions)
+                .sign(name, passphrase, message, &selected_unspent_transactions)
                 .expect_err("Unable to sign transaction")
                 .kind()
         );

--- a/client-core/src/signer/dummy_signer.rs
+++ b/client-core/src/signer/dummy_signer.rs
@@ -1,0 +1,48 @@
+use crate::SelectedUnspentTransactions;
+use chain_core::common::MerkleTree;
+use chain_core::common::H264;
+use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::{TxInWitness, TxWitness};
+use client_common::Result;
+use secp256k1::schnorrsig::SchnorrSignature;
+
+/// Default implementation of `Signer`
+#[derive(Debug, Clone)]
+pub struct DummySigner {}
+
+impl DummySigner {
+    /// Creates a mock merkletree
+    fn mock_merkletree(
+        &self,
+        raw_pubkey: RawPubkey,
+        tree_length: usize,
+    ) -> Result<MerkleTree<RawPubkey>> {
+        let tree = vec![raw_pubkey; tree_length];
+        Ok(MerkleTree::new(tree))
+    }
+
+    /// Signs with the mock key pair
+    fn sign_inside(&self, total_pubkeys_len: usize) -> Result<TxInWitness> {
+        let raw_pk = RawPubkey::from([0_u8; 33] as H264);
+        let merkle_tree = self.mock_merkletree(raw_pk.clone(), total_pubkeys_len)?;
+        let proof = merkle_tree
+            .generate_proof(raw_pk)
+            .expect("generate proof error in mocked merkle tree");
+        let mock_signature =
+            SchnorrSignature::from_default(&[0_u8; 64]).expect("set mock signature failed");
+        Ok(TxInWitness::TreeSig(mock_signature, proof))
+    }
+
+    /// Signs the selected_unspent_transactions
+    pub fn sign(
+        &self,
+        total_pubkeys_len: usize,
+        selected_unspent_transactions: &SelectedUnspentTransactions<'_>,
+    ) -> Result<TxWitness> {
+        selected_unspent_transactions
+            .iter()
+            .map(|_| self.sign_inside(total_pubkeys_len))
+            .collect::<Result<Vec<TxInWitness>>>()
+            .map(Into::into)
+    }
+}

--- a/client-core/src/signer/unauthorized_signer.rs
+++ b/client-core/src/signer/unauthorized_signer.rs
@@ -15,7 +15,7 @@ impl Signer for UnauthorizedSigner {
         _: &str,
         _: &SecUtf8,
         _: T,
-        _: SelectedUnspentTransactions<'_>,
+        _: &SelectedUnspentTransactions<'_>,
     ) -> Result<TxWitness> {
         Err(ErrorKind::PermissionDenied.into())
     }

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -133,7 +133,7 @@ where
             name,
             passphrase,
             transaction.id(),
-            unspent_transactions.select_all(),
+            &unspent_transactions.select_all(),
         )?;
 
         let signed_transaction = SignedTransaction::DepositStakeTransaction(transaction, witness);


### PR DESCRIPTION
solution:
- create a Merkle tree (length is 2) for each selected unpent transactions to get the Merkle tree `Path`
- use Vec<u8> allocated with the same number of bytes as the `signature`
- use the above `Merkle tree path` + `signature` as the witness
- pad the payload to the multiples of 128 bits used in the  mock`TxEnclaveAux::TransferTx`

