### PR TITLE
Problem: integration test doesn't use tx-query (CRO-618)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,11 @@ platform:
 
 steps:
 - name: Build and Test
+  environment:
+    SPID:
+      from_secret: dev_spid
+    IAS_API_KEY:
+      from_secret: dev_ias_key
   commands:
   - export NIX_REMOTE=daemon
   - export DOCKER_COMPOSE_PREFIX="${DRONE_BRANCH}"
@@ -119,6 +124,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 16ab872fd8e8665072dc48562ee21a134568501e65d401a8ddfa870ff2d83e79
+hmac: dae5cd458b9f583fe5d3d01f64776c6af23ea9bd9a8c651db4f840ac2fb79d6c
 
 ...

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "polyval 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polyval 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -134,7 +134,7 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.49.2"
+version = "0.49.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -462,7 +462,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -471,7 +471,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -480,7 +480,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -587,6 +587,7 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=8b9a38b870a7759fcdbd4a5d435b5ba873c70afd)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint 0.10.0 (git+https://github.com/crypto-com/tendermint-rs.git?rev=8e95731ee671777638ab2a3d5dfd7b35992b86aa)",
 ]
 
 [[package]]
@@ -1288,7 +1289,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1553,7 +1554,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1562,8 +1563,8 @@ name = "librocksdb-sys"
 version = "6.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1799,7 +1800,7 @@ version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1928,9 +1929,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "polyval"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "universal-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2271,7 +2273,7 @@ name = "ring"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2400,7 +2402,7 @@ name = "secp256k1zkp"
 version = "0.13.0"
 source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=8b9a38b870a7759fcdbd4a5d435b5ba873c70afd#8b9a38b870a7759fcdbd4a5d435b5ba873c70afd"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_tstd 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
@@ -2458,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2497,7 +2499,7 @@ name = "sgx_backtrace_sys"
 version = "1.0.9"
 source = "git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9#2042ce64fd377e790584c96a4bfd4c32de2d03ea"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_build_helper 0.1.0 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
  "sgx_libc 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
 ]
