### PR TITLE
Problem: full client flow not tested with "better" mock encryption+tx-query (CRO-510)

### DIFF
--- a/chain-tx-enclave/tx-query/enclave/src/lib.rs
+++ b/chain-tx-enclave/tx-query/enclave/src/lib.rs
@@ -100,8 +100,8 @@ fn handle_decryption_request(
     }
 
     match tls.read(&mut plain) {
-        Ok(_) => {
-            if let Ok(dr) = DecryptionRequest::decode(&mut plain.as_slice()) {
+        Ok(l) => {
+            if let Ok(dr) = DecryptionRequest::decode(&mut &plain.as_slice()[0..l]) {
                 if dr
                     .verify(&Secp256k1::verification_only(), challenge)
                     .is_err()
@@ -269,7 +269,7 @@ pub extern "C" fn run_server(socket_fd: c_int) -> sgx_status_t {
     let mut tls = rustls::Stream::new(&mut sess, &mut conn);
     let mut plain = vec![0; ENCRYPTION_REQUEST_SIZE];
     match tls.read(&mut plain) {
-        Ok(_) => match TxQueryInitRequest::decode(&mut plain.as_slice()) {
+        Ok(l) => match TxQueryInitRequest::decode(&mut &plain.as_slice()[0..l]) {
             Ok(TxQueryInitRequest::Encrypt(req)) => handle_encryption_request(&mut tls, *req),
             Ok(TxQueryInitRequest::DecryptChallenge) => handle_decryption_request(&mut tls, plain),
             _ => {

--- a/client-core/src/signer/dummy_signer.rs
+++ b/client-core/src/signer/dummy_signer.rs
@@ -21,11 +21,8 @@ impl DummySigner {
     fn pad_payload(&self, plain_txaux: PlainTxAux) -> Vec<u8> {
         let unit = 16_usize;
         let plain_payload_len = plain_txaux.encode().len();
-        if plain_payload_len % unit == 0 {
-            vec![0; plain_payload_len]
-        } else {
-            vec![0; plain_payload_len + unit - plain_payload_len % unit]
-        }
+        // PKCS7 padding -- if the len is multiple of the block length, it'll still be padded
+        vec![0; plain_payload_len + unit - plain_payload_len % unit]
     }
 
     /// Creates a mock merkletree


### PR DESCRIPTION
Solution:
- still WIP -- didn't turn it on yet, as it'll require modifications in integration test deployments etc.
- there were small problems discovered in full flow testing that should be fixed in this PR:
1) dummy signer didn't follow the cryptographic padding convention, so the estimate fee would sometimes be wrong
2) client couldn't connect to IP addresses, as they are not valid hostnames (hostname required by the TLS library)
3) tx-query randomly failed some requests (witness on CI as well) -- probably due to trying to parse the whole allocated buffer (rather than just the actual request length slice)
