### PR TITLE
Problem (CRO-594): block results and "fast sync" are not verified in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendermint 0.10.0 (git+https://github.com/crypto-com/tendermint-rs.git?rev=8e95731ee671777638ab2a3d5dfd7b35992b86aa)",
+ "test-common 0.1.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain-abci/src/app/end_block.rs
+++ b/chain-abci/src/app/end_block.rs
@@ -96,7 +96,7 @@ fn get_validator_updates(
         .council_nodes_by_power
         .iter()
         .rev()
-        .take(last_state.network_params.get_max_validators())
+        .take(last_state.top_level.network_params.get_max_validators())
     {
         let old_power = validator_voting_power.get(&address);
         let create_update = match old_power {
@@ -138,7 +138,10 @@ fn get_validator_updates(
             }
         }
     }
-    let window = last_state.network_params.get_block_signing_window();
+    let window = last_state
+        .top_level
+        .network_params
+        .get_block_signing_window();
     while let Some((validator_address, staking_address)) = new_to_track.pop() {
         last_state.validators.add_validator_for_tracking(
             validator_address,

--- a/chain-abci/src/app/jail_account.rs
+++ b/chain-abci/src/app/jail_account.rs
@@ -30,7 +30,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             .expect("Last state not found. Init chain was not called.");
 
         let block_time = last_state.block_time;
-        let jail_duration = last_state.network_params.get_jail_duration();
+        let jail_duration = last_state.top_level.network_params.get_jail_duration();
 
         account.jail_until(block_time + jail_duration, punishment_kind);
 

--- a/chain-abci/src/app/slash_accounts.rs
+++ b/chain-abci/src/app/slash_accounts.rs
@@ -68,9 +68,9 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                 .slash(schedule.slash_ratio, schedule.punishment_kind)
                 .map_err(|_| Error::InvalidSum)?;
 
-            last_state.rewards_pool.period_bonus = (last_state.rewards_pool.period_bonus
-                + slashed_amount)
-                .map_err(|_| Error::InvalidSum)?;
+            last_state.top_level.rewards_pool.period_bonus =
+                (last_state.top_level.rewards_pool.period_bonus + slashed_amount)
+                    .map_err(|_| Error::InvalidSum)?;
             self.rewards_pool_updated = true;
 
             let (new_root, _) = update_account(
@@ -113,7 +113,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                         TendermintVotePower::from(
                             get_account(
                                 &address,
-                                &last_state.last_account_root_hash,
+                                &last_state.top_level.account_root,
                                 &self.accounts,
                             )
                             .expect("Voting power for a validator not found")

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -59,6 +59,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
     ) -> Result<(Fee, Option<StakedState>), Error> {
         let state = self.last_state.as_ref().expect("the app state is expected");
         let min_fee = state
+            .top_level
             .network_params
             .calculate_fee(tx_len)
             .expect("invalid fee policy");
@@ -66,7 +67,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             min_fee_computed: min_fee,
             chain_hex_id: self.chain_hex_id,
             previous_block_time: state.block_time,
-            unbonding_period: state.network_params.get_unbonding_period(),
+            unbonding_period: state.top_level.network_params.get_unbonding_period(),
         };
         match txaux {
             TxAux::EnclaveTx(tx) => verify_enclave_tx(
@@ -79,7 +80,10 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             ),
             _ => {
                 let node_info = NodeInfo {
-                    minimal_stake: state.network_params.get_required_council_node_stake(),
+                    minimal_stake: state
+                        .top_level
+                        .network_params
+                        .get_required_council_node_stake(),
                     tendermint_validator_addresses: &state
                         .validators
                         .tendermint_validator_addresses,

--- a/chain-abci/src/storage/mod.rs
+++ b/chain-abci/src/storage/mod.rs
@@ -18,10 +18,12 @@ pub const COL_EXTRA: Option<u32> = Some(3);
 pub const COL_NODE_INFO: Option<u32> = Some(4);
 /// Column for seriliazed merkle tree: root hash => MerkleTree
 pub const COL_MERKLE_PROOFS: Option<u32> = Some(5);
-/// Column for tracking app states: height => root hash
-pub const COL_APP_STATES: Option<u32> = Some(6);
+/// Column for tracking app hashes: height => app hash
+pub const COL_APP_HASHS: Option<u32> = Some(6);
+/// Column for tracking app states: height => ChainNodeState, only available when tx_query_address set
+pub const COL_APP_STATES: Option<u32> = Some(7);
 /// Number of columns in DB
-pub const NUM_COLUMNS: Option<u32> = Some(7);
+pub const NUM_COLUMNS: Option<u32> = Some(8);
 
 pub const CHAIN_ID_KEY: &[u8] = b"chain_id";
 pub const GENESIS_APP_HASH_KEY: &[u8] = b"genesis_app_hash";

--- a/chain-abci/tests/punishment.rs
+++ b/chain-abci/tests/punishment.rs
@@ -157,7 +157,12 @@ fn begin_block_should_slash_byzantine_validators() {
     app.end_block(&RequestEndBlock::new());
     assert_eq!(
         Coin::zero(),
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 
     // Begin Block
@@ -177,7 +182,12 @@ fn begin_block_should_slash_byzantine_validators() {
         .contains_key(&env.accounts[0].staking_address()));
     assert_eq!(
         Coin::new((u64::from(env.dist_coin) / 10) * 2).unwrap(), // 0.2 * account_balance
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 }
 
@@ -216,7 +226,12 @@ fn begin_block_should_slash_non_live_validators() {
     app.end_block(&RequestEndBlock::new());
     assert_eq!(
         Coin::zero(),
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 
     // Begin Block
@@ -236,7 +251,12 @@ fn begin_block_should_slash_non_live_validators() {
         .contains_key(&env.accounts[0].staking_address()));
     assert_eq!(
         Coin::new(u64::from(env.dist_coin) / 10).unwrap(), // 0.1 * account_balance
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 }
 
@@ -275,7 +295,12 @@ fn begin_block_should_update_slash_ratio_for_multiple_punishments() {
     app.end_block(&RequestEndBlock::new());
     assert_eq!(
         Coin::zero(),
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 
     // Begin Block
@@ -298,7 +323,12 @@ fn begin_block_should_update_slash_ratio_for_multiple_punishments() {
     app.end_block(&RequestEndBlock::new());
     assert_eq!(
         Coin::zero(),
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 
     // Begin Block
@@ -318,7 +348,12 @@ fn begin_block_should_update_slash_ratio_for_multiple_punishments() {
         .contains_key(&env.accounts[0].staking_address()));
     assert_eq!(
         Coin::new(u64::from(Coin::max()) / 5).unwrap(), // 0.1 * account_balance
-        app.last_state.as_ref().unwrap().rewards_pool.period_bonus
+        app.last_state
+            .as_ref()
+            .unwrap()
+            .top_level
+            .rewards_pool
+            .period_bonus
     );
 }
 

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -101,6 +101,12 @@ pub enum Command {
             help = "Force synchronization from genesis"
         )]
         force: bool,
+        #[structopt(
+            name = "disable-fast-forward",
+            long,
+            help = "Disable fast forward, which is not secure when connecting to outside nodes"
+        )]
+        disable_fast_forward: bool,
     },
 }
 
@@ -224,6 +230,7 @@ impl Command {
                 name,
                 batch_size,
                 force,
+                disable_fast_forward,
             } => {
                 let storage = SledStorage::new(storage_path())?;
                 let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
@@ -236,8 +243,12 @@ impl Command {
                     storage.clone(),
                 );
 
-                let synchronizer =
-                    ManualSynchronizer::new(storage, tendermint_client, block_handler);
+                let synchronizer = ManualSynchronizer::new(
+                    storage,
+                    tendermint_client,
+                    block_handler,
+                    !disable_fast_forward,
+                );
 
                 Self::resync(synchronizer, name, *batch_size, *force)
             }

--- a/client-common/src/tendermint/client.rs
+++ b/client-common/src/tendermint/client.rs
@@ -1,6 +1,7 @@
 use crate::tendermint::lite;
 use crate::tendermint::types::*;
 use crate::Result;
+use chain_core::state::ChainState;
 
 /// Makes remote calls to tendermint (backend agnostic)
 pub trait Client: Send + Sync {
@@ -37,4 +38,7 @@ pub trait Client: Send + Sync {
 
     /// Makes `abci_query` call to tendermint
     fn query(&self, path: &str, data: &[u8]) -> Result<AbciQuery>;
+
+    /// Match batch state `abci_query` call to tendermint
+    fn query_state_batch<T: Iterator<Item = u64>>(&self, heights: T) -> Result<Vec<ChainState>>;
 }

--- a/client-common/src/tendermint/lite.rs
+++ b/client-common/src/tendermint/lite.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tendermint::{block::Header, validator};
 
 use crate::tendermint::client::Client;
-use crate::Result;
+use crate::Result as CommonResult;
 
 ///
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15,7 +15,7 @@ pub struct TrustedState {
 }
 
 /// get genesis validator set
-pub fn get_genesis_validators<C>(client: &C) -> Result<validator::Set>
+pub fn get_genesis_validators<C>(client: &C) -> CommonResult<validator::Set>
 where
     C: Client,
 {

--- a/client-common/src/tendermint/unauthorized_client.rs
+++ b/client-common/src/tendermint/unauthorized_client.rs
@@ -2,6 +2,7 @@ use crate::{
     tendermint::{lite, types::*, Client},
     ErrorKind, Result,
 };
+use chain_core::state::ChainState;
 
 /// `Client` which returns `PermissionDenied` error for each function call.
 #[derive(Debug, Default, Clone, Copy)]
@@ -48,6 +49,10 @@ impl Client for UnauthorizedClient {
         _state: lite::TrustedState,
         _heights: T,
     ) -> Result<(Vec<Block>, lite::TrustedState)> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+
+    fn query_state_batch<T: Iterator<Item = u64>>(&self, _heights: T) -> Result<Vec<ChainState>> {
         Err(ErrorKind::PermissionDenied.into())
     }
 }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -43,6 +43,7 @@ tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-
 hex = "0.4.0"
 base58 = "0.1.0"
 ripemd160 = "0.8.0"
+test-common = { path = "../test-common" }
 
 [features]
 default = ["sled"]

--- a/client-core/src/cipher/mock_abci_transaction_obfuscation.rs
+++ b/client-core/src/cipher/mock_abci_transaction_obfuscation.rs
@@ -116,6 +116,7 @@ mod tests {
 
     use base64::encode;
 
+    use chain_core::state::ChainState;
     use chain_core::tx::data::Tx;
     use chain_core::tx::witness::TxWitness;
     use chain_core::tx::{TxEnclaveAux, TxObfuscated};
@@ -203,6 +204,13 @@ mod tests {
                 }
                 _ => Err(ErrorKind::InvalidInput.into()),
             }
+        }
+
+        fn query_state_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<ChainState>> {
+            unreachable!()
         }
     }
 

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -93,7 +93,7 @@ where
             prev_tx_out: input.1,
             witness: None,
         });
-        self.clear_witness();
+        self.clear_witness()
     }
 
     /// Append output to raw transaction

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -473,6 +473,7 @@ mod tests {
         Punishment, PunishmentKind, StakedState, StakedStateOpAttributes,
     };
     use chain_core::state::tendermint::TendermintValidatorPubKey;
+    use chain_core::state::ChainState;
     use chain_core::tx::data::input::TxoIndex;
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::Fee;
@@ -604,6 +605,13 @@ mod tests {
                 ..Default::default()
             })
         }
+
+        fn query_state_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<ChainState>> {
+            unreachable!()
+        }
     }
 
     #[derive(Default, Clone)]
@@ -663,6 +671,13 @@ mod tests {
                 value: Some(base64::encode(&staked_state.encode())),
                 ..Default::default()
             })
+        }
+
+        fn query_state_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> Result<Vec<ChainState>> {
+            unreachable!()
         }
     }
 

