### PR TITLE
Problem (CRO-627) council node pubkey format different from tendermint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "sgx_tstd 1.0.9 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.9)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2937,6 +2938,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,6 +3903,8 @@ dependencies = [
 "checksum termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "818ef3700c2a7b447dca1a1dd28341fe635e6ee103c806c636bb9c929991b2cd"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
+"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c1c5676413eaeb1ea35300a0224416f57abc3bd251657e0fafc12c47ff98c060"

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -15,8 +15,7 @@ use chain_core::init::config::InitConfig;
 use chain_core::init::config::InitNetworkParameters;
 use chain_core::init::config::NetworkParameters;
 use chain_core::init::config::{
-    JailingParameters, RewardsParameters, SlashRatio, SlashingParameters, ValidatorKeyType,
-    ValidatorPubkey,
+    JailingParameters, RewardsParameters, SlashRatio, SlashingParameters,
 };
 use chain_core::state::account::{
     to_stake_key, CouncilNode, DepositBondTx, StakedState, StakedStateAddress,
@@ -254,19 +253,14 @@ fn init_chain_for(address: RedeemAddress) -> ChainNodeApp<MockClient> {
     .collect();
     let NetworkParameters::Genesis(params) = get_dummy_network_params();
     let mut nodes = BTreeMap::new();
-    let pub_key_base64 = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=";
-    let node_pubkey = (
-        "test".to_owned(),
-        None,
-        ValidatorPubkey {
-            consensus_pubkey_type: ValidatorKeyType::Ed25519,
-            consensus_pubkey_b64: pub_key_base64.to_string(),
-        },
-    );
+    let pub_key =
+        TendermintValidatorPubKey::from_base64(b"MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+            .unwrap();
+    let node_pubkey = ("test".to_owned(), None, pub_key.clone());
     let validator = ValidatorUpdate {
         pub_key: Some(PubKey {
             field_type: "ed25519".to_owned(),
-            data: base64::decode(&pub_key_base64).unwrap(),
+            data: pub_key.as_bytes().to_vec(),
             ..Default::default()
         })
         .into(),

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -26,6 +26,7 @@ static_assertions = { version = "1.1.0", default-features = false}
 bech32 = { version = "0.7.1", optional = true }
 aead = "0.2"
 fixed = "0.4.6"
+thiserror = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/chain-core/src/init/params.rs
+++ b/chain-core/src/init/params.rs
@@ -10,7 +10,6 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Mul;
-use std::prelude::v1::String;
 use std::str::FromStr;
 
 const MAX_SLASH_RATIO: Milli = Milli::new(1, 0); // 1.0
@@ -291,19 +290,4 @@ impl fmt::Display for SlashRatioError {
             }
         }
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum ValidatorKeyType {
-    Ed25519,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct ValidatorPubkey {
-    // Tendermint consensus public key type
-    pub consensus_pubkey_type: ValidatorKeyType,
-    // Tendermint consensus public key encoded in base64
-    pub consensus_pubkey_b64: String,
 }

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -2,9 +2,10 @@ use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::init::config::{
     InitConfig, InitNetworkParameters, JailingParameters, RewardsParameters, SlashRatio,
-    SlashingParameters, ValidatorKeyType, ValidatorPubkey,
+    SlashingParameters,
 };
 use chain_core::state::account::StakedStateDestination;
+use chain_core::state::tendermint::TendermintValidatorPubKey;
 use chain_core::tx::fee::{LinearFee, Milli};
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -29,10 +30,9 @@ fn test_verify_test_example_snapshot() {
     let node_address = "0x2440ad2533c66d91eb97807a339be13556d04990"
         .parse::<RedeemAddress>()
         .unwrap();
-    let node_pubkey = ValidatorPubkey {
-        consensus_pubkey_type: ValidatorKeyType::Ed25519,
-        consensus_pubkey_b64: "EIosObgfONUsnWCBGRpFlRFq5lSxjGIChRlVrVWVkcE=".to_string(),
-    };
+    let node_pubkey =
+        TendermintValidatorPubKey::from_base64(b"EIosObgfONUsnWCBGRpFlRFq5lSxjGIChRlVrVWVkcE=")
+            .unwrap();
     let mut nodes = BTreeMap::new();
     nodes.insert(node_address, ("no-name".to_owned(), None, node_pubkey));
 

--- a/client-common/src/tendermint/mock.rs
+++ b/client-common/src/tendermint/mock.rs
@@ -81,8 +81,8 @@ const DEFAULT_GENESIS_JSON: &str = r#"{
                 "integration test",
                 "security@integration.test",
                 {
-                    "consensus_pubkey_type": "Ed25519",
-                    "consensus_pubkey_b64": "2H0sZxyy5iOU6q0/F+ZCQ3MyJJxg8odE5NMsGIyfFV0="
+                    "type": "tendermint/PubKeyEd25519",
+                    "value": "2H0sZxyy5iOU6q0/F+ZCQ3MyJJxg8odE5NMsGIyfFV0="
                 }
             ]
         }

--- a/dev-utils/example-dev-conf.json
+++ b/dev-utils/example-dev-conf.json
@@ -27,13 +27,14 @@
         "per_byte_fee": "1.25"
     },
     "council_nodes": {
-            "0x3ae55c16800dc4bd0e3397a9d7806fb1f11639de": [
-                "test",
-                "security@example.com",
-                {
-                "consensus_pubkey_type": "Ed25519",
-                "consensus_pubkey_b64": "pPxJH5wUamXcCvSxgywzmANuO0UNR5x3nCbUzsrCeX8="
-        }]
+        "0x3ae55c16800dc4bd0e3397a9d7806fb1f11639de": [
+            "test",
+            "security@example.com",
+            {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "pPxJH5wUamXcCvSxgywzmANuO0UNR5x3nCbUzsrCeX8="
+            }
+        ]
     },
     "genesis_time": "2019-10-23T07:26:34.783271158Z"
 }

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -5,11 +5,10 @@ use serde::{Deserialize, Serialize};
 use chain_core::init::{
     address::RedeemAddress,
     coin::Coin,
-    config::{
-        JailingParameters, RewardsParameters, SlashRatio, SlashingParameters, ValidatorPubkey,
-    },
+    config::{JailingParameters, RewardsParameters, SlashRatio, SlashingParameters},
 };
 use chain_core::state::account::{ValidatorName, ValidatorSecurityContact};
+use chain_core::state::tendermint::TendermintValidatorPubKey;
 use client_common::tendermint::types::Time;
 
 #[derive(Deserialize, Debug)]
@@ -21,8 +20,14 @@ pub struct GenesisDevConfig {
     pub slashing_config: SlashingParameters,
     pub rewards_config: RewardsParameters,
     pub initial_fee_policy: InitialFeePolicy,
-    pub council_nodes:
-        BTreeMap<RedeemAddress, (ValidatorName, ValidatorSecurityContact, ValidatorPubkey)>,
+    pub council_nodes: BTreeMap<
+        RedeemAddress,
+        (
+            ValidatorName,
+            ValidatorSecurityContact,
+            TendermintValidatorPubKey,
+        ),
+    >,
     pub genesis_time: Time,
 }
 

--- a/integration-tests/fix_genesis.py
+++ b/integration-tests/fix_genesis.py
@@ -18,11 +18,8 @@ def validator_addr(pubkey_base64):
 
 GENESIS['validators'] = [
     {
-        'address': validator_addr(node[2]['consensus_pubkey_b64']),
-        'pub_key': {
-            'type': 'tendermint/PubKeyEd25519',
-            'value': node[2]['consensus_pubkey_b64'],
-        },
+        'address': validator_addr(node[2]['value']),
+        'pub_key': node[2],
         'power': get_voting_power(GENESIS['app_state']['distribution'][addr]),
     }
     for addr, node in GENESIS['app_state']['council_nodes'].items()

--- a/integration-tests/prepare.sh
+++ b/integration-tests/prepare.sh
@@ -197,8 +197,8 @@ DEV_CONF=$(cat << EOF
             "integration test",
             "security@integration.test",
         {
-            "consensus_pubkey_type": "Ed25519",
-            "consensus_pubkey_b64": "{PUB_KEY}"
+            "type": "tendermint/PubKeyEd25519",
+            "value": "{PUB_KEY}"
         }]
     },
     "genesis_time": "{GENESIS_TIME}"

--- a/test-common/src/block_generator.rs
+++ b/test-common/src/block_generator.rs
@@ -53,13 +53,6 @@ fn seed_to_pk(seed: &ed25519::Seed) -> ed25519::PublicKey {
     Ed25519Signer::from(seed).public_key().unwrap()
 }
 
-fn to_validator_pub_key(key: &PublicKey) -> params::ValidatorPubkey {
-    params::ValidatorPubkey {
-        consensus_pubkey_type: params::ValidatorKeyType::Ed25519,
-        consensus_pubkey_b64: String::from_utf8(base64::encode(key.as_bytes())).unwrap(),
-    }
-}
-
 fn coin_to_power(coin: Coin) -> vote::Power {
     vote::Power::new(TendermintVotePower::from(coin).into())
 }
@@ -246,11 +239,7 @@ impl TestnetSpec {
         for node in &self.nodes {
             council_nodes.insert(
                 node.redeem_address(0),
-                (
-                    node.name.clone(),
-                    None,
-                    to_validator_pub_key(&node.validator_pub_key()),
-                ),
+                (node.name.clone(), None, node.tendermint_pub_key()),
             );
         }
 

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -22,14 +22,16 @@ use chain_core::init::address::RedeemAddress;
 use chain_core::init::coin::Coin;
 use chain_core::init::config::{
     InitConfig, InitNetworkParameters, JailingParameters, NetworkParameters, RewardsParameters,
-    SlashRatio, SlashingParameters, ValidatorKeyType, ValidatorPubkey,
+    SlashRatio, SlashingParameters,
 };
 use chain_core::state::account::{
     to_stake_key, CouncilNode, StakedState, StakedStateAddress, StakedStateDestination,
     StakedStateOpAttributes, StakedStateOpWitness, UnbondTx, ValidatorName,
     ValidatorSecurityContact,
 };
-use chain_core::state::tendermint::{TendermintValidatorAddress, TendermintVotePower};
+use chain_core::state::tendermint::{
+    TendermintValidatorAddress, TendermintValidatorPubKey, TendermintVotePower,
+};
 use chain_core::tx::fee::{LinearFee, Milli};
 use chain_core::tx::witness::EcdsaSignature;
 use chain_core::tx::{data::TxId, TransactionId, TxAux};
@@ -38,10 +40,15 @@ const TEST_CHAIN_ID: &str = "test-00";
 
 /// Need to add more seed and validator public keys, if need more validator nodes.
 const SEEDS: [[u8; 32]; 2] = [[0xcd; 32], [0xab; 32]];
-const VALIDATOR_PUB_KEYS: [&str; 2] = [
-    "EIosObgfONUsnWCBGRpFlRFq5lSxjGIChRlVrVWVkcE=",
-    "Vcrw/tEI0JOXw2SZGeowDxw5+Eot8qndCJoh2m6RC/M=",
-];
+lazy_static! {
+    static ref VALIDATOR_PUB_KEYS: Vec<TendermintValidatorPubKey> = [
+        b"EIosObgfONUsnWCBGRpFlRFq5lSxjGIChRlVrVWVkcE=",
+        b"Vcrw/tEI0JOXw2SZGeowDxw5+Eot8qndCJoh2m6RC/M="
+    ]
+    .iter()
+    .map(|s| TendermintValidatorPubKey::from_base64(*s).unwrap())
+    .collect();
+}
 
 pub fn get_account(
     account_address: &StakedStateAddress,
@@ -117,33 +124,38 @@ pub fn get_init_network_params(expansion_cap: Coin) -> InitNetworkParameters {
 
 pub fn get_nodes(
     addresses: &[Account],
-) -> BTreeMap<RedeemAddress, (ValidatorName, ValidatorSecurityContact, ValidatorPubkey)> {
-    let mut nodes = BTreeMap::new();
-
-    for acct in addresses {
-        let node_pubkey = (
-            acct.name.clone(),
-            None,
-            ValidatorPubkey {
-                consensus_pubkey_type: ValidatorKeyType::Ed25519,
-                consensus_pubkey_b64: acct.validator_pub_key.clone(),
-            },
-        );
-        nodes.insert(acct.address, node_pubkey);
-    }
-
-    nodes
+) -> BTreeMap<
+    RedeemAddress,
+    (
+        ValidatorName,
+        ValidatorSecurityContact,
+        TendermintValidatorPubKey,
+    ),
+> {
+    addresses
+        .iter()
+        .map(|acct| {
+            (
+                acct.address,
+                (acct.name.clone(), None, acct.validator_pub_key.clone()),
+            )
+        })
+        .collect()
 }
 
 pub struct Account {
     pub secret_key: SecretKey,
     pub address: RedeemAddress,
-    pub validator_pub_key: String,
+    pub validator_pub_key: TendermintValidatorPubKey,
     pub name: String,
 }
 
 impl Account {
-    pub fn new(seed: &[u8; 32], validator_pub_key: String, name: String) -> Account {
+    pub fn new(
+        seed: &[u8; 32],
+        validator_pub_key: TendermintValidatorPubKey,
+        name: String,
+    ) -> Account {
         let secp = Secp256k1::new();
         let secret_key = SecretKey::from_slice(seed).expect("32 bytes, within curve order");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);
@@ -300,7 +312,7 @@ impl ChainEnv {
             .map(|acct| ValidatorUpdate {
                 pub_key: Some(PubKey {
                     field_type: "ed25519".to_owned(),
-                    data: base64::decode(&acct.validator_pub_key).unwrap(),
+                    data: acct.validator_pub_key.as_bytes().to_vec(),
                     ..Default::default()
                 })
                 .into(),


### PR DESCRIPTION
Solution:
- serialize TendermintValidatorPubKey the same as tendermint.
- Remove ValidatorPubkey in favor of TendermintValidatorPubKey.