### PR TITLE
Problem: (CRO-603) Bech32 address always encoded with initialized network

### DIFF
--- a/chain-core/src/init/network.rs
+++ b/chain-core/src/init/network.rs
@@ -61,20 +61,24 @@ pub fn get_network() -> Network {
 
 /// Given the chosen network, it returns the human readable part of Bech32 address
 pub fn get_bech32_human_part() -> &'static str {
-    unsafe {
-        match chosen_network::NETWORK {
-            Network::Mainnet => "cro",
-            Network::Testnet => "tcro",
-            Network::Devnet => "dcro",
-        }
+    get_bech32_human_part_from_network(get_network())
+}
+
+/// Returns the human readable part of Bech32 address of the provided network
+pub fn get_bech32_human_part_from_network(network: Network) -> &'static str {
+    match network {
+        Network::Mainnet => "cro",
+        Network::Testnet => "tcro",
+        Network::Devnet => "dcro",
     }
 }
 
+/// Given the chosen network, it returns bip44 cointype
 pub fn get_bip44_coin_type() -> u32 {
     get_bip44_coin_type_from_network(get_network())
 }
 
-/// Given the chosen network, it returns bip44 cointype
+/// Returns bip44 cointype of the provided network
 /// 1     	0x80000001 	    	Testnet (all coins)
 /// 394 	0x8000018a 	CRO 	Crypto.com Chain
 pub fn get_bip44_coin_type_from_network(network: Network) -> u32 {

--- a/client-rpc/src/rpc/transaction_rpc.rs
+++ b/client-rpc/src/rpc/transaction_rpc.rs
@@ -82,6 +82,7 @@ mod test {
     use super::*;
     use chain_core::init::address::CroAddress;
     use chain_core::init::coin::Coin;
+    use chain_core::init::network::Network;
     use chain_core::tx::data::address::ExtendedAddr;
     use client_common::PrivateKey;
 
@@ -95,6 +96,7 @@ mod test {
         let outputs = vec![TxOut::new(
             ExtendedAddr::from_cro(
                 "dcro1zz30nheum6vnug3mjs0j4kw4w739tca8cuqae2kdjmt8suhv693qcs3qyn",
+                Network::Devnet,
             )
             .unwrap(),
             Coin::new(750).unwrap(),

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -132,7 +132,7 @@ where
     fn create_staking_address(&self, request: WalletRequest) -> Result<String> {
         self.client
             .new_staking_address(&request.name, &request.passphrase)
-            .map(|extended_addr| extended_addr.to_string())
+            .map(|staked_state_addr| staked_state_addr.to_string())
             .map_err(to_rpc_error)
     }
 


### PR DESCRIPTION
Solution: Add network argument to to_cro()

---
`to_cro()` always encoded with the initialized network, making it mpossible to encode to arbitrary network