@@ -2664,7 +2666,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2933,7 +2935,7 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3001,7 +3003,7 @@ dependencies = [
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3052,7 +3054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3107,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-threadpool"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3245,7 +3247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3603,7 +3605,7 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0089c35ab7c6f2bc55ab23f769913f0ac65b1023e7e74638a1f43128dd5df2"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
-"checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
+"checksum bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c07087f3d5731bf3fb375a81841b99597e25dc11bd3bc72d16d43adf6624a6e"
 "checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
@@ -3621,7 +3623,7 @@ dependencies = [
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+"checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
@@ -3771,7 +3773,7 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum polyval 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "291cb6f0e9a1bee52f76e729e3a1b6e4728c6f77191fbbdc6b8bd11294820bad"
+"checksum polyval 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "837f0e5873d8302931be317c22d7e17cdbf1c0d8bb78de8f08d910d913074943"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
@@ -3833,7 +3835,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
-"checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
+"checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum sgx_alloc 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)" = "<none>"
@@ -3899,7 +3901,7 @@ dependencies = [
 "checksum tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
-"checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
+"checksum tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c"
 "checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
@@ -3915,7 +3917,7 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum universal-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [features]
 mock-enc-dec = []
 mock-validation = []
-default = ["mock-enc-dec"]
+default = []
 
 [dependencies]
 abci = "0.6"

--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -2,9 +2,11 @@
 ///! TODO: feature-guard when workspaces can be built with --features flag: https://github.com/rust-lang/cargo/issues/5015
 use super::*;
 use crate::storage::Storage;
+#[cfg(feature = "mock-enc-dec")]
 use crate::storage::COL_BODIES;
 use abci::{RequestQuery, ResponseQuery};
 use chain_core::state::account::DepositBondTx;
+#[cfg(feature = "mock-enc-dec")]
 use chain_core::tx::data::input::TxoIndex;
 use chain_core::tx::data::TxId;
 use chain_core::tx::PlainTxAux;
@@ -14,6 +16,7 @@ use chain_core::tx::TxObfuscated;
 use chain_core::tx::TxWithOutputs;
 use chain_tx_filter::BlockFilter;
 use chain_tx_validation::{verify_bonded_deposit, verify_transfer, verify_unbonded_withdraw};
+#[cfg(feature = "mock-enc-dec")]
 use enclave_protocol::{
     DecryptionRequest, DecryptionRequestBody, DecryptionResponse, EncryptionRequest,
     EncryptionResponse,
@@ -23,9 +26,9 @@ use std::collections::HashMap;
 
 /// TODO: Remove
 #[cfg(not(feature = "mock-enc-dec"))]
-pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &Storage) {
+pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, _storage: &Storage) {
     let msg = "received a temporary *mock* (non-enclave) encryption/decryption query in abci (use the dedicated enclaves instead)";
-    warn!(msg);
+    warn!("{}", msg);
     resp.log += msg;
     resp.code = 1;
 }
@@ -33,7 +36,10 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
 /// temporary mock
 #[cfg(feature = "mock-enc-dec")]
 pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &Storage) {
-    warn!("received a temporary *mock* (non-enclave) encryption/decryption query in abci");
+    warn!(
+        "{}",
+        "received a temporary *mock* (non-enclave) encryption/decryption query in abci"
+    );
     match _req.path.as_ref() {
         // FIXME: temporary mock
         "mockencrypt" => {

--- a/chain-tx-enclave/tx-query/Dockerfile
+++ b/chain-tx-enclave/tx-query/Dockerfile
@@ -1,0 +1,27 @@
+FROM baiduxlab/sgx-rust:1804-1.0.9
+LABEL maintainer="Crypto.com"
+
+RUN echo 'source /opt/sgxsdk/environment' >> /root/.docker_bashrc && \
+    echo 'source /root/.cargo/env' >> /root/.docker_bashrc
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libzmq3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG SGX_MODE=HW
+ARG NETWORK_ID
+
+ENV TX_VALIDATION_CONN=${TX_VALIDATION_CONN}
+ENV SPID=${SPID}
+ENV IAS_API_KEY=${IAS_API_KEY}
+ENV TX_QUERY_TIMEOUT=${TX_QUERY_TIMEOUT}
+
+ENV APP_PORT=25944
+
+COPY . .
+
+RUN ./chain-tx-enclave/tx-query/make.sh
+
+WORKDIR /root/chain-tx-enclave/tx-query/bin
+
+CMD ["../entrypoint.sh"]

--- a/chain-tx-enclave/tx-query/app/src/main.rs
+++ b/chain-tx-enclave/tx-query/app/src/main.rs
@@ -9,14 +9,15 @@ use crate::enclave_u::init_connection;
 use enclave_u::run_server;
 use enclave_u_common::enclave_u::init_enclave;
 use log::{error, info, warn};
-use sgx_types::sgx_status_t;
+use sgx_types::{c_int, sgx_status_t};
 use sgx_urts::SgxEnclave;
+use std::convert::TryInto;
 use std::env;
 use std::net::TcpListener;
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
-const TIMEOUT_SEC: u64 = 5;
+const TIMEOUT_SEC: c_int = 5;
 
 pub fn start_enclave() -> SgxEnclave {
     match init_enclave(true) {
@@ -39,6 +40,11 @@ fn main() {
 fn main() {
     env_logger::init();
     let args: Vec<String> = env::args().collect();
+    let timeout = if let Some(x) = args.get(3) {
+        x.parse::<c_int>().expect("valid timeout in seconds")
+    } else {
+        TIMEOUT_SEC
+    };
     if args.len() < 3 {
         error!("Please provide the address:port to listen on (e.g. \"0.0.0.0:3443\") as the first argument and the ZMQ connection string (e.g. \"ipc://enclave.ipc\" or \"tcp://127.0.0.1:25933\") of the tx-validation server as the second");
         return;
@@ -54,11 +60,15 @@ fn main() {
         match stream {
             Ok(stream) => {
                 info!("new client connection");
-                let _ = stream.set_read_timeout(Some(Duration::new(TIMEOUT_SEC, 0)));
-                let _ = stream.set_write_timeout(Some(Duration::new(TIMEOUT_SEC, 0)));
+                if timeout > 0 {
+                    let utimeout = timeout.try_into().unwrap();
+                    let _ = stream.set_read_timeout(Some(Duration::new(utimeout, 0)));
+                    let _ = stream.set_write_timeout(Some(Duration::new(utimeout, 0)));
+                }
                 let mut retval = sgx_status_t::SGX_SUCCESS;
-                let result =
-                    unsafe { run_server(enclave.geteid(), &mut retval, stream.as_raw_fd()) };
+                let result = unsafe {
+                    run_server(enclave.geteid(), &mut retval, stream.as_raw_fd(), timeout)
+                };
                 match result {
                     sgx_status_t::SGX_SUCCESS => {
                         info!("client query finished");

--- a/chain-tx-enclave/tx-query/enclave/Enclave.edl
+++ b/chain-tx-enclave/tx-query/enclave/Enclave.edl
@@ -8,7 +8,7 @@ enclave {
     include "sgx_quote.h"
 
     trusted {
-        public sgx_status_t run_server(int fd);
+        public sgx_status_t run_server(int fd, int timeout);
     };
     untrusted {
         sgx_status_t ocall_encrypt_request(

--- a/chain-tx-enclave/tx-query/enclave/src/attest.rs
+++ b/chain-tx-enclave/tx-query/enclave/src/attest.rs
@@ -557,7 +557,7 @@ fn get_ra_cert() -> (CertKeyPair, bool) {
     }
 
     // Do the renew
-    if renew_ra_cert(&mut cache).is_err() {
+    if let Err(e) = renew_ra_cert(&mut cache) {
         // If RA renewal fails, we do not crash for the following reasons.
         // 1. Crashing the enclave causes most data to be lost permanently,
         //    since we do not have persistent key-value storage yet. On the
@@ -568,7 +568,7 @@ fn get_ra_cert() -> (CertKeyPair, bool) {
         // 3. The certificate has a 90 days valid duration. If RA keeps
         //    failing for 90 days, the enclave itself will not serve any
         //    client.
-        panic!("RACACHE renewal failed");
+        panic!("RACACHE renewal failed: {:?}", e);
     }
 
     (cache.cert_key.clone(), true)

--- a/chain-tx-enclave/tx-query/entrypoint.sh
+++ b/chain-tx-enclave/tx-query/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+source /root/.docker_bashrc
+
+echo "[Config] SGX_MODE=${SGX_MODE}"
+echo "[Config] NETWORK_ID=${NETWORK_ID}"
+echo "[Config] TX_QUERY_TIMEOUT=${TX_QUERY_TIMEOUT}"
+
+LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service &
+
+echo "[aesm_service] Running in background ..."
+# Wait for aesm_service to initialize
+sleep 1
+
+# assumes SPID + IAS_API_KEY are set
+
+trap 'kill -TERM $PID' TERM INT
+./tx-query-app 0.0.0.0:${APP_PORT} ${TX_VALIDATION_CONN} ${TX_QUERY_TIMEOUT} &
+PID=$!
+echo "[tx-validation-app] Running in background ..."
+wait $PID
+wait $PID
+exit $?

--- a/chain-tx-enclave/tx-query/make.sh
+++ b/chain-tx-enclave/tx-query/make.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+source /root/.docker_bashrc
+cd ./chain-tx-enclave/tx-query
+make clean
+make

--- a/chain-tx-enclave/tx-validation/enclave/src/validate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/validate.rs
@@ -135,15 +135,6 @@ pub(crate) fn write_back_response(
     }
 }
 
-#[cfg(not(feature = "sgx-test"))]
-#[inline]
-fn decrypt(payload: &TxObfuscated) -> Result<PlainTxAux, ()> {
-    // FIXME: decrypting -- currently it's done in tests, but should be the default once the client can work with it
-    let _ = crate::obfuscate::decrypt(payload);
-    PlainTxAux::decode(&mut payload.txpayload.as_slice()).map_err(|_| ())
-}
-
-#[cfg(feature = "sgx-test")]
 #[inline]
 fn decrypt(payload: &TxObfuscated) -> Result<PlainTxAux, ()> {
     crate::obfuscate::decrypt(payload)

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 mock-enc-dec = []
-default = ["mock-enc-dec"]
+default = []
 
 [dependencies]
 chain-core = { path = "../chain-core" }

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -17,6 +17,8 @@ use structopt::StructOpt;
 use chain_core::init::coin::Coin;
 use chain_core::state::account::StakedStateAddress;
 use client_common::storage::SledStorage;
+#[cfg(not(feature = "mock-enc-dec"))]
+use client_common::tendermint::types::AbciQueryExt;
 use client_common::tendermint::types::GenesisExt;
 use client_common::tendermint::{Client, WebsocketRpcClient};
 use client_common::{ErrorKind, Result, ResultExt, Storage};

--- a/client-common/src/block_header.rs
+++ b/client-common/src/block_header.rs
@@ -17,6 +17,8 @@ pub struct BlockHeader {
     pub transaction_ids: Vec<TxId>,
     /// Bloom filter for view keys and staking addresses
     pub block_filter: BlockFilter,
+    /// List of successfully committed transaction of transactions that may need to be queried against
+    pub enclave_transaction_ids: Vec<TxId>,
     /// List of un-encrypted transactions (only contains transactions of type `DepositStake` and `UnbondStake`)
     pub unencrypted_transactions: Vec<Transaction>,
 }

--- a/client-core/src/handler/default_block_handler.rs
+++ b/client-core/src/handler/default_block_handler.rs
@@ -81,7 +81,7 @@ where
 
             let transactions = self
                 .transaction_obfuscation
-                .decrypt(&block_header.transaction_ids, &private_key)?;
+                .decrypt(&block_header.enclave_transaction_ids, &private_key)?;
 
             for transaction in transactions {
                 self.transaction_handler.on_next(
@@ -133,9 +133,8 @@ mod tests {
             transaction_ids: &[TxId],
             _private_key: &PrivateKey,
         ) -> Result<Vec<Transaction>> {
-            assert_eq!(2, transaction_ids.len());
+            assert_eq!(1, transaction_ids.len());
             assert_eq!(transfer_transaction().id(), transaction_ids[0]);
-            assert_eq!(unbond_transaction().id(), transaction_ids[1]);
             Ok(vec![transfer_transaction()])
         }
 
@@ -202,6 +201,7 @@ mod tests {
             block_height: 1,
             block_time: Time::from_str("2019-04-09T09:38:41.735577Z").unwrap(),
             transaction_ids,
+            enclave_transaction_ids: vec![transfer_transaction().id()],
             block_filter,
             unencrypted_transactions: vec![unbond_transaction()],
         }

--- a/client-core/src/synchronizer/manual_synchronizer.rs
+++ b/client-core/src/synchronizer/manual_synchronizer.rs
@@ -336,12 +336,14 @@ fn prepare_block_header(
 
     let unencrypted_transactions =
         check_unencrypted_transactions(&block_result, staking_addresses, block)?;
+    let enclave_transaction_ids = block.enclave_transaction_ids()?;
 
     Ok(BlockHeader {
         app_hash,
         block_height,
         block_time,
         transaction_ids,
+        enclave_transaction_ids,
         block_filter,
         unencrypted_transactions,
     })

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.1" }
 hex = "0.4.0"
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "8b9a38b870a7759fcdbd4a5d435b5ba873c70afd", features = ["recovery"] }
-
+tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "8e95731ee671777638ab2a3d5dfd7b35992b86aa" }
 
 [dev-dependencies]
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "8b9a38b870a7759fcdbd4a5d435b5ba873c70afd", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Calvin Lau <calvin@crypto.com>"]
 edition = "2018"
 
+[features]
+mock-enc-dec = []
+default = []
+
 [dependencies]
 base64 = "0.11"
 dirs = "2.0.2"

--- a/integration-tests/client-rpc/test/network-ops.test.ts
+++ b/integration-tests/client-rpc/test/network-ops.test.ts
@@ -351,7 +351,7 @@ describe("Staking", () => {
 				[],
 			]),
 		).to.eventually.rejectedWith(
-			"Tendermint RPC error: verification failed:",
+			"Validation error: Staking state is not yet unbonded",
 			"Withdraw unbonded stake should fail before unbond from period",
 		);
 

--- a/integration-tests/const-env.sh
+++ b/integration-tests/const-env.sh
@@ -3,7 +3,7 @@ set -e
 IFS=
 
 export WALLET_PASSPHRASE=${WALLET_PASSPHRASE:-123456}
-export TENDERMINT_VERSION=${TENDERMINT_VERSION:-0.32.0}
+export TENDERMINT_VERSION=${TENDERMINT_VERSION:-0.32.8}
 export SGX_MODE=${SGX_MODE:-SW}
 export DOCKER_SGX_DEVICE_BINDING="/dev/zero:/dev/dummy"
 if [ ! -z "${DRONE}" ]; then
@@ -14,6 +14,7 @@ fi
 # Constants (No not modify unless you are absolutely sure what you are doing)
 export CHAIN_DOCKER_IMAGE="integration-tests-chain"
 export CHAIN_TX_ENCLAVE_DOCKER_IMAGE="integration-tests-chain-tx-enclave"
+export CHAIN_TX_ENCLAVE_QUERY_DOCKER_IMAGE="integration-tests-chain-tx-enclave-query"
 export DOCKER_DATA_DIRECTORY="docker-data"
 export TENDERMINT_TEMP_DIRECTORY="${DOCKER_DATA_DIRECTORY}/temp/tendermint"
 export TENDERMINT_WITHFEE_DIRECTORY="${DOCKER_DATA_DIRECTORY}/withfee/tendermint"

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   tendermint:
-    image: "tendermint/tendermint:v${TENDERMINT_VERSION:-0.32.0}"
+    image: "tendermint/tendermint:v${TENDERMINT_VERSION:-0.32.8}"
     command: node --proxy_app=chain-abci:26658 --rpc.laddr=tcp://0.0.0.0:26657 --consensus.create_empty_blocks=true
     user: root
     volumes:
@@ -11,12 +11,12 @@ services:
       - ${TENDERMINT_RPC_PORT:-26657}:26657
   chain-abci:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
-    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${WITHFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave:25933 --tx_query=tcp://chain-tx-enclave:25933 --data=/.storage"
+    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${WITHFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave:25933 --tx_query=chain-tx-query-enclave:25944 --data=/.storage"
     volumes:
       - "./${CHAIN_ABCI_WITHFEE_DIRECTORY}:/.storage"
     environment:
       RUST_BACKTRACE: 1
-      RUST_LOG: debug
+      RUST_LOG: info
   chain-tx-enclave:
     image: "${CHAIN_TX_ENCLAVE_DOCKER_IMAGE:-integration-tests-chain-tx-enclave}"
     volumes:
@@ -27,6 +27,17 @@ services:
       RUST_BACKTRACE: 1
       RUST_LOG: debug
       TX_ENCLAVE_STORAGE: /.storage
+  chain-tx-query-enclave:
+    image: "${CHAIN_TX_ENCLAVE_QUERY_DOCKER_IMAGE:-integration-tests-chain-tx-query-enclave}"
+    devices:
+      - "${DOCKER_SGX_DEVICE_BINDING}"
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: debug
+      TX_QUERY_TIMEOUT: 120
+      SPID: ${SPID}
+      IAS_API_KEY: ${IAS_API_KEY}
+      TX_VALIDATION_CONN: tcp://chain-tx-enclave:25933
   client-rpc:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
     command: /usr/bin/wait-for-it.sh tendermint:26657 --timeout=60 --strict -- /usr/bin/client-rpc --host=0.0.0.0 --port=26659 --chain-id=${CHAIN_ID} --storage-dir=/.storage --websocket-url=ws://tendermint:26657/websocket
@@ -48,7 +59,7 @@ services:
       - ${TENDERMINT_ZEROFEE_RPC_PORT:-16657}:26657
   chain-abci-zerofee:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
-    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${ZEROFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave-zerofee:25933 --tx_query=tcp://chain-tx-enclave-zerofee:25933 --data=/.storage"
+    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${ZEROFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave-zerofee:25933 --tx_query=chain-tx-query-enclave-zerofee:25944 --data=/.storage"
     volumes:
       - "./${CHAIN_ABCI_ZEROFEE_DIRECTORY}:/.storage"
     environment:
@@ -64,6 +75,17 @@ services:
       RUST_BACKTRACE: 1
       RUST_LOG: debug
       TX_ENCLAVE_STORAGE: /.storage
+  chain-tx-query-enclave-zerofee:
+    image: "${CHAIN_TX_ENCLAVE_QUERY_DOCKER_IMAGE:-integration-tests-chain-tx-query-enclave}"
+    devices:
+      - "${DOCKER_SGX_DEVICE_BINDING}"
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: debug
+      TX_QUERY_TIMEOUT: 120
+      SPID: ${SPID}
+      IAS_API_KEY: ${IAS_API_KEY}
+      TX_VALIDATION_CONN: tcp://chain-tx-enclave-zerofee:25933
   client-rpc-zerofee:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
     command: /usr/bin/wait-for-it.sh tendermint-zerofee:26657 --timeout=60 --strict -- /usr/bin/client-rpc --host=0.0.0.0 --port=26659 --chain-id=${CHAIN_ID} --storage-dir=/.storage --websocket-url=ws://tendermint-zerofee:26657/websocket

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -53,6 +53,15 @@ function build_chain_tx_enclave_docker_image() {
     cd "${CWD}"
 }
 
+function build_chain_tx_enclave_query_docker_image() {
+    print_config "SGX_MODE" "${SGX_MODE}"
+    CWD=$(pwd)
+    cd ../ && docker build -t "${CHAIN_TX_ENCLAVE_QUERY_DOCKER_IMAGE}" \
+        -f ./chain-tx-enclave/tx-query/Dockerfile .
+    cd "${CWD}"
+}
+
+
 # @argument Tendermint directory
 function init_tendermint() {
     mkdir -p "${1}"
@@ -278,6 +287,7 @@ fi
 
 print_step "Build Chain Transaction Enclave image"
 build_chain_tx_enclave_docker_image
+build_chain_tx_enclave_query_docker_image
 
 print_step "Initialize Tendermint"
 rm -rf "${TENDERMINT_TEMP_DIRECTORY}"


### PR DESCRIPTION
Solution:
- changed chain-abci, client-cli and client-rpc default compilation not to use the complete mock
- added decryption in tx-validation by default
- extended client-rpc with mock feature for transaction obfuscation
- added dockerfile etc. for tx-query
- extended integration test setup + drone pipeline

NOTE: transaction confidentiality is still WIP -- currently data is sealed with a static key known at compile time
(rather than some enclave-only random secret that's periodically re-generated by validators' bootstrapping enclaves),
so it's still a "mock", but better in the sense that client workflows are more realistic / closer to the complete implementation
(decryption queries are over attested TLS to the tx-query enclave rather than plain abci query)