### PR TITLE
Problem: (CRO-405) Querying public information by probablistic filter

### DIFF
--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -20,7 +20,6 @@ use chain_core::state::account::{CouncilNode, StakedState, StakedStateAddress};
 use chain_core::state::tendermint::{BlockHeight, TendermintValidatorAddress, TendermintVotePower};
 use chain_core::state::RewardsPoolState;
 use chain_core::tx::TxAux;
-use chain_tx_filter::BlockFilter;
 use enclave_protocol::{EnclaveRequest, EnclaveResponse};
 use kvdb::DBTransaction;
 use log::{info, warn};
@@ -88,8 +87,6 @@ pub struct ChainNodeApp<T: EnclaveProxy> {
     pub accounts: AccountStorage,
     /// valid transactions after DeliverTx before EndBlock/Commit
     pub delivered_txs: Vec<TxAux>,
-    /// current block filter
-    pub filter: BlockFilter,
     /// root hash of the sparse merkle patricia trie of staking account states after DeliverTx before EndBlock/Commit
     pub uncommitted_account_root_hash: StarlingFixedKey,
     /// a reference to genesis (used when there is no committed state)
@@ -251,7 +248,6 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             storage,
             accounts,
             delivered_txs: Vec::new(),
-            filter: BlockFilter::default(),
             uncommitted_account_root_hash: last_app_state.last_account_root_hash,
             chain_hex_id,
             genesis_app_hash,
@@ -265,7 +261,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
     }
 
     /// Creates a new App initialized with a given storage (could be in-mem or persistent).
-    /// If persistent storage is used, it'll try to recove stored arguments (e.g. last app hash / block height) from it.
+    /// If persistent storage is used, it'll try to recover stored arguments (e.g. last app hash / block height) from it.
     ///
     /// # Arguments
     ///
@@ -359,7 +355,6 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                 storage,
                 accounts,
                 delivered_txs: Vec::new(),
-                filter: BlockFilter::default(),
                 uncommitted_account_root_hash: [0u8; 32],
                 chain_hex_id,
                 genesis_app_hash,

--- a/chain-abci/src/app/slash_accounts.rs
+++ b/chain-abci/src/app/slash_accounts.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use abci::{Event, KVPair};
 
-use chain_core::common::TendermintEventType;
+use chain_core::common::{TendermintEventKey, TendermintEventType};
 use chain_core::init::config::SlashRatio;
 use chain_core::state::account::StakedStateAddress;
 use chain_core::tx::fee::Milli;
@@ -40,7 +40,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
 
         for staking_address in accounts_to_slash {
             let mut kvpair = KVPair::new();
-            kvpair.key = b"account".to_vec();
+            kvpair.key = TendermintEventKey::Account.into();
             kvpair.value = staking_address.to_string().into_bytes();
 
             slashing_event.attributes.push(kvpair);

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -8,7 +8,7 @@ use chain_core::tx::TxAux;
 use chain_tx_validation::ChainInfo;
 use parity_scale_codec::Decode;
 
-/// Wrapper to astract over CheckTx and DeliverTx requests
+/// Wrapper to abstract over CheckTx and DeliverTx requests
 pub trait RequestWithTx {
     fn tx(&self) -> &[u8];
 }
@@ -25,7 +25,7 @@ impl RequestWithTx for RequestDeliverTx {
     }
 }
 
