### PR TITLE
Problem: tx-query doesn't return cause for invalid transactions (CRO-638 / CRO-336)

### DIFF
--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -48,7 +48,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                 Ok(EncryptionRequest::TransferTx(tx, witness)) => {
                     let plain = PlainTxAux::TransferTx(tx.clone(), witness);
                     let mock = EncryptionResponse {
-                        tx: TxEnclaveAux::TransferTx {
+                        resp: Ok(TxEnclaveAux::TransferTx {
                             inputs: tx.inputs.clone(),
                             no_of_outputs: tx.outputs.len() as TxoIndex,
                             payload: TxObfuscated {
@@ -57,14 +57,14 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                                 init_vector: [0u8; 12],
                                 txpayload: plain.encode(),
                             },
-                        },
+                        }),
                     };
                     resp.value = mock.encode();
                 }
                 Ok(EncryptionRequest::DepositStake(maintx, witness)) => {
                     let plain = PlainTxAux::DepositStakeTx(witness);
                     let mock = EncryptionResponse {
-                        tx: TxEnclaveAux::DepositStakeTx {
+                        resp: Ok(TxEnclaveAux::DepositStakeTx {
                             tx: maintx.clone(),
                             payload: TxObfuscated {
                                 key_from: 0,
@@ -72,14 +72,14 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                                 init_vector: [0u8; 12],
                                 txpayload: plain.encode(),
                             },
-                        },
+                        }),
                     };
                     resp.value = mock.encode();
                 }
                 Ok(EncryptionRequest::WithdrawStake(tx, _, witness)) => {
                     let plain = PlainTxAux::WithdrawUnbondedStakeTx(tx.clone());
                     let mock = EncryptionResponse {
-                        tx: TxEnclaveAux::WithdrawUnbondedStakeTx {
+                        resp: Ok(TxEnclaveAux::WithdrawUnbondedStakeTx {
                             no_of_outputs: tx.outputs.len() as TxoIndex,
                             witness,
                             payload: TxObfuscated {
@@ -88,7 +88,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                                 init_vector: [0u8; 12],
                                 txpayload: plain.encode(),
                             },
-                        },
+                        }),
                     };
                     resp.value = mock.encode();
                 }

--- a/client-core/src/cipher/default.rs
+++ b/client-core/src/cipher/default.rs
@@ -199,7 +199,13 @@ impl TransactionObfuscation for DefaultTransactionObfuscation {
                             "Unable to deserialize encryption response from enclave",
                         )
                     })?
-                    .tx;
+                    .resp
+                    .map_err(|e| {
+                        Error::new(
+                            ErrorKind::InvalidInput,
+                            format!("Invalid transaction was submitted: {}", e),
+                        )
+                    })?;
                 Ok(TxAux::EnclaveTx(tx))
             }
             Err(_) => Err(Error::new(

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -234,10 +234,9 @@ impl Decode for EncryptionRequest {
 }
 
 /// Response from TQE
-/// TODO: validation error?
 #[derive(Encode, Decode)]
 pub struct EncryptionResponse {
-    pub tx: TxEnclaveAux,
+    pub resp: Result<TxEnclaveAux, chain_tx_validation::Error>,
 }
 
 /// Request in direct communication (over one-side attested TLS) to TQE


### PR DESCRIPTION
Solution: changed the enclave protocol response to return result and the tx-query implementation
to return that instead of closing the connection in that case