### PR TITLE
Problem: (CRO-582) Create transfer address is not re-usable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "chain-tx-filter 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -14,6 +14,7 @@ aes-gcm-siv = "0.2"
 blake2 = "0.8"
 hex = "0.4"
 base64 = "0.11"
+itertools = "0.8"
 secstr = { version = "0.3.2", features = ["serde"] }
 zeroize = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/client-common/src/key/public_key.rs
+++ b/client-common/src/key/public_key.rs
@@ -71,6 +71,15 @@ impl PublicKey {
         Ok(PublicKey(public_key))
     }
 
+    /// Combine multiple public keys into one and returns as RawPubKey
+    pub fn combine_to_raw_pubkey(public_keys: &[PublicKey]) -> Result<RawPubkey> {
+        if public_keys.len() == 1 {
+            Ok(RawPubkey::from(&public_keys[0]))
+        } else {
+            Ok(RawPubkey::from(PublicKey::combine(&public_keys)?.0))
+        }
+    }
+
     /// Combines multiple public keys into one and also returns hash of combined public key
     pub fn combine(public_keys: &[Self]) -> Result<(Self, H256)> {
         let (public_key, public_key_hash) = SECP

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -5,6 +5,7 @@ mod transaction;
 
 pub mod error;
 pub mod key;
+pub mod multi_sig_address;
 pub mod storage;
 pub mod tendermint;
 
@@ -14,6 +15,8 @@ pub use block_header::BlockHeader;
 pub use error::{Error, ErrorKind, Result, ResultExt};
 #[doc(inline)]
 pub use key::{PrivateKey, PublicKey};
+#[doc(inline)]
+pub use multi_sig_address::MultiSigAddress;
 #[doc(inline)]
 pub use storage::{SecureStorage, Storage};
 #[doc(inline)]

--- a/client-common/src/multi_sig_address.rs
+++ b/client-common/src/multi_sig_address.rs
@@ -1,0 +1,434 @@
+//! m-of-n multi-sig address
+use itertools::Itertools;
+use parity_scale_codec::{Decode, Encode};
+
+use super::{Error, ErrorKind, PublicKey, Result};
+use chain_core::common::{MerkleTree, Proof, H256};
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::witness::tree::RawPubkey;
+
+// TODO: Remove pub
+/// m-of-n multi-sig address
+#[derive(Debug, Encode, Decode)]
+pub struct MultiSigAddress {
+    /// Number of required co-signers
+    pub m: u64,
+    /// Total number of co-signers
+    pub n: u64,
+    /// Public key of current signer
+    pub self_public_key: PublicKey,
+    /// Merkle tree with different combinations of `n` public keys as leaf nodes
+    pub merkle_tree: MerkleTree<RawPubkey>,
+}
+
+impl From<MultiSigAddress> for ExtendedAddr {
+    fn from(addr: MultiSigAddress) -> Self {
+        addr.to_extended_addr()
+    }
+}
+
+impl MultiSigAddress {
+    /// Create MultiSig address from list of public keys
+    pub fn new(
+        public_keys: Vec<PublicKey>,
+        self_public_key: PublicKey,
+        required_signers: usize,
+    ) -> Result<Self> {
+        let total_signers = public_keys.len();
+        if required_signers > total_signers
+            || total_signers == 0
+            || required_signers == 0
+            || !public_keys.contains(&self_public_key)
+        {
+            // TODO: Return different error kinds for different input errors
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
+        let combinations = public_key_combinations(public_keys, required_signers)?;
+        let merkle_tree = MerkleTree::new(combinations);
+
+        Ok(MultiSigAddress {
+            m: required_signers as u64,
+            n: total_signers as u64,
+            self_public_key,
+            merkle_tree,
+        })
+    }
+
+    #[inline]
+    /// Returns root hash of the underlying MerkleTree
+    pub fn root_hash(&self) -> H256 {
+        self.merkle_tree.root_hash()
+    }
+
+    /// Generate inclusion proof of particular public keys combination in the
+    /// MultiSig address
+    pub fn generate_proof(
+        &self,
+        mut public_keys: Vec<PublicKey>,
+    ) -> Result<Option<Proof<RawPubkey>>> {
+        if public_keys.len() != self.required_signers() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "{} public keys are required to generate a proof",
+                    self.required_signers()
+                ),
+            ));
+        }
+
+        public_keys.sort();
+
+        let raw_pubkey = PublicKey::combine_to_raw_pubkey(&public_keys)?;
+        Ok(self.merkle_tree.generate_proof(raw_pubkey))
+    }
+
+    /// Returns ExtendedAddr representation of the MultiSigAddress
+    #[inline]
+    pub fn to_extended_addr(&self) -> ExtendedAddr {
+        ExtendedAddr::OrTree(self.root_hash())
+    }
+
+    /// Returns required number of co-signers
+    #[inline]
+    pub fn required_signers(&self) -> usize {
+        self.m as usize
+    }
+
+    /// Returns total number of co-signers
+    #[inline]
+    pub fn total_signers(&self) -> usize {
+        self.n as usize
+    }
+
+    /// Returns self public key
+    #[inline]
+    pub fn self_public_key(&self) -> PublicKey {
+        self.self_public_key.clone()
+    }
+}
+
+fn public_key_combinations(
+    public_keys: Vec<PublicKey>,
+    required_signers: usize,
+) -> Result<Vec<RawPubkey>> {
+    if public_keys.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Length of public keys cannot be zero",
+        ));
+    }
+
+    if required_signers > public_keys.len() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Length of public keys cannot be less than number of required signers",
+        ));
+    }
+
+    if required_signers == 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Number of required signers cannot be zero",
+        ));
+    }
+
+    let mut combinations = public_keys
+        .into_iter()
+        .combinations(required_signers)
+        .map(|mut combination| {
+            combination.sort();
+            PublicKey::combine_to_raw_pubkey(&combination)
+        })
+        .collect::<Result<Vec<RawPubkey>>>()?;
+
+    combinations.sort();
+    Ok(combinations)
+}
+
+#[cfg(test)]
+mod multi_sig_tests {
+    use super::*;
+
+    use crate::PrivateKey;
+
+    mod generate_proof {
+        use super::*;
+
+        fn should_throw_error_when_number_of_provided_public_keys_is_different_from_required_signers(
+        ) {
+            let public_key_1 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_key_2 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_keys = vec![public_key_1.clone(), public_key_2.clone()];
+            let required_signers = 1;
+
+            let multi_sig_address =
+                MultiSigAddress::new(public_keys, public_key_1.clone(), required_signers)
+                    .expect("Should create MultiSig address");
+
+            let target_public_keys = vec![public_key_1.clone()];
+            let maybe_proof_result = multi_sig_address.generate_proof(target_public_keys);
+
+            assert!(maybe_proof_result.is_err());
+            assert_eq!(
+                maybe_proof_result.unwrap_err().kind(),
+                ErrorKind::InvalidInput
+            );
+        }
+    }
+
+    mod new {
+        use super::*;
+
+        #[test]
+        fn should_throw_error_when_public_key_list_is_empty() {
+            let public_keys = Vec::new();
+            let self_public_key = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let required_signers = 1;
+
+            let result = MultiSigAddress::new(public_keys, self_public_key, required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+        }
+
+        #[test]
+        fn should_throw_error_when_required_signers_is_zero() {
+            let public_key = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_keys = vec![public_key.clone()];
+            let self_public_key = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let required_signers = 0;
+
+            let result = MultiSigAddress::new(public_keys, self_public_key, required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+        }
+
+        #[test]
+        fn should_throw_error_when_self_public_key_is_not_in_public_key_list() {
+            let public_key_1 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_key_2 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_keys = vec![public_key_1.clone()];
+            let required_signers = 1;
+
+            let result = MultiSigAddress::new(public_keys, public_key_2, required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+        }
+
+        #[test]
+        fn should_throw_error_when_required_signers_is_greater_than_total_signers() {
+            let public_key_1 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_key_2 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_keys = vec![public_key_1.clone(), public_key_2.clone()];
+
+            let required_signers = 10;
+
+            let result = MultiSigAddress::new(public_keys, public_key_1, required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+        }
+
+        #[test]
+        fn should_work() {
+            let public_key_1 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_key_2 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_key_3 = PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            );
+            let public_keys = vec![
+                public_key_1.clone(),
+                public_key_2.clone(),
+                public_key_3.clone(),
+            ];
+
+            let required_signers = 2;
+
+            let result = MultiSigAddress::new(public_keys, public_key_1, required_signers);
+
+            assert!(result.is_ok());
+        }
+    }
+
+    mod public_key_combinations {
+        use super::*;
+
+        #[test]
+        fn should_throw_error_when_public_keys_is_empty() {
+            let required_signers = 1;
+            let result = public_key_combinations(Vec::new(), required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(
+                result
+                    .expect_err("Length of public keys cannot be zero")
+                    .kind(),
+                ErrorKind::InvalidInput
+            );
+        }
+
+        #[test]
+        fn should_throw_error_when_required_signers_is_larger_than_total_public_keys() {
+            let public_keys = vec![PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            )];
+            let required_signers = 2;
+            let result = public_key_combinations(public_keys, required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(
+                result
+                    .expect_err(
+                        "Length of public keys cannot be less than number of required signers"
+                    )
+                    .kind(),
+                ErrorKind::InvalidInput
+            );
+        }
+
+        #[test]
+        fn should_throw_error_when_required_signers_is_zero() {
+            let public_keys = vec![PublicKey::from(
+                &PrivateKey::new().expect("Derive public key from private key should work"),
+            )];
+            let required_signers = 0;
+            let result = public_key_combinations(public_keys, required_signers);
+
+            assert!(result.is_err());
+            assert_eq!(
+                result
+                    .expect_err("Number of required signers cannot be zero")
+                    .kind(),
+                ErrorKind::InvalidInput
+            );
+        }
+
+        #[test]
+        fn should_return_result_of_raw_pub_key_combinations() {
+            // 8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841bd1e8a8697ad42251de39f6a72081dfdf42abc542a6d6fe0715548b588fafbe70
+            let public_key_1 = PublicKey::from(
+                &PrivateKey::deserialize_from(&[0x01; 32]).expect("32 bytes, within curve order"),
+            );
+            // 66074d25a751c4743342c90ad8ead9454daa00d9b9aed29bca321036d16c4b4dd036ed0d31bd98c1546bb6577f852e668442060feb7c256d8b20fed0a2ad3e2a
+            let public_key_2 = PublicKey::from(
+                &PrivateKey::deserialize_from(&[0x02; 32]).expect("32 bytes, within curve order"),
+            );
+            // 37e31fcbbdbdc5c3449a7e533cc8a68fac67c827321323273d50348106e61f5358546af286730e3bd9924e52cd0f205a70ac475a67842aa81b481ee765c2929e
+            let public_key_3 = PublicKey::from(
+                &PrivateKey::deserialize_from(&[0x03; 32]).expect("32 bytes, within curve order"),
+            );
+            let public_keys = vec![
+                public_key_1.clone(),
+                public_key_2.clone(),
+                public_key_3.clone(),
+            ];
+
+            let required_signers = 1;
+            assert_eq!(
+                public_key_combinations(public_keys.clone(), required_signers).unwrap(),
+                vec![
+                    RawPubkey::from(&public_key_2),
+                    RawPubkey::from(&public_key_3),
+                    RawPubkey::from(&public_key_1),
+                ]
+            );
+
+            let required_signers = 2;
+            assert_eq!(
+                public_key_combinations(public_keys.clone(), required_signers).unwrap(),
+                vec![
+                    RawPubkey::from(
+                        PublicKey::combine(&vec![public_key_2.clone(), public_key_1.clone()])
+                            .expect("Combine public keys should work")
+                            .0
+                    ),
+                    RawPubkey::from(
+                        PublicKey::combine(&vec![public_key_3.clone(), public_key_2.clone()])
+                            .expect("Combine public keys should work")
+                            .0
+                    ),
+                    RawPubkey::from(
+                        PublicKey::combine(&vec![public_key_3.clone(), public_key_1.clone()])
+                            .expect("Combine public keys should work")
+                            .0
+                    ),
+                ]
+            );
+
+            let required_signers = 3;
+            assert_eq!(
+                public_key_combinations(public_keys.clone(), required_signers).unwrap(),
+                vec![RawPubkey::from(
+                    PublicKey::combine(&vec![
+                        public_key_3.clone(),
+                        public_key_2.clone(),
+                        public_key_1.clone()
+                    ])
+                    .expect("Combine public keys should work")
+                    .0
+                ),]
+            );
+        }
+    }
+
+    fn check_root_hash_flow() {
+        // 8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841bd1e8a8697ad42251de39f6a72081dfdf42abc542a6d6fe0715548b588fafbe70
+        let public_key_1 = PublicKey::from(
+            &PrivateKey::deserialize_from(&[0x01; 32]).expect("32 bytes, within curve order"),
+        );
+        // 66074d25a751c4743342c90ad8ead9454daa00d9b9aed29bca321036d16c4b4dd036ed0d31bd98c1546bb6577f852e668442060feb7c256d8b20fed0a2ad3e2a
+        let public_key_2 = PublicKey::from(
+            &PrivateKey::deserialize_from(&[0x02; 32]).expect("32 bytes, within curve order"),
+        );
+        // 37e31fcbbdbdc5c3449a7e533cc8a68fac67c827321323273d50348106e61f5358546af286730e3bd9924e52cd0f205a70ac475a67842aa81b481ee765c2929e
+        let public_key_3 = PublicKey::from(
+            &PrivateKey::deserialize_from(&[0x03; 32]).expect("32 bytes, within curve order"),
+        );
+        let public_keys = vec![
+            public_key_1.clone(),
+            public_key_2.clone(),
+            public_key_3.clone(),
+        ];
+        let required_signers = 2;
+
+        let multi_sig_address =
+            MultiSigAddress::new(public_keys, public_key_1.clone(), required_signers)
+                .expect("Should create MultiSig address");
+
+        let target_public_keys = vec![public_key_2.clone(), public_key_1.clone()];
+        let maybe_proof_result = multi_sig_address.generate_proof(target_public_keys);
+
+        assert!(maybe_proof_result.is_ok());
+        let maybe_proof = maybe_proof_result.unwrap();
+        assert!(maybe_proof.is_some());
+        let proof = maybe_proof.unwrap();
+
+        let root_hash = multi_sig_address.root_hash();
+        assert!(proof.verify(&root_hash));
+    }
+}

--- a/client-core/src/signer/default_signer.rs
+++ b/client-core/src/signer/default_signer.rs
@@ -169,7 +169,6 @@ mod tests {
                 public_keys.clone(),
                 public_keys[0].clone(),
                 1,
-                3,
             )
             .unwrap();
 
@@ -221,7 +220,6 @@ mod tests {
                 public_keys.clone(),
                 public_keys[0].clone(),
                 2,
-                3,
             )
             .unwrap();
 

--- a/client-core/src/transaction_builder/default_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_transaction_builder.rs
@@ -303,7 +303,6 @@ mod tests {
                     public_keys.clone(),
                     public_keys[0].clone(),
                     1,
-                    3,
                 )
                 .unwrap(),
         ];
@@ -444,7 +443,6 @@ mod tests {
                     public_keys.clone(),
                     public_keys[0].clone(),
                     1,
-                    3,
                 )
                 .unwrap(),
         ];

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -114,7 +114,6 @@ pub trait WalletClient: Send + Sync {
     /// `public_keys`: Public keys of co-signers (including public key of current co-signer)
     /// `self_public_key`: Public key of current co-signer
     /// `m`: Number of required co-signers
-    /// `n`: Total number of co-signers
     fn new_multisig_transfer_address(
         &self,
         name: &str,
@@ -122,7 +121,6 @@ pub trait WalletClient: Send + Sync {
         public_keys: Vec<PublicKey>,
         self_public_key: PublicKey,
         m: usize,
-        n: usize,
     ) -> Result<ExtendedAddr>;
 
     /// Generates inclusion proof for set of public keys in multi-sig address

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -289,7 +289,6 @@ where
             vec![public_key.clone()],
             public_key,
             1,
-            1,
         )
     }
 
@@ -300,7 +299,6 @@ where
         public_keys: Vec<PublicKey>,
         self_public_key: PublicKey,
         m: usize,
-        n: usize,
     ) -> Result<ExtendedAddr> {
         // Check if self public key belongs to current wallet
         let _ = self.private_key(passphrase, &self_public_key)?.chain(|| {
@@ -317,14 +315,14 @@ where
             ));
         }
 
-        let root_hash =
+        let (root_hash, multi_sig_address) =
             self.root_hash_service
-                .new_root_hash(public_keys, self_public_key, m, n, passphrase)?;
+                .new_root_hash(public_keys, self_public_key, m, passphrase)?;
 
         self.wallet_service
             .add_root_hash(name, passphrase, root_hash)?;
 
-        Ok(ExtendedAddr::OrTree(root_hash))
+        Ok(multi_sig_address.into())
     }
 
     fn generate_proof(

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -106,7 +106,6 @@ where
         required_signatures: usize,
     ) -> Result<String> {
         let public_keys = parse_public_keys(public_keys).map_err(to_rpc_error)?;
-        let total_public_keys = public_keys.len();
         let self_public_key = parse_public_key(self_public_key).map_err(to_rpc_error)?;
         let extended_address = self
             .client
@@ -116,7 +115,6 @@ where
                 public_keys,
                 self_public_key,
                 required_signatures,
-                total_public_keys,
             )
             .map_err(to_rpc_error)?;
 


### PR DESCRIPTION
Solution: Extracted MultiSigAddress from root_hash service to serve single responsibility

---
Remarks:
- This PR is a pre-requisite of the JS library by making components re-usable by JS
- Removed n(total_signers) field because it is implied from len of public keys