### PR TITLE
Problem: (CRO-622) Raw call function of WebsocketRpcClient cannot be accessed from other crates

### DIFF
--- a/client-common/src/tendermint/websocket_rpc_client.rs
+++ b/client-common/src/tendermint/websocket_rpc_client.rs
@@ -215,7 +215,7 @@ impl WebsocketRpcClient {
     }
 
     /// Makes an RPC call and deserializes response
-    fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
+    pub fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
     where
         for<'de> T: Deserialize<'de>,
     {
@@ -232,7 +232,7 @@ impl WebsocketRpcClient {
     }
 
     /// Makes RPC call in batch and deserializes responses
-    fn call_batch<T>(&self, params: Vec<(&str, Vec<Value>)>) -> Result<Vec<T>>
+    pub fn call_batch<T>(&self, params: Vec<(&str, Vec<Value>)>) -> Result<Vec<T>>
     where
         for<'de> T: Deserialize<'de>,
     {


### PR DESCRIPTION
Solution: Made `call` and `call_batch` functions `pub`