### PR TITLE
Problem: integration tests occasionally fail due to tx-query not started

### DIFF
--- a/chain-tx-enclave/tx-query/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-query/app/src/test/mod.rs
@@ -98,12 +98,12 @@ pub fn test_integration() {
     let t = thread::spawn(move || {
         info!("Trying to launch TX Query server...");
         let enclave = start_enclave();
-        tx.send(()).expect("Could not send signal on channel.");
         info!("Running TX Query server...");
 
         let listener = TcpListener::bind(query_server_addr).expect("failed to bind the TCP socket");
 
         for _ in 0..3 {
+            tx.send(()).expect("Could not send signal on channel.");
             match listener.accept() {
                 Ok((stream, addr)) => {
                     info!("new client: {:?}", addr);
@@ -174,7 +174,7 @@ pub fn test_integration() {
                 fail_exit(&mut validation);
             }
         }
-        rx.recv().expect("Could not receive from channel.");
+        rx.recv().expect("Could not receive from channel. 1");
         let c = DefaultTransactionObfuscation::new(
             format!("localhost:{}", query_server_port),
             "localhost".to_owned(),
@@ -238,8 +238,7 @@ pub fn test_integration() {
             }
         }
 
-        thread::sleep(time::Duration::from_secs(10));
-
+        rx.recv().expect("Could not receive from channel. 2");
         let txids = vec![*txid];
         let r1 = c.decrypt(
             txids.as_slice(),
@@ -255,6 +254,7 @@ pub fn test_integration() {
                 fail_exit(&mut validation);
             }
         }
+        rx.recv().expect("Could not receive from channel. 3");
         let r2 = c.decrypt(txids.as_slice(), &PrivateKey::new().expect("random key"));
         match r2 {
             Ok(v) => {

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       TX_VALIDATION_CONN: tcp://chain-tx-enclave:25933
   client-rpc:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
-    command: /usr/bin/wait-for-it.sh tendermint:26657 --timeout=60 --strict -- /usr/bin/client-rpc --host=0.0.0.0 --port=26659 --chain-id=${CHAIN_ID} --storage-dir=/.storage --websocket-url=ws://tendermint:26657/websocket
+    command: /usr/bin/wait-for-it.sh chain-tx-query-enclave:25944 --timeout=60 -- /usr/bin/client-rpc --host=0.0.0.0 --port=26659 --chain-id=${CHAIN_ID} --storage-dir=/.storage --websocket-url=ws://tendermint:26657/websocket
     volumes:
       - "./${WALLET_STORAGE_WITHFEE_DIRECTORY}:/.storage"
     environment:
@@ -88,7 +88,7 @@ services:
       TX_VALIDATION_CONN: tcp://chain-tx-enclave-zerofee:25933
   client-rpc-zerofee:
     image: "${CHAIN_DOCKER_IMAGE:-integration-tests-chain}"
-    command: /usr/bin/wait-for-it.sh tendermint-zerofee:26657 --timeout=60 --strict -- /usr/bin/client-rpc --host=0.0.0.0 --port=26659 --chain-id=${CHAIN_ID} --storage-dir=/.storage --websocket-url=ws://tendermint-zerofee:26657/websocket
+    command: /usr/bin/wait-for-it.sh chain-tx-query-enclave-zerofee:25944 --timeout=60 --strict -- /usr/bin/client-rpc --host=0.0.0.0 --port=26659 --chain-id=${CHAIN_ID} --storage-dir=/.storage --websocket-url=ws://tendermint-zerofee:26657/websocket
     volumes:
       - "./${WALLET_STORAGE_ZEROFEE_DIRECTORY}:/.storage"
     environment:


### PR DESCRIPTION
Solution: changed wait-for-it in docker compose to tx-query, as that may take the longest time to start up