### PR TITLE
Problem: complex feature-guarding of chain-core (CRO-628)

### DIFF
--- a/chain-core/src/init/address.rs
+++ b/chain-core/src/init/address.rs
@@ -11,31 +11,31 @@
 //!   These 20 bytes are the address.
 //!
 //! [Recommended Read](https://kobl.one/blog/create-full-ethereum-keypair-and-address/)
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use bech32::{self, u5, FromBase32, ToBase32};
 use parity_scale_codec::{Decode, Encode};
 use std::ops;
 use std::prelude::v1::String;
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::str::FromStr;
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use hex;
 use secp256k1::key::PublicKey;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de::Error;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
 use tiny_keccak::{Hasher, Keccak};
 
 use crate::common::{H256, HASH_SIZE_256};
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::network::{get_bech32_human_part_from_network, Network};
 
 #[derive(Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub enum CroAddressError {
     // TODO: use directly bech32::Error or wrap it
     Bech32Error(String),
@@ -43,13 +43,13 @@ pub enum CroAddressError {
     ConvertError,
 }
 
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl ::std::error::Error for CroAddressError {}
 
 // CRO: mainnet transfer
 // TCRO: testnet transfer
 // DCRO: devnet/regnet transfer
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 pub trait CroAddress<T> {
     fn to_cro(&self, network: Network) -> Result<String, CroAddressError>;
     fn from_cro(encoded: &str, network: Network) -> Result<T, CroAddressError>;
@@ -85,7 +85,7 @@ where
 
 /// Core domain logic errors
 #[derive(Debug)]
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 pub enum ErrorAddress {
     /// An invalid length
     InvalidLength(usize),
@@ -103,21 +103,21 @@ pub enum ErrorAddress {
     InvalidCroAddress,
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl From<hex::FromHexError> for ErrorAddress {
     fn from(err: hex::FromHexError) -> Self {
         ErrorAddress::UnexpectedHexEncoding(err)
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl From<secp256k1::Error> for ErrorAddress {
     fn from(err: secp256k1::Error) -> Self {
         ErrorAddress::EcdsaCrypto(err)
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for ErrorAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -134,7 +134,7 @@ impl fmt::Display for ErrorAddress {
     }
 }
 
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for CroAddressError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -145,7 +145,7 @@ impl fmt::Display for CroAddressError {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl std::error::Error for ErrorAddress {
     fn description(&self) -> &str {
         "Core error"
@@ -167,10 +167,10 @@ pub type RedeemAddressRaw = [u8; REDEEM_ADDRESS_BYTES];
 
 /// Eth-style Account address (20 bytes)
 #[derive(Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
-#[cfg_attr(not(feature = "hex"), derive(Debug))]
+#[cfg_attr(feature = "mesalock_sgx", derive(Debug))]
 pub struct RedeemAddress(pub RedeemAddressRaw);
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl RedeemAddress {
     /// Try to convert a byte vector to `RedeemAddress`.
     ///
@@ -187,7 +187,7 @@ impl RedeemAddress {
     }
 }
 
-#[cfg(all(feature = "bech32", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl CroAddress<RedeemAddress> for RedeemAddress {
     fn to_cro(&self, network: Network) -> Result<String, CroAddressError> {
         let checked_data: Vec<u5> = self.0.to_vec().to_base32();
@@ -231,7 +231,7 @@ impl From<[u8; REDEEM_ADDRESS_BYTES]> for RedeemAddress {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl FromStr for RedeemAddress {
     type Err = ErrorAddress;
 
@@ -250,21 +250,21 @@ impl FromStr for RedeemAddress {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for RedeemAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "0x{}", hex::encode(self.0))
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Debug for RedeemAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(0x{}", hex::encode(self.0))
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl Serialize for RedeemAddress {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -274,7 +274,7 @@ impl Serialize for RedeemAddress {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl<'de> Deserialize<'de> for RedeemAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/chain-core/src/init/coin.rs
+++ b/chain-core/src/init/coin.rs
@@ -3,16 +3,16 @@
 //! Copyright (c) 2018, Input Output HK (licensed under the MIT License)
 //! Modifications Copyright (c) 2018 - 2019, Foris Limited (licensed under the Apache License, Version 2.0)
 
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::config::SlashRatio;
 use crate::init::{MAX_COIN, MAX_COIN_DECIMALS, MAX_COIN_UNITS};
 use crate::state::tendermint::TendermintVotePower;
 use crate::state::tendermint::TENDERMINT_MAX_VOTE_POWER;
 use parity_scale_codec::{Decode, Encode, Error as ScaleError, Input};
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de::{Deserializer, Error, Visitor};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize, Serializer};
 
 use static_assertions::const_assert;
@@ -39,7 +39,7 @@ pub enum CoinError {
     Overflow,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl Serialize for Coin {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -50,7 +50,7 @@ impl Serialize for Coin {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl<'de> Deserialize<'de> for Coin {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -239,7 +239,7 @@ impl ops::Rem<u64> for Coin {
     }
 }
 
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl ops::Mul<SlashRatio> for Coin {
     type Output = Self;
 

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -9,7 +9,7 @@ use crate::state::account::{
 };
 use crate::state::tendermint::{TendermintValidatorPubKey, TendermintVotePower};
 use crate::state::RewardsPoolState;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
@@ -73,7 +73,7 @@ impl fmt::Display for DistributionError {
 /// Initial configuration ("app_state" in genesis.json of Tendermint config)
 /// TODO: reward/treasury config, extra validator config...
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct InitConfig {
     // Redeem mapping of ERC20 snapshot: Eth address => (StakedStateDestination,CRO tokens)
     // (doesn't include the rewards pool amount)

--- a/chain-core/src/init/mod.rs
+++ b/chain-core/src/init/mod.rs
@@ -6,11 +6,11 @@ pub mod address;
 /// Fixed supply coin/amounts
 pub mod coin;
 /// Configuration in JSON passed to InitChain
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 pub mod config;
 
 /// Network static configuration
-#[cfg(all(feature = "bech32", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 pub mod network;
 
 /// Network parameters

--- a/chain-core/src/init/params.rs
+++ b/chain-core/src/init/params.rs
@@ -5,7 +5,7 @@ use crate::tx::fee::{Fee, FeeAlgorithm};
 use crate::tx::fee::{LinearFee, Milli, MilliError};
 use blake2::Blake2s;
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::fmt;
@@ -15,7 +15,7 @@ use std::str::FromStr;
 const MAX_SLASH_RATIO: Milli = Milli::new(1, 0); // 1.0
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct InitNetworkParameters {
     /// Initial fee setting
     /// -- TODO: perhaps change to be against T: FeeAlgorithm
@@ -36,7 +36,7 @@ pub struct InitNetworkParameters {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub enum NetworkParameters {
     /// parameters specified at genesis time
     Genesis(InitNetworkParameters),
@@ -147,7 +147,7 @@ impl NetworkParameters {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct JailingParameters {
     /// Minimum jailing time for punished accounts (in seconds)
     pub jail_duration: u32,
@@ -159,7 +159,7 @@ pub struct JailingParameters {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct SlashingParameters {
     /// Percentage of funds (bonded + unbonded) slashed when validator is not live (liveness is calculated by jailing
     /// parameters)
@@ -171,7 +171,7 @@ pub struct SlashingParameters {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct RewardsParameters {
     /// Maximum monetary expansion for rewards.
     pub monetary_expansion_cap: Coin,
@@ -249,7 +249,7 @@ impl fmt::Display for SlashRatio {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl Serialize for SlashRatio {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -259,7 +259,7 @@ impl Serialize for SlashRatio {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl<'de> Deserialize<'de> for SlashRatio {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -1,7 +1,7 @@
 use crate::common::{hash256, Timespec, HASH_SIZE_256};
 use crate::init::address::RedeemAddress;
 use crate::init::coin::{sum_coins, Coin, CoinError};
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::config::SlashRatio;
 use crate::tx::data::attribute::TxAttributes;
 use crate::tx::data::input::TxoPointer;
@@ -10,22 +10,22 @@ use crate::tx::witness::{tree::RawSignature, EcdsaSignature};
 use crate::tx::TransactionId;
 use blake2::Blake2s;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::prelude::v1::Vec;
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::str::FromStr;
 // TODO: switch to normal signatures + explicit public key
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::address::ErrorAddress;
 use crate::state::tendermint::{TendermintValidatorPubKey, TendermintVotePower};
 use secp256k1::recovery::{RecoverableSignature, RecoveryId};
 use std::convert::From;
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::convert::TryFrom;
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
 use std::prelude::v1::{String, ToString};
 
@@ -47,7 +47,7 @@ pub enum StakedStateAddress {
     BasicRedeem(RedeemAddress),
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl Serialize for StakedStateAddress {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -57,7 +57,7 @@ impl Serialize for StakedStateAddress {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl<'de> Deserialize<'de> for StakedStateAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -86,7 +86,7 @@ impl<'de> Deserialize<'de> for StakedStateAddress {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl TryFrom<&[u8]> for StakedStateAddress {
     type Error = ErrorAddress;
 
@@ -102,7 +102,7 @@ impl From<RedeemAddress> for StakedStateAddress {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for StakedStateAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -111,7 +111,7 @@ impl fmt::Display for StakedStateAddress {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl FromStr for StakedStateAddress {
     type Err = ErrorAddress;
 
@@ -126,7 +126,7 @@ pub type ValidatorSecurityContact = Option<String>;
 /// holds state about a node responsible for transaction validation / block signing and service node whitelist management
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
+    not(feature = "mesalock_sgx"),
     derive(Serialize, Deserialize)
 )]
 pub struct CouncilNode {
@@ -204,7 +204,10 @@ impl CouncilNode {
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(all(feature = "serde", feature = "hex"), derive(Serialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize)
+)]
 /// Metadata of a validator
 pub struct CouncilNodeMetadata {
     /// Name of validator
@@ -222,15 +225,15 @@ pub struct CouncilNodeMetadata {
 /// Types of possible punishments
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
-    derive(Deserialize, Serialize)
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
 )]
 pub enum PunishmentKind {
     NonLive,
     ByzantineFault,
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for PunishmentKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -243,8 +246,8 @@ impl fmt::Display for PunishmentKind {
 /// Details of a punishment for a staked state
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
-    derive(Deserialize, Serialize)
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
 )]
 pub struct Punishment {
     pub kind: PunishmentKind,
@@ -252,7 +255,7 @@ pub struct Punishment {
     pub slash_amount: Option<Coin>,
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for CouncilNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} -- {}", self.name, self.consensus_pubkey)
@@ -262,8 +265,8 @@ impl fmt::Display for CouncilNode {
 /// represents the StakedState (account involved in staking)
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
-    derive(Deserialize, Serialize)
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
 )]
 pub struct StakedState {
     pub nonce: Nonce,
@@ -416,7 +419,8 @@ impl StakedState {
     }
 
     /// Slashes current account with given ratio and returns slashed amount
-    #[cfg(feature = "base64")]
+    /// TODO: previously this required base64, not sure why? check if this needs to be guarded, or it was a mistake
+    #[cfg(not(feature = "mesalock_sgx"))]
     pub fn slash(
         &mut self,
         slash_ratio: SlashRatio,
@@ -448,7 +452,10 @@ impl StakedState {
 
 /// attributes in StakedState-related transactions
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub struct StakedStateOpAttributes {
     pub chain_hex_id: u8,
     // TODO: Other attributes?
@@ -462,7 +469,10 @@ impl StakedStateOpAttributes {
 
 /// bond status for StakedState initialize
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub enum StakedStateDestination {
     Bonded,
     UnbondedFromGenesis,
@@ -473,7 +483,7 @@ pub enum StakedStateDestination {
 /// (updates StakedState's bonded + nonce)
 #[derive(Debug, PartialEq, Eq, Clone, Encode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
+    not(feature = "mesalock_sgx"),
     derive(Serialize, Deserialize)
 )]
 pub struct DepositBondTx {
@@ -520,7 +530,7 @@ impl DepositBondTx {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for DepositBondTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for input in self.inputs.iter() {
@@ -534,7 +544,10 @@ impl fmt::Display for DepositBondTx {
 /// updates the StakedState (TODO: implicit from the witness?) by moving some of the bonded amount - fee into unbonded,
 /// and setting the unbonded_from to last_block_time+min_unbonding_time (network parameter)
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub struct UnbondTx {
     pub from_staked_account: StakedStateAddress,
     pub nonce: Nonce,
@@ -560,7 +573,7 @@ impl UnbondTx {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for UnbondTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
@@ -576,7 +589,7 @@ impl fmt::Display for UnbondTx {
 /// (update's StakedState's unbonded + nonce)
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
+    not(feature = "mesalock_sgx"),
     derive(Serialize, Deserialize)
 )]
 pub struct WithdrawUnbondedTx {
@@ -604,7 +617,7 @@ impl WithdrawUnbondedTx {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for WithdrawUnbondedTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "-> (unbonded) (nonce: {})", self.nonce)?;
@@ -617,7 +630,10 @@ impl fmt::Display for WithdrawUnbondedTx {
 
 /// Unjails an account
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub struct UnjailTx {
     pub nonce: Nonce,
     pub address: StakedStateAddress,
@@ -641,7 +657,7 @@ impl UnjailTx {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for UnjailTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "unjailed: {} (nonce: {})", self.address, self.nonce)?;
@@ -651,7 +667,10 @@ impl fmt::Display for UnjailTx {
 
 /// A witness for StakedState operations
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub enum StakedStateOpWitness {
     BasicRedeem(EcdsaSignature),
 }

--- a/chain-core/src/state/mod.rs
+++ b/chain-core/src/state/mod.rs
@@ -7,7 +7,7 @@ pub mod validator;
 
 use blake2::Blake2s;
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize};
 use std::prelude::v1::Vec;
 
@@ -20,7 +20,10 @@ use crate::tx::data::TxId;
 
 /// ABCI chain state
 #[derive(PartialEq, Debug, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub struct ChainState {
     /// root hash of the sparse merkle patricia trie of staking account states
     pub account_root: H256,
@@ -42,7 +45,10 @@ impl ChainState {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "mesalock_sgx"),
+    derive(Serialize, Deserialize)
+)]
 pub struct RewardsPoolState {
     /// Rewards accumulated in current period
     pub period_bonus: Coin,

--- a/chain-core/src/state/tendermint.rs
+++ b/chain-core/src/state/tendermint.rs
@@ -1,5 +1,5 @@
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{
     de::{self, Error as _, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 use std::convert::TryFrom;
 use std::fmt;
 use std::prelude::v1::{String, ToString, Vec};
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use thiserror::Error;
 
 /// Tendermint block height
@@ -22,11 +22,11 @@ pub const PUBLIC_KEY_SIZE: usize = 32;
 /// and variable length byte array. In this internal representation,
 /// it's desirable to keep it restricted and compact. (TM should be encoding using the compressed form.)
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type", content = "value"))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), serde(tag = "type", content = "value"))]
 pub enum TendermintValidatorPubKey {
     #[cfg_attr(
-        feature = "serde",
+        not(feature = "mesalock_sgx"),
         serde(
             rename = "tendermint/PubKeyEd25519",
             serialize_with = "serialize_ed25519_base64",
@@ -42,7 +42,7 @@ pub enum TendermintValidatorPubKey {
 }
 
 /// Serialize the bytes of an Ed25519 public key as Base64. Used for serializing JSON
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn serialize_ed25519_base64<S>(pk: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -50,7 +50,7 @@ where
     base64::encode(pk).serialize(serializer)
 }
 
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn deserialize_ed25519_base64<'de, D>(deserializer: D) -> Result<[u8; PUBLIC_KEY_SIZE], D::Error>
 where
     D: Deserializer<'de>,
@@ -60,7 +60,7 @@ where
         .map_err(|e| D::Error::custom(format!("{}", e)))
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for TendermintValidatorPubKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -69,7 +69,7 @@ impl fmt::Display for TendermintValidatorPubKey {
     }
 }
 
-#[cfg(feature = "base64")]
+#[cfg(not(feature = "mesalock_sgx"))]
 #[derive(Error, Debug)]
 pub enum PubKeyDecodeError {
     #[error("Base64 decode error")]
@@ -79,7 +79,7 @@ pub enum PubKeyDecodeError {
 }
 
 impl TendermintValidatorPubKey {
-    #[cfg(feature = "base64")]
+    #[cfg(not(feature = "mesalock_sgx"))]
     pub fn from_base64(input: &[u8]) -> Result<TendermintValidatorPubKey, PubKeyDecodeError> {
         let bytes = base64::decode(input)?;
         if bytes.len() != PUBLIC_KEY_SIZE {
@@ -115,7 +115,7 @@ impl From<&TendermintValidatorAddress> for [u8; 20] {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl Serialize for TendermintValidatorAddress {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -125,7 +125,7 @@ impl Serialize for TendermintValidatorAddress {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl<'de> Deserialize<'de> for TendermintValidatorAddress {
     fn deserialize<D>(deserializer: D) -> Result<TendermintValidatorAddress, D::Error>
     where
@@ -154,7 +154,7 @@ impl<'de> Deserialize<'de> for TendermintValidatorAddress {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for TendermintValidatorAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(&self.0))
@@ -235,7 +235,7 @@ pub const TENDERMINT_MAX_VOTE_POWER: i64 = std::i64::MAX / 1000;
 
 /// Tendermint consensus voting power
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct TendermintVotePower(i64);
 
 impl From<TendermintVotePower> for i64 {

--- a/chain-core/src/state/validator.rs
+++ b/chain-core/src/state/validator.rs
@@ -1,9 +1,9 @@
 use crate::state::account::{CouncilNode, Nonce, StakedStateAddress, StakedStateOpAttributes};
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
 
 /// Submits a proposal to add a council node:
@@ -17,7 +17,7 @@ use std::fmt;
 /// - the bonded amount in the stake state is more than the minimal required one
 /// - the witness is correct
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct NodeJoinRequestTx {
     pub nonce: Nonce,
     pub address: StakedStateAddress,
@@ -44,7 +44,7 @@ impl NodeJoinRequestTx {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for NodeJoinRequestTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(

--- a/chain-core/src/tx/data/access.rs
+++ b/chain-core/src/tx/data/access.rs
@@ -1,13 +1,13 @@
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::str::FromStr;
 
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 use secp256k1::key::PublicKey;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::common::H264;
@@ -15,7 +15,7 @@ use crate::common::H264;
 /// What can be access in TX -- TODO: revisit when enforced by HW encryption / enclaves
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub enum TxAccess {
     AllData,
     // TODO: u16 and Vec size check in Decode implementation
@@ -32,15 +32,15 @@ impl Default for TxAccess {
 
 /// Specifies who can access what -- TODO: revisit when enforced by HW encryption / enclaves
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct TxAccessPolicy {
-    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_view_key"))]
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_view_key"))]
+    #[cfg_attr(not(feature = "mesalock_sgx"), serde(serialize_with = "serialize_view_key"))]
+    #[cfg_attr(not(feature = "mesalock_sgx"), serde(deserialize_with = "deserialize_view_key"))]
     pub view_key: PublicKey,
     pub access: TxAccess,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn serialize_view_key<S>(
     view_key: &PublicKey,
     serializer: S,
@@ -52,7 +52,7 @@ where
     serializer.serialize_str(&view_key_string)
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn deserialize_view_key<'de, D>(deserializer: D) -> std::result::Result<PublicKey, D::Error>
 where
     D: Deserializer<'de>,

--- a/chain-core/src/tx/data/address.rs
+++ b/chain-core/src/tx/data/address.rs
@@ -1,18 +1,18 @@
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::str::FromStr;
 
 use crate::common::H256;
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::address::{CroAddress, CroAddressError};
-#[cfg(feature = "bech32")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use bech32::{self, u5, FromBase32, ToBase32};
 
-#[cfg(all(feature = "bech32", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::network::{get_bech32_human_part_from_network, get_network, Network};
 
 /// TODO: opaque types?
@@ -22,12 +22,12 @@ type TreeRoot = H256;
 /// TODO: HD-addresses?
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub enum ExtendedAddr {
     OrTree(TreeRoot),
 }
 
-#[cfg(all(feature = "bech32", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl CroAddress<ExtendedAddr> for ExtendedAddr {
     fn to_cro(&self, network: Network) -> Result<String, CroAddressError> {
         match self {
@@ -59,14 +59,14 @@ impl CroAddress<ExtendedAddr> for ExtendedAddr {
     }
 }
 
-#[cfg(all(feature = "bech32", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for ExtendedAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_cro(get_network()).unwrap())
     }
 }
 
-#[cfg(all(feature = "bech32", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl FromStr for ExtendedAddr {
     type Err = CroAddressError;
 

--- a/chain-core/src/tx/data/attribute.rs
+++ b/chain-core/src/tx/data/attribute.rs
@@ -1,9 +1,9 @@
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
 use std::prelude::v1::Vec;
 
@@ -11,14 +11,14 @@ use crate::tx::data::access::TxAccessPolicy;
 
 /// Tx extra metadata, e.g. network ID
 #[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct TxAttributes {
     #[cfg_attr(
-        all(feature = "serde", feature = "hex"),
+        not(feature = "mesalock_sgx"),
         serde(serialize_with = "serialize_chain_hex_id")
     )]
     #[cfg_attr(
-        all(feature = "serde", feature = "hex"),
+        not(feature = "mesalock_sgx"),
         serde(deserialize_with = "deserialize_chain_hex_id")
     )]
     pub chain_hex_id: u8,
@@ -26,7 +26,7 @@ pub struct TxAttributes {
     // TODO: other attributes, e.g. versioning info
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn serialize_chain_hex_id<S>(
     chain_hex_id: &u8,
@@ -38,7 +38,7 @@ where
     serializer.serialize_str(&hex::encode_upper(vec![*chain_hex_id]))
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn deserialize_chain_hex_id<'de, D>(deserializer: D) -> std::result::Result<u8, D::Error>
 where
     D: Deserializer<'de>,

--- a/chain-core/src/tx/data/input.rs
+++ b/chain-core/src/tx/data/input.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::tx::data::TxId;
@@ -16,16 +16,16 @@ pub type TxoIndex = u16;
 /// transaction.
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Encode, Decode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
+    not(feature = "mesalock_sgx"),
     derive(Serialize, Deserialize)
 )]
 pub struct TxoPointer {
     #[cfg_attr(
-        all(feature = "serde", feature = "hex"),
+        not(feature = "mesalock_sgx"),
         serde(serialize_with = "serialize_transaction_id")
     )]
     #[cfg_attr(
-        all(feature = "serde", feature = "hex"),
+        not(feature = "mesalock_sgx"),
         serde(deserialize_with = "deserialize_transaction_id")
     )]
     pub id: TxId,
@@ -33,7 +33,7 @@ pub struct TxoPointer {
     pub index: TxoIndex,
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn serialize_transaction_id<S>(
     transaction_id: &TxId,
     serializer: S,
@@ -44,7 +44,7 @@ where
     serializer.serialize_str(&hex::encode(transaction_id))
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn deserialize_transaction_id<'de, D>(deserializer: D) -> std::result::Result<TxId, D::Error>
 where
     D: Deserializer<'de>,

--- a/chain-core/src/tx/data/mod.rs
+++ b/chain-core/src/tx/data/mod.rs
@@ -11,12 +11,12 @@ pub mod input;
 /// Transaction outputs (amount to an address)
 pub mod output;
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
 
 use blake2::Blake2s;
 use parity_scale_codec::{Decode, Encode, Error, Input};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize};
 
 use crate::common::{hash256, H256};
@@ -49,7 +49,7 @@ pub type TxId = H256;
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 #[derive(Debug, Default, PartialEq, Eq, Clone, Encode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
+    not(feature = "mesalock_sgx"),
     derive(Serialize, Deserialize)
 )]
 pub struct Tx {
@@ -80,7 +80,7 @@ impl Decode for Tx {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for Tx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for input in self.inputs.iter() {

--- a/chain-core/src/tx/data/output.rs
+++ b/chain-core/src/tx/data/output.rs
@@ -1,12 +1,12 @@
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::str::FromStr;
 
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::de;
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::common::Timespec;
@@ -17,16 +17,16 @@ use crate::tx::data::address::ExtendedAddr;
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(
-    all(feature = "serde", feature = "hex"),
+    not(feature = "mesalock_sgx"),
     derive(Serialize, Deserialize)
 )]
 pub struct TxOut {
     #[cfg_attr(
-        all(feature = "serde", feature = "hex"),
+        not(feature = "mesalock_sgx"),
         serde(serialize_with = "serialize_address")
     )]
     #[cfg_attr(
-        all(feature = "serde", feature = "hex"),
+        not(feature = "mesalock_sgx"),
         serde(deserialize_with = "deserialize_address")
     )]
     pub address: ExtendedAddr,
@@ -34,7 +34,7 @@ pub struct TxOut {
     pub valid_from: Option<Timespec>,
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn serialize_address<S>(
     address: &ExtendedAddr,
     serializer: S,
@@ -45,7 +45,7 @@ where
     serializer.serialize_str(&address.to_string())
 }
 
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn deserialize_address<'de, D>(deserializer: D) -> std::result::Result<ExtendedAddr, D::Error>
 where
     D: Deserializer<'de>,
@@ -71,7 +71,7 @@ where
     deserializer.deserialize_str(StrVisitor)
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for TxOut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} -> {}", self.address, self.value)

--- a/chain-core/src/tx/fee/mod.rs
+++ b/chain-core/src/tx/fee/mod.rs
@@ -6,7 +6,7 @@
 use crate::init::coin::{Coin, CoinError};
 use crate::tx::TxAux;
 use parity_scale_codec::{Decode, Encode};
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Serialize};
 use std::num::ParseIntError;
 use std::ops::{Add, Div, Mul};
@@ -33,8 +33,8 @@ impl Fee {
 /// [profile.release]
 /// overflow-checks = true
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Encode, Decode)]
-#[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), serde(transparent))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct Milli(u64);
 
 impl Milli {
@@ -202,7 +202,7 @@ impl Div for Milli {
 
 /// Linear fee using the basic affine formula `COEFFICIENT * scale_bytes(txaux).len() + CONSTANT`
 #[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct LinearFee {
     /// this is the minimal fee
     pub constant: Milli,

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -7,7 +7,7 @@ pub mod fee;
 /// Witness structures (e.g. signatures) for transactions
 pub mod witness;
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 use std::fmt;
 
 use parity_scale_codec::{Decode, Encode, Error, Input};
@@ -71,7 +71,7 @@ impl PlainTxAux {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for PlainTxAux {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -246,7 +246,7 @@ impl TxAux {
     }
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 fn display_tx_witness<T: fmt::Display, W: fmt::Debug>(
     f: &mut fmt::Formatter<'_>,
     tx: T,
@@ -256,7 +256,7 @@ fn display_tx_witness<T: fmt::Display, W: fmt::Debug>(
     writeln!(f, "witness: {:?}\n", witness)
 }
 
-#[cfg(feature = "hex")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl fmt::Display for TxAux {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/chain-core/src/tx/witness/tree.rs
+++ b/chain-core/src/tx/witness/tree.rs
@@ -10,14 +10,14 @@ use crate::common::{H264, H512};
 #[derive(Clone, Encode, Decode)]
 pub struct RawPubkey(H264);
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl ::serde::Serialize for RawPubkey {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_bytes(&self.0)
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(not(feature = "mesalock_sgx"))]
 impl<'de> ::serde::Deserialize<'de> for RawPubkey {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<RawPubkey, D::Error> {
         use serde::de::Error;


### PR DESCRIPTION
Solution: simplified feature guards to be just a switch on "mesalock_sgx"
instead of various combinations of required crates, as the feature guarding
is only needed for reduced dependencies in the enclave compilation