--- a/client-rpc/src/program.rs
+++ b/client-rpc/src/program.rs
@@ -47,6 +47,13 @@ pub struct Options {
         help = "Url for connecting with tendermint websocket RPC"
     )]
     pub websocket_url: String,
+
+    #[structopt(
+        name = "disable-fast-forward",
+        long,
+        help = "Disable fast forward, which is not secure when connecting to outside nodes"
+    )]
+    pub disable_fast_forward: bool,
 }
 
 #[allow(dead_code)]

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -309,6 +309,7 @@ mod test {
     use secstr::SecUtf8;
 
     use chain_core::init::coin::CoinError;
+    use chain_core::state::ChainState;
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::{Fee, FeeAlgorithm};
     use chain_core::tx::TxAux;
@@ -472,6 +473,13 @@ mod test {
 
         fn query(&self, _path: &str, _data: &[u8]) -> CommonResult<AbciQuery> {
             unreachable!("query")
+        }
+
+        fn query_state_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> CommonResult<Vec<ChainState>> {
+            unreachable!()
         }
     }
 }

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -264,6 +264,7 @@ pub mod tests {
     use parity_scale_codec::Encode;
 
     use chain_core::init::coin::CoinError;
+    use chain_core::state::ChainState;
     use chain_core::tx::data::input::TxoIndex;
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::{Fee, FeeAlgorithm};
@@ -452,6 +453,13 @@ pub mod tests {
 
         fn query(&self, _path: &str, _data: &[u8]) -> CommonResult<AbciQuery> {
             unreachable!("query")
+        }
+
+        fn query_state_batch<T: Iterator<Item = u64>>(
+            &self,
+            _heights: T,
+        ) -> CommonResult<Vec<ChainState>> {
+            unreachable!()
         }
     }
 

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -45,6 +45,7 @@ pub(crate) struct Server {
     network_id: u8,
     storage_dir: String,
     websocket_url: String,
+    enable_fast_forward: bool,
 }
 
 impl Server {
@@ -59,6 +60,7 @@ impl Server {
             network_id,
             storage_dir: options.storage_dir,
             websocket_url: options.websocket_url,
+            enable_fast_forward: !options.disable_fast_forward,
         })
     }
 
