### PR TITLE
Problem: (CRO-608) Transaction builder and signer are coupled with wallet

### DIFF
--- a/chain-tx-validation/src/witness.rs
+++ b/chain-tx-validation/src/witness.rs
@@ -6,7 +6,7 @@ use chain_core::tx::witness::TxInWitness;
 use secp256k1::{schnorrsig::schnorr_verify, Message, PublicKey, Secp256k1};
 
 /// verify a given extended address is associated to the witness
-/// and the signature against the given transation `Tx`
+/// and the signature against the given transaction `Tx`
 /// TODO: capture possible errors in enum?
 ///
 pub fn verify_tx_address(

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -25,9 +25,9 @@ use client_core::cipher::DefaultTransactionObfuscation;
 #[cfg(feature = "mock-enc-dec")]
 use client_core::cipher::MockAbciTransactionObfuscation;
 use client_core::handler::{DefaultBlockHandler, DefaultTransactionHandler};
-use client_core::signer::DefaultSigner;
+use client_core::signer::WalletSignerManager;
 use client_core::synchronizer::{ManualSynchronizer, ProgressReport};
-use client_core::transaction_builder::DefaultTransactionBuilder;
+use client_core::transaction_builder::DefaultWalletTransactionBuilder;
 use client_core::types::BalanceChange;
 use client_core::wallet::{DefaultWalletClient, WalletClient};
 use client_core::BlockHandler;
@@ -170,11 +170,11 @@ impl Command {
             } => {
                 let storage = SledStorage::new(storage_path())?;
                 let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
-                let signer = DefaultSigner::new(storage.clone());
+                let signer_manager = WalletSignerManager::new(storage.clone());
                 let fee_algorithm = tendermint_client.genesis()?.fee_policy();
                 let transaction_obfuscation = get_tx_query(tendermint_client.clone())?;
-                let transaction_builder = DefaultTransactionBuilder::new(
-                    signer.clone(),
+                let transaction_builder = DefaultWalletTransactionBuilder::new(
+                    signer_manager.clone(),
                     fee_algorithm,
                     transaction_obfuscation.clone(),
                 );
@@ -186,7 +186,7 @@ impl Command {
                 );
                 let network_ops_client = DefaultNetworkOpsClient::new(
                     wallet_client,
-                    signer,
+                    signer_manager,
                     tendermint_client,
                     fee_algorithm,
                     transaction_obfuscation,
@@ -197,11 +197,11 @@ impl Command {
             Command::StakedState { name, address } => {
                 let storage = SledStorage::new(storage_path())?;
                 let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
-                let signer = DefaultSigner::new(storage.clone());
+                let signer_manager = WalletSignerManager::new(storage.clone());
                 let fee_algorithm = tendermint_client.genesis()?.fee_policy();
                 let transaction_obfuscation = get_tx_query(tendermint_client.clone())?;
-                let transaction_builder = DefaultTransactionBuilder::new(
-                    signer.clone(),
+                let transaction_builder = DefaultWalletTransactionBuilder::new(
+                    signer_manager.clone(),
                     fee_algorithm,
                     transaction_obfuscation.clone(),
                 );
@@ -213,7 +213,7 @@ impl Command {
 
                 let network_ops_client = DefaultNetworkOpsClient::new(
                     wallet_client,
-                    signer,
+                    signer_manager,
                     tendermint_client,
                     fee_algorithm,
                     transaction_obfuscation,

--- a/client-common/src/error.rs
+++ b/client-common/src/error.rs
@@ -44,6 +44,12 @@ impl Error {
         }
     }
 
+    #[inline]
+    /// Returns message
+    pub fn message(&self) -> &str {
+        self.message.as_str()
+    }
+
     /// Returns kind of error
     #[inline]
     pub fn kind(&self) -> ErrorKind {

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -36,9 +36,9 @@ pub use crate::mnemonic::Mnemonic;
 #[doc(inline)]
 pub use crate::service::WalletStateMemento;
 #[doc(inline)]
-pub use crate::signer::Signer;
+pub use crate::signer::{SignCondition, Signer};
 #[doc(inline)]
-pub use crate::transaction_builder::TransactionBuilder;
+pub use crate::transaction_builder::WalletTransactionBuilder;
 #[doc(inline)]
 pub use crate::unspent_transactions::{SelectedUnspentTransactions, UnspentTransactions};
 #[doc(inline)]

--- a/client-core/src/signer/dummy_signer.rs
+++ b/client-core/src/signer/dummy_signer.rs
@@ -1,4 +1,3 @@
-use crate::SelectedUnspentTransactions;
 use chain_core::common::MerkleTree;
 use chain_core::common::H264;
 use chain_core::state::account::{StakedStateOpWitness, WithdrawUnbondedTx};
@@ -47,17 +46,17 @@ impl DummySigner {
         Ok(TxInWitness::TreeSig(mock_signature, proof))
     }
 
-    /// Signs the selected_unspent_transactions
-    pub fn sign_txs(
+    /// Schnorr sign consecutive imaginary inputs of provided length
+    pub fn schnorr_sign_inputs_len(
         &self,
         total_pubkeys_len: usize,
-        selected_unspent_transactions: &SelectedUnspentTransactions<'_>,
+        inputs_len: usize,
     ) -> Result<TxWitness> {
-        selected_unspent_transactions
-            .iter()
-            .map(|_| self.sign_tx(total_pubkeys_len))
-            .collect::<Result<Vec<TxInWitness>>>()
-            .map(Into::into)
+        let dummy_witness = self.sign_tx(total_pubkeys_len)?;
+        Ok(std::iter::repeat(dummy_witness)
+            .take(inputs_len)
+            .collect::<Vec<TxInWitness>>()
+            .into())
     }
 
     /// Mock the txaux for transactions

--- a/client-core/src/signer/key_pair_signer.rs
+++ b/client-core/src/signer/key_pair_signer.rs
@@ -1,0 +1,84 @@
+//! A signer that sign message using the provided key pair
+use chain_core::common::Proof;
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::{TxInWitness, TxWitness};
+use client_common::{Error, ErrorKind, MultiSigAddress, PrivateKey, PublicKey, Result, ResultExt};
+
+use crate::{SelectedUnspentTransactions, SignCondition, Signer};
+
+/// Signer using key pair
+pub struct KeyPairSigner {
+    extended_addr: ExtendedAddr,
+    proof: Proof<RawPubkey>,
+    private_key: PrivateKey,
+}
+
+impl KeyPairSigner {
+    /// Create a new signer using the provided key pair
+    #[inline]
+    pub fn new(private_key: PrivateKey, public_key: PublicKey) -> Result<Self> {
+        let (extended_addr, proof) = generate_extended_addr_and_proof(public_key)?;
+        Ok(KeyPairSigner {
+            extended_addr,
+            proof,
+            private_key,
+        })
+    }
+}
+
+fn generate_extended_addr_and_proof(
+    public_key: PublicKey,
+) -> Result<(ExtendedAddr, Proof<RawPubkey>)> {
+    let require_signers = 1;
+    let multi_sig_address = MultiSigAddress::new(
+        vec![public_key.clone()],
+        public_key.clone(),
+        require_signers,
+    )?;
+    let proof = multi_sig_address
+        .generate_proof(vec![public_key])?
+        .chain(|| (ErrorKind::InvalidInput, "Unable to generate merkle proof"))?;
+    let extended_addr = ExtendedAddr::from(multi_sig_address);
+
+    Ok((extended_addr, proof))
+}
+
+impl Signer for KeyPairSigner {
+    fn schnorr_sign_transaction<T: AsRef<[u8]>>(
+        &self,
+        message: T,
+        selected_unspent_transactions: &SelectedUnspentTransactions<'_>,
+    ) -> Result<TxWitness> {
+        selected_unspent_transactions
+            .iter()
+            .map(|(_, output)| self.schnorr_sign(&message, &output.address))
+            .collect::<Result<Vec<TxInWitness>>>()
+            .map(Into::into)
+    }
+
+    fn schnorr_sign_condition(&self, signing_addr: &ExtendedAddr) -> Result<SignCondition> {
+        if *signing_addr == self.extended_addr {
+            Ok(SignCondition::SingleSignUnlock)
+        } else {
+            Ok(SignCondition::Impossible)
+        }
+    }
+    fn schnorr_sign<T: AsRef<[u8]>>(
+        &self,
+        message: T,
+        signing_addr: &ExtendedAddr,
+    ) -> Result<TxInWitness> {
+        if *signing_addr != self.extended_addr {
+            return Err(Error::new(
+                ErrorKind::MultiSigError,
+                "Signing address does not belong to the key pair",
+            ));
+        }
+
+        Ok(TxInWitness::TreeSig(
+            self.private_key.schnorr_sign(&message)?,
+            self.proof.clone(),
+        ))
+    }
+}

--- a/client-core/src/signer/unauthorized_signer.rs
+++ b/client-core/src/signer/unauthorized_signer.rs
@@ -1,22 +1,28 @@
-use secstr::SecUtf8;
-
-use chain_core::tx::witness::TxWitness;
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::witness::{TxInWitness, TxWitness};
 use client_common::{ErrorKind, Result};
 
-use crate::{SelectedUnspentTransactions, Signer};
+use crate::unspent_transactions::SelectedUnspentTransactions;
+use crate::{SignCondition, Signer};
 
 /// `TransactionBuilder` which returns `PermissionDenied` error for each function call.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct UnauthorizedSigner;
 
 impl Signer for UnauthorizedSigner {
-    fn sign<T: AsRef<[u8]>>(
+    fn schnorr_sign_transaction<T: AsRef<[u8]>>(
         &self,
-        _: &str,
-        _: &SecUtf8,
         _: T,
         _: &SelectedUnspentTransactions<'_>,
     ) -> Result<TxWitness> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+
+    fn schnorr_sign_condition(&self, _: &ExtendedAddr) -> Result<SignCondition> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+
+    fn schnorr_sign<T: AsRef<[u8]>>(&self, _: T, _: &ExtendedAddr) -> Result<TxInWitness> {
         Err(ErrorKind::PermissionDenied.into())
     }
 }

--- a/client-core/src/transaction_builder.rs
+++ b/client-core/src/transaction_builder.rs
@@ -1,9 +1,11 @@
-//! Transaction building
-mod default_transaction_builder;
-mod unauthorized_transaction_builder;
+//! Transaction builder
+mod default_wallet_transaction_builder;
+mod raw_transfer_transaction_builder;
+mod unauthorized_wallet_transaction_builder;
 
-pub use default_transaction_builder::DefaultTransactionBuilder;
-pub use unauthorized_transaction_builder::UnauthorizedTransactionBuilder;
+pub use default_wallet_transaction_builder::DefaultWalletTransactionBuilder;
+pub use raw_transfer_transaction_builder::RawTransferTransactionBuilder;
+pub use unauthorized_wallet_transaction_builder::UnauthorizedWalletTransactionBuilder;
 
 use secstr::SecUtf8;
 
@@ -15,27 +17,27 @@ use client_common::{Result, SignedTransaction};
 
 use crate::UnspentTransactions;
 
-/// Interface for transaction building from output addresses and amount. This trait is also responsible for UTXO
-/// selection.
-pub trait TransactionBuilder: Send + Sync {
-    /// Builds a transaction
+/// Interface for wallet transaction building from output addresses and amount.
+/// This trait is also responsible for UTXO selection.
+pub trait WalletTransactionBuilder: Send + Sync {
+    /// Builds a transfer transaction
     ///
     /// # Attributes
     ///
     /// - `name`: Name of wallet
     /// - `passphrase`: Passphrase of wallet
-    /// - `outputs`: Transaction outputs
-    /// - `attributes`: Transaction attributes,
     /// - `unspent_transactions`: Unspent transactions
+    /// - `outputs`: Transaction outputs
     /// - `return_address`: Address to which change amount will get returned
-    fn build(
+    /// - `attributes`: Transaction attributes,
+    fn build_transfer_tx(
         &self,
         name: &str,
         passphrase: &SecUtf8,
-        outputs: Vec<TxOut>,
-        attributes: TxAttributes,
         unspent_transactions: UnspentTransactions,
+        outputs: Vec<TxOut>,
         return_address: ExtendedAddr,
+        attributes: TxAttributes,
     ) -> Result<TxAux>;
 
     /// Obfuscates given signed transaction

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -1,0 +1,1099 @@
+//! Builder for building raw transfer transaction
+use std::slice::Iter;
+
+use parity_scale_codec::{Decode, Encode};
+
+use chain_core::init::coin::{sum_coins, Coin};
+use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::input::TxoPointer;
+use chain_core::tx::data::output::TxOut;
+use chain_core::tx::data::{Tx, TxId};
+use chain_core::tx::fee::FeeAlgorithm;
+use chain_core::tx::witness::{TxInWitness, TxWitness};
+use chain_core::tx::{TransactionId, TxAux};
+use chain_tx_validation::witness::verify_tx_address;
+use chain_tx_validation::{check_inputs_basic, check_outputs_basic};
+use client_common::{Error, ErrorKind, Result, ResultExt, SignedTransaction};
+
+use crate::signer::{DummySigner, SignCondition, Signer};
+use crate::TransactionObfuscation;
+
+/// Unspent transaction output with witness data
+#[derive(Debug, Decode, Encode)]
+pub struct WitnessedUTxO {
+    pub prev_txo_pointer: TxoPointer,
+    pub prev_tx_out: TxOut,
+    pub witness: Option<TxInWitness>,
+}
+
+impl WitnessedUTxO {
+    /// Returns if witness data presents
+    pub fn has_witness(&self) -> bool {
+        self.witness.is_some()
+    }
+}
+
+/// Raw transfer transaction data structure
+#[derive(Debug, Decode, Encode)]
+pub struct RawTransferTransaction {
+    inputs: Vec<WitnessedUTxO>,
+    outputs: Vec<TxOut>,
+    attributes: TxAttributes,
+}
+
+/// Raw transfer transaction builder
+#[derive(Debug)]
+pub struct RawTransferTransactionBuilder<F, O>
+where
+    F: FeeAlgorithm,
+    O: TransactionObfuscation,
+{
+    raw_transaction: RawTransferTransaction,
+    fee_algorithm: F,
+    transaction_obfuscation: O,
+}
+
+impl<F, O> RawTransferTransactionBuilder<F, O>
+where
+    F: FeeAlgorithm,
+    O: TransactionObfuscation,
+{
+    // TODO: Refactor attribute setter/getter to separate methods
+    /// Create an instance of raw transfer transaction builder
+    pub fn new(attributes: TxAttributes, fee_algorithm: F, transaction_obfuscation: O) -> Self {
+        let raw_transaction = RawTransferTransaction {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            attributes,
+        };
+        RawTransferTransactionBuilder {
+            raw_transaction,
+            fee_algorithm,
+            transaction_obfuscation,
+        }
+    }
+
+    /// Create an iterator over inputs
+    pub fn iter_inputs(&self) -> Iter<WitnessedUTxO> {
+        self.raw_transaction.inputs.iter()
+    }
+
+    /// Create an iterator over outputs
+    pub fn iter_outputs(&self) -> Iter<TxOut> {
+        self.raw_transaction.outputs.iter()
+    }
+
+    /// Append output to raw transaction
+    /// # Warning
+    /// When a new input is appended, any previous witness will be cleared
+    /// because transaction id will be changed
+    pub fn add_input(&mut self, input: (TxoPointer, TxOut)) {
+        self.raw_transaction.inputs.push(WitnessedUTxO {
+            prev_txo_pointer: input.0,
+            prev_tx_out: input.1,
+            witness: None,
+        });
+;
+        self.clear_witness();
+    }
+
+    /// Append output to raw transaction
+    /// # Warning
+    /// When a new output is appended, any previous witness will be cleared
+    /// because transaction id will be changed
+    pub fn add_output(&mut self, output: TxOut) {
+        self.raw_transaction.outputs.push(output);
+
+        self.clear_witness();
+    }
+
+    /// Clear all inputs witness.
+    /// # Warning
+    /// This operation cannot be reverted.
+    pub fn clear_witness(&mut self) {
+        for input in self.raw_transaction.inputs.iter_mut() {
+            input.witness = None;
+        }
+    }
+
+    /// Returns current raw transaction inputs length
+    pub fn inputs_len(&self) -> usize {
+        self.raw_transaction.inputs.len()
+    }
+
+    /// Returns current raw transaction outputs length
+    pub fn outputs_len(&self) -> usize {
+        self.raw_transaction.outputs.len()
+    }
+
+    /// Get input at provided index
+    pub fn input_at_index(&self, index: usize) -> Result<&WitnessedUTxO> {
+        if self.inputs_len() < index {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Input index out of bound",
+            ));
+        }
+
+        Ok(&self.raw_transaction.inputs[index])
+    }
+
+    /// Get output at provided index
+    pub fn output_at_index(&self, index: usize) -> Result<&TxOut> {
+        if self.outputs_len() < index {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Output index out of bound",
+            ));
+        }
+
+        Ok(&self.raw_transaction.outputs[index])
+    }
+
+    /// Sign all signable inputs with signer
+    pub fn sign_all<S>(&mut self, signer: S) -> Result<()>
+    where
+        S: Signer,
+    {
+        let tx_id = self.tx_id();
+        let input_witness_pairs: Vec<(usize, TxInWitness)> = self
+            .iter_inputs()
+            .enumerate()
+            .map(|(i, input)| {
+                let signing_addr = &input.prev_tx_out.address;
+                if SignCondition::SingleSignUnlock != signer.schnorr_sign_condition(signing_addr)? {
+                    return Ok(None);
+                }
+
+                let witness = signer.schnorr_sign(&tx_id, signing_addr)?;
+
+                Ok(Some((i, witness)))
+            })
+            .collect::<Result<Vec<Option<(usize, TxInWitness)>>>>()?
+            .into_iter()
+            .filter_map(|x| x)
+            .collect();
+        for (i, witness) in input_witness_pairs.into_iter() {
+            self.add_witness(i, witness)?;
+        }
+
+        Ok(())
+    }
+
+    /// Add witness data to provided input index
+    pub fn add_witness(&mut self, index: usize, witness: TxInWitness) -> Result<()> {
+        if index > self.inputs_len() {
+            return Err(Error::new(ErrorKind::InvalidInput, "Invalid input index"));
+        }
+
+        let output_addr = &self.input_at_index(index)?.prev_tx_out.address;
+        verify_tx_address(&witness, &self.tx_id(), output_addr).map_err(|err| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!("Incorrect signature: {}", err),
+            )
+        })?;
+
+        self.mut_input_at_index(index)?.witness = Some(witness);
+
+        Ok(())
+    }
+
+    /// Get mutable input at provided index
+    fn mut_input_at_index(&mut self, index: usize) -> Result<&mut WitnessedUTxO> {
+        if self.inputs_len() < index {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Input index out of bound",
+            ));
+        }
+
+        Ok(&mut self.raw_transaction.inputs[index])
+    }
+
+    /// Returns fee of completed transfer transaction
+    /// # Error
+    /// Returns error when transaction is incompleted
+    pub fn fee(&self) -> Result<Coin> {
+        let fee = self
+            .fee_algorithm
+            .calculate_for_txaux(&self.to_tx_aux()?)
+            .chain(|| {
+                (
+                    ErrorKind::IllegalInput,
+                    "Fee exceeds maximum allowed amount",
+                )
+            })?
+            .to_coin();
+
+        Ok(fee)
+    }
+
+    /// Estimate transaction fee with dummy signatures
+    pub fn estimate_fee(&self) -> Result<Coin> {
+        let dummy_signer = DummySigner();
+        let total_pubkeys_len = 2;
+        let witness = dummy_signer.schnorr_sign_inputs_len(total_pubkeys_len, self.inputs_len())?;
+        let tx_aux = dummy_signer.mock_txaux_for_tx(self.to_tx(), witness);
+        let estimated_fee = self
+            .fee_algorithm
+            .calculate_for_txaux(&tx_aux)
+            .chain(|| {
+                (
+                    ErrorKind::IllegalInput,
+                    "Fee exceeds maximum allowed amount",
+                )
+            })?
+            .to_coin();
+
+        Ok(estimated_fee)
+    }
+
+    /// Returns transfer transaction id
+    pub fn tx_id(&self) -> TxId {
+        self.to_tx().id()
+    }
+
+    /// Convert raw transaction to TxAux
+    pub fn to_tx_aux(&self) -> Result<TxAux> {
+        self.verify()?;
+
+        let tx = self.to_tx();
+        let witness_vec: Vec<TxInWitness> = self
+            .iter_inputs()
+            .map(|input| input.witness.clone().unwrap())
+            .collect();
+        let witness = TxWitness::from(witness_vec);
+        let signed_transaction = SignedTransaction::TransferTransaction(tx, witness);
+
+        self.transaction_obfuscation.encrypt(signed_transaction)
+    }
+
+    /// Verify the raw transaction is valid
+    /// # Error
+    /// Returns VerifyError when the transaction is invalid
+    pub fn verify(&self) -> Result<()> {
+        if !self.is_completed() {
+            return Err(Error::new(
+                ErrorKind::VerifyError,
+                "Missing signature in inputs",
+            ));
+        }
+
+        self.verify_inputs()?;
+        self.verify_outputs()?;
+        self.verify_output_does_not_exceed_input_amount()?;
+        self.verify_input_witnesses()?;
+
+        Ok(())
+    }
+
+    fn verify_inputs(&self) -> Result<()> {
+        let inputs: Vec<TxoPointer> = self
+            .iter_inputs()
+            .map(|input| input.prev_txo_pointer.clone())
+            .collect();
+        let witness: Vec<TxInWitness> = self
+            .iter_inputs()
+            .map(|input| input.witness.clone().unwrap())
+            .collect();
+        let witness = TxWitness::from(witness);
+        check_inputs_basic(&inputs, &witness).map_err(|e| {
+            Error::new(
+                ErrorKind::VerifyError,
+                format!("Failed to validate transaction inputs: {}", e),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn verify_outputs(&self) -> Result<()> {
+        check_outputs_basic(&self.raw_transaction.outputs).map_err(|e| {
+            Error::new(
+                ErrorKind::VerifyError,
+                format!("Failed to validate transaction outputs: {}", e),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn verify_output_does_not_exceed_input_amount(&self) -> Result<()> {
+        let input_value = sum_coins(self.iter_inputs().map(|input| input.prev_tx_out.value))
+            .chain(|| {
+                (
+                    ErrorKind::VerifyError,
+                    "Sum of input values exceeds maximum allowed amount",
+                )
+            })?;
+        let output_value =
+            sum_coins(self.iter_outputs().map(|output| output.value)).chain(|| {
+                (
+                    ErrorKind::VerifyError,
+                    "Sum of output values exceeds maximum allowed amount",
+                )
+            })?;
+        // TODO: Include fee in calculation?
+        if input_value < output_value {
+            return Err(Error::new(
+                ErrorKind::VerifyError,
+                "Output amount exceed input amount",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn verify_input_witnesses(&self) -> Result<()> {
+        let tx_id = self.tx_id();
+        for input in self.iter_inputs() {
+            let witness = input
+                .witness
+                .as_ref()
+                .chain(|| (ErrorKind::VerifyError, "Missing signature in inputs"))?;
+            let output_addr = &input.prev_tx_out.address;
+            verify_tx_address(witness, &tx_id, output_addr).map_err(|err| {
+                Error::new(
+                    ErrorKind::VerifyError,
+                    format!("Incorrect signature: {}", err),
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns if the all inputs of the transaction are signed
+    pub fn is_completed(&self) -> bool {
+        self.iter_inputs().all(|input| input.has_witness())
+    }
+
+    fn to_tx(&self) -> Tx {
+        Tx {
+            inputs: self
+                .iter_inputs()
+                .map(|input| input.prev_txo_pointer.clone())
+                .collect(),
+            outputs: self.raw_transaction.outputs.clone(),
+            attributes: self.raw_transaction.attributes.clone(),
+        }
+    }
+
+    /// Encode incompleted raw transaction
+    pub fn to_incomplete(&self) -> Vec<u8> {
+        self.raw_transaction.encode()
+    }
+
+    /// Create raw transaction builder from encoded incompleted raw transaction bytes
+    pub fn from_incomplete(
+        bytes: Vec<u8>,
+        fee_algorithm: F,
+        transaction_obfuscation: O,
+    ) -> Result<Self> {
+        let raw_transaction =
+            RawTransferTransaction::decode(&mut bytes.as_slice()).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to deserialize raw transaction",
+                )
+            })?;
+
+        Ok(RawTransferTransactionBuilder {
+            raw_transaction,
+            fee_algorithm,
+            transaction_obfuscation,
+        })
+    }
+}
+
+#[cfg(test)]
+mod raw_transfer_transaction_builder_tests {
+    use super::*;
+
+    use rand::random;
+    use secp256k1::schnorrsig::SchnorrSignature;
+
+    use chain_core::common::MerkleTree;
+    use chain_core::common::H264;
+    use chain_core::init::MAX_COIN;
+    use chain_core::tx::data::address::ExtendedAddr;
+    use chain_core::tx::data::input::TxoIndex;
+    use chain_core::tx::fee::{LinearFee, Milli};
+    use chain_core::tx::witness::tree::RawPubkey;
+    use chain_core::tx::{TxEnclaveAux, TxObfuscated};
+    use client_common::{MultiSigAddress, PrivateKey, PublicKey, Transaction};
+
+    use crate::signer::{KeyPairSigner, Signer};
+    use crate::unspent_transactions::SelectedUnspentTransactions;
+
+    mod verify {
+        use super::*;
+
+        #[test]
+        fn should_return_error_when_there_is_unsigned_input() {
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let err = builder.verify().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(err.message(), "Missing signature in inputs");
+        }
+
+        #[test]
+        fn should_return_error_when_input_is_invalid() {
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(250).unwrap(),
+            ));
+
+            let err = builder.verify().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(
+                err.message(),
+                "Failed to validate transaction inputs: transaction has no inputs"
+            );
+        }
+
+        #[test]
+        fn should_return_error_when_output_is_invalid() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(100).unwrap()),
+            ));
+
+            builder
+                .add_witness(
+                    0,
+                    create_public_key_witness(private_key, public_key, builder.tx_id()),
+                )
+                .expect("should add witness to builder");
+
+            let err = builder.verify().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(
+                err.message(),
+                "Failed to validate transaction outputs: transaction has no outputs"
+            );
+        }
+
+        #[test]
+        fn should_return_error_when_output_exceed_max_coin() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(100).unwrap()),
+            ));
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(MAX_COIN).unwrap(),
+            ));
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(MAX_COIN).unwrap(),
+            ));
+
+            builder
+                .add_witness(
+                    0,
+                    create_public_key_witness(private_key, public_key, builder.tx_id()),
+                )
+                .expect("should add witness to builder");
+
+            let err = builder.verify().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(
+                err.message(),
+                "Sum of output values exceeds maximum allowed amount"
+            );
+        }
+
+        #[test]
+        fn should_return_error_when_output_exceed_input_coin() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(100).unwrap()),
+            ));
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(200).unwrap(),
+            ));
+
+            builder
+                .add_witness(
+                    0,
+                    create_public_key_witness(private_key, public_key, builder.tx_id()),
+                )
+                .expect("should add witness to builder");
+
+            let err = builder.verify().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(err.message(), "Output amount exceed input amount");
+        }
+
+        #[test]
+        fn should_return_ok_when_raw_transaction_is_valid() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let witness = create_public_key_witness(private_key, public_key, builder.tx_id());
+            let _ = builder.add_witness(0, witness.clone());
+            let _ = builder.add_witness(1, witness);
+
+            assert!(builder.verify().is_ok());
+        }
+    }
+
+    mod add_input {
+        use super::*;
+
+        #[test]
+        fn should_append_input_to_raw_transaction() {
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            assert_eq!(builder.inputs_len(), 0);
+
+            let input = (
+                TxoPointer::new(random(), 0),
+                TxOut::new(ExtendedAddr::OrTree(random()), Coin::new(100).unwrap()),
+            );
+            builder.add_input(input.clone());
+
+            assert_eq!(builder.inputs_len(), 1);
+            assert_eq!(builder.input_at_index(0).unwrap().prev_txo_pointer, input.0);
+            assert_eq!(builder.input_at_index(0).unwrap().prev_tx_out, input.1);
+        }
+
+        #[test]
+        fn should_clear_existing_witness() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr.clone());
+
+            let input_index = 1;
+            builder
+                .add_witness(
+                    input_index,
+                    create_public_key_witness(private_key, public_key, builder.tx_id()),
+                )
+                .unwrap();
+
+            assert!(builder.input_at_index(input_index).unwrap().has_witness());
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(100).unwrap()),
+            ));
+
+            assert!(!builder.input_at_index(input_index).unwrap().has_witness());
+        }
+    }
+
+    mod add_output {
+        use super::*;
+
+        #[test]
+        fn should_append_output_to_raw_transaction() {
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            assert_eq!(builder.outputs_len(), 0);
+
+            let output = TxOut::new(ExtendedAddr::OrTree(random()), Coin::new(50).unwrap());
+            builder.add_output(output.clone());
+
+            assert_eq!(builder.outputs_len(), 1);
+            assert_eq!(*builder.output_at_index(0).unwrap(), output);
+        }
+
+        #[test]
+        fn should_clear_existing_witness() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr.clone());
+
+            let input_index = 1;
+            builder
+                .add_witness(
+                    input_index,
+                    create_public_key_witness(private_key, public_key, builder.tx_id()),
+                )
+                .unwrap();
+
+            assert!(builder.input_at_index(input_index).unwrap().has_witness());
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(100).unwrap()),
+            ));
+
+            assert!(!builder.input_at_index(input_index).unwrap().has_witness());
+        }
+    }
+
+    mod sign_all {
+        use super::*;
+
+        #[test]
+        fn should_return_error_when_signer_returns_error_when_sign() {
+            struct MockSigner;
+
+            impl Signer for MockSigner {
+                fn schnorr_sign<T: AsRef<[u8]>>(
+                    &self,
+                    _: T,
+                    _: &ExtendedAddr,
+                ) -> Result<TxInWitness> {
+                    Err(Error::from(ErrorKind::InternalError))
+                }
+
+                fn schnorr_sign_transaction<T: AsRef<[u8]>>(
+                    &self,
+                    _: T,
+                    _: &SelectedUnspentTransactions<'_>,
+                ) -> Result<TxWitness> {
+                    unreachable!()
+                }
+
+                fn schnorr_sign_condition(&self, _: &ExtendedAddr) -> Result<SignCondition> {
+                    Ok(SignCondition::SingleSignUnlock)
+                }
+            }
+
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr.clone(), Coin::new(100).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(ExtendedAddr::OrTree(random()), Coin::new(200).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(200).unwrap()),
+            ));
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(300).unwrap(),
+            ));
+
+            let mock_signer = MockSigner;
+
+            let err = builder.sign_all(mock_signer).unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InternalError);
+        }
+
+        #[test]
+        fn should_return_error_when_signed_witness_is_incorrect() {
+            struct MockSigner;
+
+            impl Signer for MockSigner {
+                fn schnorr_sign<T: AsRef<[u8]>>(
+                    &self,
+                    _: T,
+                    _: &ExtendedAddr,
+                ) -> Result<TxInWitness> {
+                    Ok(create_dummy_witness())
+                }
+
+                fn schnorr_sign_transaction<T: AsRef<[u8]>>(
+                    &self,
+                    _: T,
+                    _: &SelectedUnspentTransactions<'_>,
+                ) -> Result<TxWitness> {
+                    unreachable!()
+                }
+
+                fn schnorr_sign_condition(&self, _: &ExtendedAddr) -> Result<SignCondition> {
+                    Ok(SignCondition::SingleSignUnlock)
+                }
+            }
+
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr.clone(), Coin::new(100).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(ExtendedAddr::OrTree(random()), Coin::new(200).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(200).unwrap()),
+            ));
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(300).unwrap(),
+            ));
+
+            let mock_signer = MockSigner;
+
+            let err = builder.sign_all(mock_signer).unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
+            assert_eq!(
+                err.message(),
+                "Incorrect signature: secp: malformed public key"
+            )
+        }
+
+        #[test]
+        fn should_sign_all_signable_inputs_by_signer() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr.clone(), Coin::new(100).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(ExtendedAddr::OrTree(random()), Coin::new(200).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(200).unwrap()),
+            ));
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(300).unwrap(),
+            ));
+
+            let key_pair_signer = KeyPairSigner::new(private_key, public_key).unwrap();
+
+            builder
+                .sign_all(key_pair_signer)
+                .expect("sign_all should work");
+
+            assert!(builder.input_at_index(0).unwrap().has_witness());
+            assert_eq!(builder.input_at_index(1).unwrap().has_witness(), false);
+            assert!(builder.input_at_index(2).unwrap().has_witness());
+        }
+    }
+
+    mod add_witness {
+        use super::*;
+
+        #[test]
+        fn should_return_error_when_input_index_does_not_exist() {
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let out_of_bound_input_index = 5;
+            let add_witness_result =
+                builder.add_witness(out_of_bound_input_index, create_dummy_witness());
+            assert_eq!(
+                add_witness_result.expect_err("Invalid input index").kind(),
+                ErrorKind::InvalidInput
+            );
+        }
+
+        #[test]
+        fn should_return_error_when_witness_is_incorrect() {
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let add_witness_result = builder.add_witness(1, create_dummy_witness());
+
+            let err = add_witness_result.unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
+            assert_eq!(
+                err.message(),
+                "Incorrect signature: secp: malformed public key"
+            );
+        }
+
+        #[test]
+        fn should_add_witness_to_specified_input_index() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let input_index = 1;
+            let add_witness_result = builder.add_witness(
+                input_index,
+                create_public_key_witness(private_key, public_key, builder.tx_id()),
+            );
+            assert!(add_witness_result.is_ok());
+            assert!(builder
+                .input_at_index(input_index)
+                .expect("input should exist")
+                .has_witness());
+        }
+    }
+
+    mod is_completed {
+        use super::*;
+
+        #[test]
+        fn should_return_false_when_one_of_the_input_is_unsigned() {
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let raw_transaction_builder =
+                create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            assert_eq!(raw_transaction_builder.is_completed(), false);
+        }
+
+        #[test]
+        fn should_return_true_when_all_the_input_is_signed() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let witness = create_public_key_witness(private_key, public_key, builder.tx_id());
+            builder
+                .add_witness(0, witness.clone())
+                .expect("should add witness to input index");
+            builder
+                .add_witness(1, witness)
+                .expect("should add witness to input index");
+
+            assert_eq!(builder.is_completed(), true);
+        }
+    }
+
+    mod fee {
+        use super::*;
+
+        #[test]
+        fn fee_should_return_error_when_raw_transaction_is_incompleted() {
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let err = builder.fee().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(err.message(), "Missing signature in inputs");
+        }
+
+        #[test]
+        fn estimate_fee_should_be_greater_than_or_equal_to_fee() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+            let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+            let witness = create_public_key_witness(private_key, public_key, builder.tx_id());
+            builder
+                .add_witness(0, witness.clone())
+                .expect("should add witness to input index");
+            builder
+                .add_witness(1, witness)
+                .expect("should add witness to input index");
+
+            let fee = builder.fee().unwrap();
+            let estimated_fee = builder.estimate_fee().unwrap();
+
+            assert!(estimated_fee >= fee);
+        }
+    }
+
+    #[test]
+    fn test_to_incomplete_from_incomplete_flow() {
+        let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+        let mut raw_transaction_builder =
+            create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+        raw_transaction_builder
+            .add_witness(
+                0,
+                create_public_key_witness(private_key, public_key, raw_transaction_builder.tx_id()),
+            )
+            .expect("should add witness to input index");
+
+        let encoded_incomplete_bytes = raw_transaction_builder.to_incomplete();
+
+        let fee_algorithm = create_testing_fee_algorithm();
+        let tx_obfuscation = MockTransactionCipher;
+        assert_eq!(
+            RawTransferTransactionBuilder::from_incomplete(
+                String::from("hello from rust").into_bytes(),
+                fee_algorithm,
+                tx_obfuscation,
+            )
+            .expect_err("Unable to decode raw transaction bytes")
+            .kind(),
+            ErrorKind::DeserializationError
+        );
+
+        let fee_algorithm = create_testing_fee_algorithm();
+        let tx_obfuscation = MockTransactionCipher;
+        let restored_raw_transaction_builder_result =
+            RawTransferTransactionBuilder::from_incomplete(
+                encoded_incomplete_bytes,
+                fee_algorithm,
+                tx_obfuscation,
+            );
+
+        assert!(restored_raw_transaction_builder_result.is_ok());
+
+        let restored_raw_transaction_builder = restored_raw_transaction_builder_result.unwrap();
+        assert_eq!(restored_raw_transaction_builder.is_completed(), false);
+    }
+
+    fn create_2in2out_testing_raw_transaction_builder(
+        transfer_addr: ExtendedAddr,
+    ) -> RawTransferTransactionBuilder<LinearFee, MockTransactionCipher> {
+        let attributes = TxAttributes::default();
+        let fee_algorithm = create_testing_fee_algorithm();
+        let tx_obfuscation = MockTransactionCipher;
+        let mut builder =
+            RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+        builder.add_input((
+            TxoPointer::new(random(), 0),
+            TxOut::new(transfer_addr.clone(), Coin::new(100).unwrap()),
+        ));
+        builder.add_input((
+            TxoPointer::new(random(), 0),
+            TxOut::new(transfer_addr, Coin::new(200).unwrap()),
+        ));
+
+        builder.add_output(TxOut::new(
+            ExtendedAddr::OrTree(random()),
+            Coin::new(50).unwrap(),
+        ));
+        builder.add_output(TxOut::new(
+            ExtendedAddr::OrTree(random()),
+            Coin::new(250).unwrap(),
+        ));
+
+        builder
+    }
+
+    fn create_testing_fee_algorithm() -> LinearFee {
+        LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
+    }
+
+    fn create_key_pair_and_transfer_addr() -> (PrivateKey, PublicKey, ExtendedAddr) {
+        let private_key = PrivateKey::new().expect("should create private key");
+        let public_key = PublicKey::from(&private_key);
+        let transfer_addr = create_transfer_addr(public_key.clone());
+
+        (private_key, public_key, transfer_addr)
+    }
+
+    fn create_public_key_witness(
+        private_key: PrivateKey,
+        public_key: PublicKey,
+        tx_id: TxId,
+    ) -> TxInWitness {
+        let signing_addr = create_transfer_addr(public_key.clone());
+
+        let signer =
+            KeyPairSigner::new(private_key, public_key).expect("should create KeyPairSigner");
+        signer
+            .schnorr_sign(tx_id, &signing_addr)
+            .expect("should sign transaction id")
+    }
+
+    fn create_transfer_addr(public_key: PublicKey) -> ExtendedAddr {
+        let require_signers = 1;
+        let multi_sig_address = MultiSigAddress::new(
+            vec![public_key.clone()],
+            public_key.clone(),
+            require_signers,
+        )
+        .expect("should create multi sig address");
+
+        ExtendedAddr::from(multi_sig_address)
+    }
+
+    fn create_dummy_witness() -> TxInWitness {
+        let raw_pubkey = RawPubkey::from([0_u8; 33] as H264);
+        let total_pubkeys_len = 2;
+        let tree = vec![raw_pubkey.clone(); total_pubkeys_len];
+        let merkle_tree = MerkleTree::new(tree);
+
+        let proof = merkle_tree
+            .generate_proof(raw_pubkey)
+            .expect("generate proof error in mocked merkle tree");
+        let mock_signature =
+            SchnorrSignature::from_default(&[0_u8; 64]).expect("set mock signature failed");
+
+        TxInWitness::TreeSig(mock_signature, proof)
+    }
+
+    #[derive(Debug)]
+    struct MockTransactionCipher;
+
+    impl TransactionObfuscation for MockTransactionCipher {
+        fn decrypt(
+            &self,
+            _transaction_ids: &[TxId],
+            _private_key: &PrivateKey,
+        ) -> Result<Vec<Transaction>> {
+            unreachable!()
+        }
+
+        fn encrypt(&self, transaction: SignedTransaction) -> Result<TxAux> {
+            let txpayload = transaction.encode();
+
+            match transaction {
+                SignedTransaction::TransferTransaction(tx, _) => {
+                    Ok(TxAux::EnclaveTx(TxEnclaveAux::TransferTx {
+                        inputs: tx.inputs.clone(),
+                        no_of_outputs: tx.outputs.len() as TxoIndex,
+                        payload: TxObfuscated {
+                            txid: [0; 32],
+                            key_from: 0,
+                            init_vector: [0u8; 12],
+                            txpayload,
+                        },
+                    }))
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/client-core/src/transaction_builder/unauthorized_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/unauthorized_wallet_transaction_builder.rs
@@ -1,0 +1,32 @@
+use secstr::SecUtf8;
+
+use chain_core::tx::data::address::ExtendedAddr;
+use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::output::TxOut;
+use chain_core::tx::TxAux;
+use client_common::{ErrorKind, Result, SignedTransaction};
+
+use crate::{UnspentTransactions, WalletTransactionBuilder};
+
+/// Implementation of `WalletTransactionBuilder` which always returns
+/// permission denied
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnauthorizedWalletTransactionBuilder;
+
+impl WalletTransactionBuilder for UnauthorizedWalletTransactionBuilder {
+    fn build_transfer_tx(
+        &self,
+        _: &str,
+        _: &SecUtf8,
+        _: UnspentTransactions,
+        _: Vec<TxOut>,
+        _: ExtendedAddr,
+        _: TxAttributes,
+    ) -> Result<TxAux> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+
+    fn obfuscate(&self, _: SignedTransaction) -> Result<TxAux> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+}

--- a/client-core/src/unspent_transactions.rs
+++ b/client-core/src/unspent_transactions.rs
@@ -196,7 +196,7 @@ impl Sorter {
 }
 
 #[cfg(test)]
-mod tests {
+mod unspent_transactions_tests {
     use super::*;
 
     use rand::random;

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -317,8 +317,8 @@ mod test {
     use client_common::tendermint::types::*;
     use client_common::tendermint::Client;
     use client_common::{PrivateKey, Result as CommonResult, SignedTransaction, Transaction};
-    use client_core::signer::DefaultSigner;
-    use client_core::transaction_builder::DefaultTransactionBuilder;
+    use client_core::signer::WalletSignerManager;
+    use client_core::transaction_builder::DefaultWalletTransactionBuilder;
     use client_core::types::WalletKind;
     use client_core::wallet::DefaultWalletClient;
     use client_core::TransactionObfuscation;
@@ -365,9 +365,9 @@ mod test {
     }
 
     fn make_test_wallet_client(storage: MemoryStorage) -> TestWalletClient {
-        let signer = DefaultSigner::new(storage.clone());
-        let transaction_builder = DefaultTransactionBuilder::new(
-            signer,
+        let signer_manager = WalletSignerManager::new(storage.clone());
+        let transaction_builder = DefaultWalletTransactionBuilder::new(
+            signer_manager,
             ZeroFeeAlgorithm::default(),
             MockTransactionCipher,
         );
@@ -389,7 +389,7 @@ mod test {
         }
     }
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct ZeroFeeAlgorithm;
 
     impl FeeAlgorithm for ZeroFeeAlgorithm {
@@ -402,7 +402,7 @@ mod test {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     struct MockTransactionCipher;
 
     impl TransactionObfuscation for MockTransactionCipher {
@@ -419,10 +419,10 @@ mod test {
         }
     }
 
-    type TestTxBuilder =
-        DefaultTransactionBuilder<TestSigner, ZeroFeeAlgorithm, MockTransactionCipher>;
-    type TestSigner = DefaultSigner<MemoryStorage>;
-    type TestWalletClient = DefaultWalletClient<MemoryStorage, MockRpcClient, TestTxBuilder>;
+    type TestWalletTransactionBuilder =
+        DefaultWalletTransactionBuilder<MemoryStorage, ZeroFeeAlgorithm, MockTransactionCipher>;
+    type TestWalletClient =
+        DefaultWalletClient<MemoryStorage, MockRpcClient, TestWalletTransactionBuilder>;
 
     #[derive(Default)]
     pub struct MockRpcClient;

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -276,12 +276,12 @@ pub mod tests {
     use client_common::{
         Error, ErrorKind, PrivateKey, Result as CommonResult, SignedTransaction, Transaction,
     };
-    use client_core::signer::DefaultSigner;
-    use client_core::transaction_builder::DefaultTransactionBuilder;
+    use client_core::signer::WalletSignerManager;
+    use client_core::transaction_builder::DefaultWalletTransactionBuilder;
     use client_core::wallet::DefaultWalletClient;
     use client_core::TransactionObfuscation;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct ZeroFeeAlgorithm;
 
     impl FeeAlgorithm for ZeroFeeAlgorithm {
@@ -294,7 +294,7 @@ pub mod tests {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     struct MockTransactionCipher;
 
     impl TransactionObfuscation for MockTransactionCipher {
@@ -351,10 +351,10 @@ pub mod tests {
         }
     }
 
-    type TestTxBuilder =
-        DefaultTransactionBuilder<TestSigner, ZeroFeeAlgorithm, MockTransactionCipher>;
-    type TestSigner = DefaultSigner<MemoryStorage>;
-    type TestWalletClient = DefaultWalletClient<MemoryStorage, MockRpcClient, TestTxBuilder>;
+    type TestWalletTransactionBuilder =
+        DefaultWalletTransactionBuilder<MemoryStorage, ZeroFeeAlgorithm, MockTransactionCipher>;
+    type TestWalletClient =
+        DefaultWalletClient<MemoryStorage, MockRpcClient, TestWalletTransactionBuilder>;
 
     #[derive(Default)]
     pub struct MockRpcClient;
@@ -667,9 +667,9 @@ pub mod tests {
     }
 
     fn make_test_wallet_client(storage: MemoryStorage) -> TestWalletClient {
-        let signer = DefaultSigner::new(storage.clone());
-        let transaction_builder = DefaultTransactionBuilder::new(
-            signer,
+        let signer_manager = WalletSignerManager::new(storage.clone());
+        let transaction_builder = DefaultWalletTransactionBuilder::new(
+            signer_manager,
             ZeroFeeAlgorithm::default(),
             MockTransactionCipher,
         );

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -14,9 +14,9 @@ use client_common::tendermint::{Client, WebsocketRpcClient};
 use client_common::{Error, Result};
 use client_core::cipher::MockAbciTransactionObfuscation;
 use client_core::handler::{DefaultBlockHandler, DefaultTransactionHandler};
-use client_core::signer::DefaultSigner;
+use client_core::signer::WalletSignerManager;
 use client_core::synchronizer::ManualSynchronizer;
-use client_core::transaction_builder::DefaultTransactionBuilder;
+use client_core::transaction_builder::DefaultWalletTransactionBuilder;
 use client_core::wallet::DefaultWalletClient;
 use client_network::network_ops::DefaultNetworkOpsClient;
 
@@ -25,13 +25,12 @@ use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBui
 use secstr::SecUtf8;
 use serde::{Deserialize, Serialize};
 
-type AppSigner = DefaultSigner<SledStorage>;
 type AppTransactionCipher = MockAbciTransactionObfuscation<WebsocketRpcClient>;
-type AppTxBuilder = DefaultTransactionBuilder<AppSigner, LinearFee, AppTransactionCipher>;
+type AppTxBuilder = DefaultWalletTransactionBuilder<SledStorage, LinearFee, AppTransactionCipher>;
 type AppWalletClient = DefaultWalletClient<SledStorage, WebsocketRpcClient, AppTxBuilder>;
 type AppOpsClient = DefaultNetworkOpsClient<
     AppWalletClient,
-    AppSigner,
+    SledStorage,
     WebsocketRpcClient,
     LinearFee,
     AppTransactionCipher,
@@ -68,10 +67,10 @@ impl Server {
         storage: SledStorage,
         tendermint_client: WebsocketRpcClient,
     ) -> Result<AppWalletClient> {
-        let signer = DefaultSigner::new(storage.clone());
+        let signer_manager = WalletSignerManager::new(storage.clone());
         let transaction_cipher = MockAbciTransactionObfuscation::new(tendermint_client.clone());
-        let transaction_builder = DefaultTransactionBuilder::new(
-            signer,
+        let transaction_builder = DefaultWalletTransactionBuilder::new(
+            signer_manager,
             tendermint_client.genesis().unwrap().fee_policy(),
             transaction_cipher,
         );
@@ -88,12 +87,12 @@ impl Server {
         tendermint_client: WebsocketRpcClient,
     ) -> Result<AppOpsClient> {
         let transaction_cipher = MockAbciTransactionObfuscation::new(tendermint_client.clone());
-        let signer = DefaultSigner::new(storage.clone());
+        let signer_manager = WalletSignerManager::new(storage.clone());
         let fee_algorithm = tendermint_client.genesis().unwrap().fee_policy();
         let wallet_client = self.make_wallet_client(storage, tendermint_client.clone())?;
         Ok(DefaultNetworkOpsClient::new(
             wallet_client,
-            signer,
+            signer_manager,
             tendermint_client,
             fee_algorithm,
             transaction_cipher,


### PR DESCRIPTION
Solution: Refactor transaction builder and signer to be generic

---
- Keep transaction builder and signer; But rename with wallet prefix
- Extract transaction building logic into `RawTransferTransactionBuilder`
- Refactor `Signer` trait to be generic