-/// Wrapper to astract over CheckTx and DeliverTx responses
+/// Wrapper to abstract over CheckTx and DeliverTx responses
 pub trait ResponseWithCodeAndLog {
     fn set_code(&mut self, _: u32);
     fn add_log(&mut self, _: &str);

--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -174,9 +174,13 @@ impl EnclaveProxy for MockClient {
                 }
             }
             EnclaveRequest::EndBlock => {
-                let raw = self.filter.get_raw();
+                let maybe_filter = if self.filter.is_modified() {
+                    Some(Box::new(self.filter.get_raw()))
+                } else {
+                    None
+                };
                 self.filter.reset();
-                EnclaveResponse::EndBlock(Ok(Box::new(raw)))
+                EnclaveResponse::EndBlock(Ok(maybe_filter))
             }
             EnclaveRequest::CommitBlock { .. } => EnclaveResponse::CommitBlock(Ok(())),
             EnclaveRequest::VerifyTx(txrequest) => {

--- a/chain-core/src/common/mod.rs
+++ b/chain-core/src/common/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::prelude::v1::{String, Vec};
 
 use digest::Digest;
 
@@ -42,6 +43,55 @@ impl fmt::Display for TendermintEventType {
             TendermintEventType::BlockFilter => write!(f, "block_filter"),
             TendermintEventType::JailValidators => write!(f, "jail_validators"),
             TendermintEventType::SlashValidators => write!(f, "slash_validators"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Attribute key of tendermint events
+pub enum TendermintEventKey {
+    Account,
+    Fee,
+    TxId,
+    EthBloom,
+}
+
+impl From<TendermintEventKey> for Vec<u8> {
+    #[inline]
+    fn from(key: TendermintEventKey) -> Vec<u8> {
+        key.to_vec()
+    }
+}
+
+impl PartialEq<TendermintEventKey> for Vec<u8> {
+    fn eq(&self, other: &TendermintEventKey) -> bool {
+        *self == other.to_vec()
+    }
+}
+impl PartialEq<Vec<u8>> for TendermintEventKey {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.to_vec() == *other
+    }
+}
+
+impl TendermintEventKey {
+    #[inline]
+    pub fn to_vec(self) -> Vec<u8> {
+        match self {
+            TendermintEventKey::Account => Vec::from(&b"account"[..]),
+            TendermintEventKey::Fee => Vec::from(&b"fee"[..]),
+            TendermintEventKey::TxId => Vec::from(&b"txid"[..]),
+            TendermintEventKey::EthBloom => Vec::from(&b"ethbloom"[..]),
+        }
+    }
+
+    #[inline]
+    pub fn to_base64_string(self) -> String {
+        match self {
+            TendermintEventKey::Account => String::from("YWNjb3VudA=="),
+            TendermintEventKey::Fee => String::from("ZmVl"),
+            TendermintEventKey::TxId => String::from("dHhpZA=="),
+            TendermintEventKey::EthBloom => String::from("ZXRoYmxvb20="),
         }
     }
 }

--- a/chain-tx-enclave/tx-validation/app/src/enclave_u/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/enclave_u/mod.rs
@@ -47,8 +47,9 @@ pub fn check_initchain(
 pub fn end_block(
     eid: sgx_enclave_id_t,
     request: IntraEnclaveRequest,
-) -> Result<Box<[u8; 256]>, ()> {
+) -> Result<Option<Box<[u8; 256]>>, ()> {
     let request_buf: Vec<u8> = request.encode();
+    // Buffer size: Result(1)+Result(1)+Enum(1)+Option(1)+Box(0)+TxFilter(256)
     let mut response_buf: Vec<u8> = vec![0u8; 260];
     let mut retval: sgx_status_t = sgx_status_t::SGX_SUCCESS;
     let response_slice = &mut response_buf[..];
@@ -65,7 +66,7 @@ pub fn end_block(
     if retval == sgx_status_t::SGX_SUCCESS && result == retval {
         let response = IntraEnclaveResponse::decode(&mut response_buf.as_slice());
         match response {
-            Ok(Ok(IntraEnclaveResponseOk::EndBlock(filter))) => Ok(filter),
+            Ok(Ok(IntraEnclaveResponseOk::EndBlock(maybe_filter))) => Ok(maybe_filter),
             _ => Err(()),
         }
     } else {

--- a/chain-tx-enclave/tx-validation/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/test/mod.rs
@@ -130,7 +130,7 @@ pub fn test_sealing() {
     match end_b {
         Ok(b) => {
             debug!("request filter in the beginning");
-            assert!(b.iter().all(|x| *x == 0u8), "empty filter");
+            assert!(b.is_none(), "empty filter");
         }
         _ => {
             cleanup(&mut db);
@@ -209,7 +209,7 @@ pub fn test_sealing() {
     match end_b {
         Ok(b) => {
             debug!("request filter after one tx");
-            assert!(b.iter().any(|x| *x != 0u8), "non-empty filter");
+            assert!(b.unwrap().iter().any(|x| *x != 0u8), "non-empty filter");
         }
         _ => {
             cleanup(&mut db);

--- a/chain-tx-enclave/tx-validation/enclave/src/validate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/validate.rs
@@ -28,10 +28,14 @@ pub(crate) fn handle_end_block(response_buf: *mut u8, response_len: u32) -> sgx_
     let mut filter = FILTER
         .lock()
         .expect("poisoned lock: failed to get block tx filter");
-    let payload: [u8; 256] = filter.get_raw();
+    let maybe_filter = if filter.is_modified() {
+        Some(Box::new(filter.get_raw()))
+    } else {
+        None
+    };
     filter.reset();
     write_back_response(
-        Ok(Ok(IntraEnclaveResponseOk::EndBlock(Box::new(payload)))),
+        Ok(Ok(IntraEnclaveResponseOk::EndBlock(maybe_filter))),
         response_buf,
         response_len,
     )

--- a/client-common/src/tendermint/types/block_results.rs
+++ b/client-common/src/tendermint/types/block_results.rs
@@ -1,10 +1,13 @@
 #![allow(missing_docs)]
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 use base64;
 use serde::Deserialize;
 
-use chain_core::common::TendermintEventType;
+use chain_core::common::{TendermintEventKey, TendermintEventType};
+use chain_core::init::address::RedeemAddress;
+use chain_core::state::account::StakedStateAddress;
 use chain_core::tx::data::TxId;
 use chain_tx_filter::BlockFilter;
 
@@ -41,7 +44,7 @@ pub struct Event {
     pub attributes: Vec<Attribute>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Attribute {
     pub key: String,
     pub value: String,
@@ -67,6 +70,33 @@ impl BlockResults {
                 }
 
                 Ok(transactions)
+            }
+        }
+    }
+
+    /// Checks if a StakedStateAddress is included in devlier_tx account event.
+    /// Returns true when the address presents
+    pub fn contains_account(&self, target_account: &StakedStateAddress) -> Result<bool> {
+        match &self.results.deliver_tx {
+            None => Ok(false),
+            Some(deliver_tx) => {
+                for transaction in deliver_tx.iter() {
+                    for event in transaction.events.iter() {
+                        if event.event_type != TendermintEventType::ValidTransactions.to_string() {
+                            continue;
+                        }
+                        match find_account_from_event_attributes(&event.attributes)? {
+                            None => continue,
+                            Some(address) => {
+                                if address == *target_account {
+                                    return Ok(true);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok(false)
             }
         }
     }
@@ -98,7 +128,10 @@ impl BlockResults {
     }
 }
 
-fn find_tx_id_from_event_attributes(attributes: &[Attribute]) -> Result<Option<[u8; 32]>> {
+fn find_event_attribute_by_key(
+    attributes: &[Attribute],
+    target_key: TendermintEventKey,
+) -> Result<Option<&Attribute>> {
     for attribute in attributes.iter() {
         let key = base64::decode(&attribute.key).chain(|| {
             (
@@ -106,34 +139,75 @@ fn find_tx_id_from_event_attributes(attributes: &[Attribute]) -> Result<Option<[
                 "Unable to decode base64 bytes of attribute key in block results",
             )
         })?;
-        if key != b"txid" {
-            continue;
+        if key == target_key {
+            return Ok(Some(attribute));
         }
-
-        let tx_id = base64::decode(&attribute.value).chain(|| {
-            (
-                ErrorKind::DeserializationError,
-                "Unable to decode base64 bytes of transaction id in block results",
-            )
-        })?;
-        let tx_id = hex::decode(&tx_id).chain(|| {
-            (
-                ErrorKind::DeserializationError,
-                "Unable to decode hex bytes of transaction id in block results",
-            )
-        })?;
-        if 32 != tx_id.len() {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "Expected transaction id of 32 bytes",
-            ));
-        }
-        let mut id: [u8; 32] = [0; 32];
-        id.copy_from_slice(&tx_id);
-
-        return Ok(Some(id));
     }
+
     Ok(None)
+}
+
+fn find_tx_id_from_event_attributes(attributes: &[Attribute]) -> Result<Option<[u8; 32]>> {
+    let maybe_attribute = find_event_attribute_by_key(attributes, TendermintEventKey::TxId)?;
+    match maybe_attribute {
+        None => Ok(None),
+        Some(attribute) => {
+            let tx_id = base64::decode(&attribute.value).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to decode base64 bytes of transaction id in block results",
+                )
+            })?;
+            let tx_id = hex::decode(&tx_id).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to decode hex bytes of transaction id in block results",
+                )
+            })?;
+            if 32 != tx_id.len() {
+                return Err(Error::new(
+                    ErrorKind::DeserializationError,
+                    "Expected transaction id of 32 bytes",
+                ));
+            }
+            let mut id: [u8; 32] = [0; 32];
+            id.copy_from_slice(&tx_id);
+
+            Ok(Some(id))
+        }
+    }
+}
+
+fn find_account_from_event_attributes(
+    attributes: &[Attribute],
+) -> Result<Option<StakedStateAddress>> {
+    let maybe_attribute = find_event_attribute_by_key(attributes, TendermintEventKey::Account)?;
+    match maybe_attribute {
+        None => Ok(None),
+        Some(attribute) => {
+            let account = base64::decode(&attribute.value).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to decode base64 bytes of account in block results",
+                )
+            })?;
+            let address = String::from_utf8(account).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to decode string of account in block results",
+                )
+            })?;
+            let redeem_address = RedeemAddress::from_str(&address).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to decode account address in block results",
+                )
+            })?;
+            let address = StakedStateAddress::from(redeem_address);
+
+            Ok(Some(address))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -141,6 +215,222 @@ mod tests {
     use super::*;
 
     use base64::encode;
+
+    mod find_account_from_event_attributes {
+        use super::*;
+
+        #[test]
+        fn should_return_err_when_event_value_is_invalid_base64_encoded() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![DeliverTx {
+                        events: vec![Event {
+                            event_type: TendermintEventType::ValidTransactions.to_string(),
+                            attributes: vec![Attribute {
+                                key: TendermintEventKey::Account.to_base64_string(),
+                                value: "Invalid==".to_owned(),
+                            }],
+                        }],
+                    }]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0x0e7c045110b8dbf29765047380898919c5cb56f4").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_err());
+            assert_eq!(ErrorKind::DeserializationError, result.unwrap_err().kind());
+        }
+
+        #[test]
+        fn should_return_err_when_account_value_is_invalid_utf8_string() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![DeliverTx {
+                        events: vec![Event {
+                            event_type: TendermintEventType::ValidTransactions.to_string(),
+                            attributes: vec![Attribute {
+                                key: TendermintEventKey::Account.to_base64_string(),
+                                value: base64::encode(&vec![0, 159, 146, 150]),
+                            }],
+                        }],
+                    }]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0x0e7c045110b8dbf29765047380898919c5cb56f4").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_err());
+            assert_eq!(ErrorKind::DeserializationError, result.unwrap_err().kind());
+        }
+
+        #[test]
+        fn should_return_err_when_account_address_is_invalid() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![DeliverTx {
+                        events: vec![Event {
+                            event_type: TendermintEventType::ValidTransactions.to_string(),
+                            attributes: vec![Attribute {
+                                key: TendermintEventKey::Account.to_base64_string(),
+                                value: base64::encode("0xInvalid".as_bytes()),
+                            }],
+                        }],
+                    }]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0x0e7c045110b8dbf29765047380898919c5cb56f4").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_err());
+            assert_eq!(ErrorKind::DeserializationError, result.unwrap_err().kind());
+        }
+
+        #[test]
+        fn should_return_ok_of_none_when_block_results_has_no_account_event() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![DeliverTx {
+                        events: vec![Event {
+                            event_type: TendermintEventType::ValidTransactions.to_string(),
+                            attributes: vec![Attribute {
+                                key: TendermintEventKey::TxId.to_base64_string(),
+                                value: "MDc2NmQ0ZTFjMDkxMjRhZjlhZWI0YTdlZDk5ZDgxNjU0YTg0NDczZjEzMzk0OGNlYTA1MGRhYTE3ZmYwZTdmZg==".to_owned(),
+                            }],
+                        }],
+                    }]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0x0e7c045110b8dbf29765047380898919c5cb56f4").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_ok());
+            assert_eq!(false, result.unwrap());
+        }
+
+        #[test]
+        fn should_return_ok_of_true_when_block_results_has_the_target_account_event() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![DeliverTx {
+                        events: vec![Event {
+                            event_type: TendermintEventType::ValidTransactions.to_string(),
+                            attributes: vec![Attribute {
+                                key: TendermintEventKey::Account.to_base64_string(),
+                                value: base64::encode(
+                                    "0xe4a2a719ca933d3f79a8506aa96cefde3405b0a7".as_bytes(),
+                                ),
+                            }],
+                        }],
+                    }]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0xe4a2a719ca933d3f79a8506aa96cefde3405b0a7").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_ok());
+            assert_eq!(true, result.unwrap());
+        }
+
+        #[test]
+        fn should_return_ok_of_true_when_target_account_event_is_from_second_transaction() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![
+                        DeliverTx {
+                            events: vec![Event {
+                                event_type: TendermintEventType::ValidTransactions.to_string(),
+                                attributes: vec![Attribute {
+                                    key: TendermintEventKey::TxId.to_base64_string(),
+                                    value: "MDc2NmQ0ZTFjMDkxMjRhZjlhZWI0YTdlZDk5ZDgxNjU0YTg0NDczZjEzMzk0OGNlYTA1MGRhYTE3ZmYwZTdmZg==".to_owned(),
+                                }],
+                            }],
+                        },
+                        DeliverTx {
+                            events: vec![Event {
+                                event_type: TendermintEventType::ValidTransactions.to_string(),
+                                attributes: vec![Attribute {
+                                    key: TendermintEventKey::Account.to_base64_string(),
+                                    value: base64::encode(
+                                        "0xe4a2a719ca933d3f79a8506aa96cefde3405b0a7".as_bytes(),
+                                    ),
+                                }],
+                            }],
+                        },
+                    ]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0xe4a2a719ca933d3f79a8506aa96cefde3405b0a7").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_ok());
+            assert_eq!(true, result.unwrap());
+        }
+
+        #[test]
+        fn should_return_ok_of_true_when_account_event_exists_in_multiple_transactions() {
+            let block_results = BlockResults {
+                height: "2".to_owned(),
+                results: Results {
+                    deliver_tx: Some(vec![
+                        DeliverTx {
+                            events: vec![Event {
+                                event_type: TendermintEventType::ValidTransactions.to_string(),
+                                attributes: vec![Attribute {
+                                    key: TendermintEventKey::Account.to_base64_string(),
+                                    value: base64::encode(
+                                        "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b".as_bytes(),
+                                    ),
+                                }],
+                            }],
+                        },
+                        DeliverTx {
+                            events: vec![Event {
+                                event_type: TendermintEventType::ValidTransactions.to_string(),
+                                attributes: vec![Attribute {
+                                    key: TendermintEventKey::Account.to_base64_string(),
+                                    value: base64::encode(
+                                        "0xe4a2a719ca933d3f79a8506aa96cefde3405b0a7".as_bytes(),
+                                    ),
+                                }],
+                            }],
+                        },
+                    ]),
+                    end_block: None,
+                },
+            };
+
+            let target_account = StakedStateAddress::from(
+                RedeemAddress::from_str("0xe4a2a719ca933d3f79a8506aa96cefde3405b0a7").unwrap(),
+            );
+            let result = block_results.contains_account(&target_account);
+            assert!(result.is_ok());
+            assert_eq!(true, result.unwrap());
+        }
+    }
 
     #[test]
     fn check_ids() {
@@ -151,7 +441,7 @@ mod tests {
                     events: vec![Event {
                         event_type: TendermintEventType::ValidTransactions.to_string(),
                         attributes: vec![Attribute {
-                            key: "dHhpZA==".to_owned(),
+                            key: TendermintEventKey::TxId.to_base64_string(),
                             value: "MDc2NmQ0ZTFjMDkxMjRhZjlhZWI0YTdlZDk5ZDgxNjU0YTg0NDczZjEzMzk0OGNlYTA1MGRhYTE3ZmYwZTdmZg==".to_owned(),
                         }],
                     }],
@@ -172,7 +462,7 @@ mod tests {
                     events: vec![Event {
                         event_type: TendermintEventType::BlockFilter.to_string(),
                         attributes: vec![Attribute {
-                            key: "ethbloom".to_owned(),
+                            key: TendermintEventKey::EthBloom.to_base64_string(),
                             value: encode(&[0; 256][..]),
                         }],
                     }],
@@ -191,7 +481,7 @@ mod tests {
                     events: vec![Event {
                         event_type: TendermintEventType::ValidTransactions.to_string(),
                         attributes: vec![Attribute {
-                            key: "dHhpZA==".to_owned(),
+                            key: TendermintEventKey::TxId.to_base64_string(),
                             value: "kOzcmhZgAAaw5riwRjjKNe+foJEiDAOObTDQ=".to_owned(),
                         }],
                     }],
@@ -213,5 +503,53 @@ mod tests {
             },
         };
         assert_eq!(0, block_results.transaction_ids().unwrap().len());
+    }
+
+    mod find_event_attribute_by_key {
+        use super::*;
+
+        #[test]
+        fn should_return_err_when_event_key_is_invalid_base64_encoded() {
+            let attributes = vec![Attribute {
+                key: "Invalid==".to_owned(),
+                value: "MDc2NmQ0ZTFjMDkxMjRhZjlhZWI0YTdlZDk5ZDgxNjU0YTg0NDczZjEzMzk0OGNlYTA1MGRhYTE3ZmYwZTdmZg==".to_owned(),
+            }];
+
+            let result = find_event_attribute_by_key(&attributes, TendermintEventKey::Account);
+            assert!(result.is_err());
+            assert_eq!(ErrorKind::DeserializationError, result.unwrap_err().kind());
+        }
+
+        #[test]
+        fn should_return_result_of_none_when_key_does_not_exist() {
+            let attribute = Attribute {
+                key: TendermintEventKey::TxId.to_base64_string(),
+                value: "Y2MwMjkxNThhZTFmMjVlN2I5ZGVhZTc5MWVjMTQ2MDA5ZTNjZTliMjZhMjFmZDEzOTZiMTA3YzYyZDIzNmMwOQ==".to_owned(),
+            };
+            let attributes = vec![attribute];
+
+            assert!(
+                find_event_attribute_by_key(&attributes, TendermintEventKey::Account)
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn should_return_result_of_the_attribute_when_key_exist() {
+            let account_attribute = Attribute {
+                key: TendermintEventKey::Account.to_base64_string(),
+                value: "MHhlNGEyYTcxOWNhOTMzZDNmNzlhODUwNmFhOTZjZWZkZTM0MDViMGE3".to_owned(),
+            };
+            let attributes = vec![account_attribute.clone()];
+
+            assert_eq!(
+                account_attribute,
+                find_event_attribute_by_key(&attributes, TendermintEventKey::Account)
+                    .unwrap()
+                    .unwrap()
+                    .to_owned()
+            );
+        }
     }
 }

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -99,7 +99,7 @@ pub enum IntraEnclaveResponseOk {
     /// deposit stake pays minimal fee, so this returns the sum of input amounts -- staked stake's bonded balance is added `input_coins-min_fee`
     DepositStakeTx { input_coins: Coin },
     /// transaction filter
-    EndBlock(Box<TxFilter>),
+    EndBlock(Option<Box<TxFilter>>),
     /// encryption response
     Encrypt(TxObfuscated),
 }
@@ -167,7 +167,7 @@ pub enum EnclaveResponse {
     /// returns the affected (account) state (if any) and paid fee if the TX is valid
     VerifyTx(Result<(Fee, Option<StakedState>), chain_tx_validation::Error>),
     /// returns the transaction filter for the current block
-    EndBlock(Result<Box<TxFilter>, ()>),
+    EndBlock(Result<Option<Box<TxFilter>>, ()>),
     /// returns if the data was successfully persisted in the enclave's local storage
     CommitBlock(Result<(), ()>),
     /// returns Some(sealed data payloads) or None (if any TXID was not found / invalid)


### PR DESCRIPTION
Solution: Query informatin using event in deliver_tx

--- 

Before this PR staking account is put into bloom filter in `end_block` event. The syncrhonizer will use the filter to probablistically check if there is staking related transactions inside.

But actually the staking account info. is public and stored inside the `deliver_tx` events.
So there is not need to add the staking address to bloom filter anymore; And should use the `deliver_tx` event instead