### PR TITLE
Problem: (CRO-585) No client support for new validator node joining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
 name = "client-cli"
 version = "0.1.0"
 dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "cli-table 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -24,4 +24,5 @@ log = "0.4.8"
 env_logger = "0.7.1"
 cli-table = "0.2"
 zeroize = "1.0"
+base64 = "0.11"
 tiny-bip39 = { version = "0.6", default-features = false }

--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -6,7 +6,9 @@ pub use self::default_network_ops_client::DefaultNetworkOpsClient;
 use secstr::SecUtf8;
 
 use chain_core::init::coin::Coin;
-use chain_core::state::account::{StakedState, StakedStateAddress, StakedStateOpAttributes};
+use chain_core::state::account::{
+    CouncilNode, StakedState, StakedStateAddress, StakedStateOpAttributes,
+};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
@@ -63,6 +65,16 @@ pub trait NetworkOpsClient: Send + Sync {
         passphrase: &SecUtf8,
         address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
+    ) -> Result<TxAux>;
+
+    /// Creates a new transaction for a node joining validator set
+    fn create_node_join_transaction(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        staking_account_address: StakedStateAddress,
+        attributes: StakedStateOpAttributes,
+        node_metadata: CouncilNode,
     ) -> Result<TxAux>;
 
     /// Returns staked stake corresponding to given address


### PR DESCRIPTION
Solution: Added support for creating new `node-join` transaction in `client-cli`

Note: I've also performed a basic manual test to check the node addition flow. It works!