### PR TITLE
Problem: developers may accidentally commit ssh keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 
 # TODOR
 .todor
+
+# SSH
+id_rsa
+id_ecdsa


### PR DESCRIPTION
Solution: extended .gitignore