@@ -113,6 +115,7 @@ impl Server {
             storage,
             tendermint_client,
             block_handler,
+            self.enable_fast_forward,
         ))
     }
 

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -47,8 +47,8 @@ impl GenesisDevConfig {
                 monetary_expansion_cap: expansion_cap,
                 distribution_period: 24 * 60 * 60,
                 monetary_expansion_r0: "0.5".parse().unwrap(),
-                monetary_expansion_tau: 145000000,
-                monetary_expansion_decay: 999860,
+                monetary_expansion_tau: 145_000_000,
+                monetary_expansion_decay: 999_860,
             },
             initial_fee_policy: InitialFeePolicy {
                 base_fee: "1.1".to_string(),

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ${TENDERMINT_RPC_PORT:-26657}:26657
   chain-abci:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
-    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${WITHFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave:25933 --data=/.storage"
+    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${WITHFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave:25933 --tx_query=tcp://chain-tx-enclave:25933 --data=/.storage"
     volumes:
       - "./${CHAIN_ABCI_WITHFEE_DIRECTORY}:/.storage"
     environment:
@@ -48,7 +48,7 @@ services:
       - ${TENDERMINT_ZEROFEE_RPC_PORT:-16657}:26657
   chain-abci-zerofee:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
-    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${ZEROFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave-zerofee:25933 --data=/.storage"
+    command: "/usr/bin/chain-abci --host=0.0.0.0 --port=26658 --chain_id=${CHAIN_ID} --genesis_app_hash=${ZEROFEE_APP_HASH} --enclave_server=tcp://chain-tx-enclave-zerofee:25933 --tx_query=tcp://chain-tx-enclave-zerofee:25933 --data=/.storage"
     volumes:
       - "./${CHAIN_ABCI_ZEROFEE_DIRECTORY}:/.storage"
     environment:

--- a/integration-tests/start-local.sh
+++ b/integration-tests/start-local.sh
@@ -111,7 +111,8 @@ function start_chain_abci() {
             --port "${2}" \
             --chain_id "${CHAIN_ID}" \
             --genesis_app_hash ${1} \
-            --enclave_server "tcp://127.0.0.1:${3}"
+            --enclave_server "tcp://127.0.0.1:${3}" \
+            --tx_query "tcp://127.0.0.1:${3}"
 }
 
 # @argument Wallet Storage directory

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -55,7 +55,7 @@ pub fn get_account(
     let state = app.last_state.clone().expect("app state");
     println!(
         "committed root hash: {}",
-        hex::encode(&state.last_account_root_hash)
+        hex::encode(&state.top_level.account_root)
     );
     let account = app
         .accounts


### PR DESCRIPTION
Solution:
- Store history hashes to `COL_APP_HASHS`, history state to `COL_APP_STATES`
- Add `query_state_batch` to rpc client, and verify block results with it.
- Make fast-forward syncing optional
- Improve `BlockGenerator` to pass manual synchronizer test

`BlockGenerator` not support mocking transaction data yet, maybe save it for another PR.