### PR TITLE
Problem (CRO-558): client code doesn't compile with futures 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,6 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-common 0.1.0",
  "enclave-protocol 0.1.0",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -29,7 +29,6 @@ num-bigint = "0.2.3"
 serde_json = "1.0.41"
 uuid = { version = "0.8.1", features = ["v4"] }
 websocket = "0.24.0"
-futures = "0.1.29"
 jsonrpc-core = "14.0"
 log ="0.4.8"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Solution:
futures related code in client already removed by previous commits,
so simply remove the dependency.