### PR TITLE
Problem: (CRO-635) Transaction builder is not Node.js lib friendly

### DIFF
--- a/client-core/src/cipher/default.rs
+++ b/client-core/src/cipher/default.rs
@@ -70,6 +70,11 @@ impl DefaultTransactionObfuscation {
                 "Unable to decode txquery address",
             )
         })?;
+        DefaultTransactionObfuscation::from_tx_query_address(&address)
+    }
+
+    /// Get DefaultTransactionObfuscation from tx query address
+    pub fn from_tx_query_address(address: &str) -> Result<DefaultTransactionObfuscation> {
         if let Some(hostname) = address.split(':').next() {
             Ok(DefaultTransactionObfuscation::new(
                 address.to_string(),

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -97,8 +97,8 @@ where
         }
     }
 
-    ///  Create a `DummySigner` which signs a transaction with dummy values for fees calculation.
-    /// Returns a result of fees , `Tx` and selected unspent transactions
+    /// Create a `DummySigner` which signs a transaction with dummy values for fees calculation.
+    /// Returns a result of unsigned raw transfer transaction builder
     pub fn select_and_build<'a>(
         &self,
         unspent_transactions: &'a UnspentTransactions,

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -149,10 +149,8 @@ where
         change_amount: Coin,
         attributes: TxAttributes,
     ) -> RawTransferTransactionBuilder<F> {
-        let mut raw_tx_builder = RawTransferTransactionBuilder::new(
-            attributes,
-            self.fee_algorithm.clone(),
-        );
+        let mut raw_tx_builder =
+            RawTransferTransactionBuilder::new(attributes, self.fee_algorithm.clone());
         for input in selected_unspent_transactions.iter() {
             raw_tx_builder.add_input(input.clone());
         }

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -66,7 +66,7 @@ where
 
         raw_builder.sign_all(signer)?;
 
-        let tx_aux = raw_builder.to_tx_aux()?;
+        let tx_aux = raw_builder.to_tx_aux(self.transaction_obfuscation.clone())?;
 
         Ok(tx_aux)
     }
@@ -105,7 +105,7 @@ where
         outputs: Vec<TxOut>,
         return_address: ExtendedAddr,
         attributes: TxAttributes,
-    ) -> Result<RawTransferTransactionBuilder<F, O>> {
+    ) -> Result<RawTransferTransactionBuilder<F>> {
         let output_value = sum_coins(outputs.iter().map(|output| output.value)).chain(|| {
             (
                 ErrorKind::IllegalInput,
@@ -148,11 +148,10 @@ where
         return_address: ExtendedAddr,
         change_amount: Coin,
         attributes: TxAttributes,
-    ) -> RawTransferTransactionBuilder<F, O> {
+    ) -> RawTransferTransactionBuilder<F> {
         let mut raw_tx_builder = RawTransferTransactionBuilder::new(
             attributes,
             self.fee_algorithm.clone(),
-            self.transaction_obfuscation.clone(),
         );
         for input in selected_unspent_transactions.iter() {
             raw_tx_builder.add_input(input.clone());

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -298,18 +298,7 @@ where
         transaction_obfuscation.encrypt(signed_transaction)
     }
 
-    /// Verify the raw transaction has inputs and outputs
-    /// # Error
-    /// Returns VerifyError when the transaction has invalid inputs and outputs
-    pub fn verify_inputs_outputs(&self) -> Result<()> {
-        self.verify_inputs()?;
-        self.verify_outputs()?;
-        self.verify_output_does_not_exceed_input_amount()?;
-
-        Ok(())
-    }
-
-    /// Verify the raw transaction is valid to be broadcasted
+    /// Verify the raw transaction is valid
     /// # Error
     /// Returns VerifyError when the transaction is invalid
     pub fn verify(&self) -> Result<()> {
@@ -320,7 +309,9 @@ where
             ));
         }
 
-        self.verify_inputs_outputs()?;
+        self.verify_inputs()?;
+        self.verify_outputs()?;
+        self.verify_output_does_not_exceed_input_amount()?;
         self.verify_input_witnesses()?;
 
         Ok(())

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -1,4 +1,5 @@
 //! Builder for building raw transfer transaction
+use std::ops::Sub;
 use std::slice::Iter;
 
 use parity_scale_codec::{Decode, Encode};
@@ -93,7 +94,8 @@ where
             prev_tx_out: input.1,
             witness: None,
         });
-        self.clear_witness()
+
+        self.clear_witness();
     }
 
     /// Append output to raw transaction
@@ -210,10 +212,36 @@ where
         Ok(&mut self.raw_transaction.inputs[index])
     }
 
-    /// Returns fee of completed transfer transaction
+    /// Return the fee paid in this transaction
     /// # Error
     /// Returns error when transaction is incompleted
     pub fn fee(&self) -> Result<Coin> {
+        if !self.is_completed() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Missing signature in inputs",
+            ));
+        }
+
+        self.verify_output_does_not_exceed_input_amount()?;
+
+        let input_value = self.total_input_amount()?;
+        let output_value = self.total_output_amount()?;
+
+        Ok(input_value.sub(output_value).unwrap())
+    }
+
+    /// Returns required fee of completed transfer transaction according to fee
+    /// algorithm
+    /// # Error
+    /// Returns error when transaction is incompleted
+    pub fn required_fee(&self) -> Result<Coin> {
+        if !self.is_completed() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Missing signature in inputs",
+            ));
+        }
         let fee = self
             .fee_algorithm
             .calculate_for_txaux(&self.to_tx_aux()?)
@@ -319,20 +347,9 @@ where
     }
 
     fn verify_output_does_not_exceed_input_amount(&self) -> Result<()> {
-        let input_value = sum_coins(self.iter_inputs().map(|input| input.prev_tx_out.value))
-            .chain(|| {
-                (
-                    ErrorKind::VerifyError,
-                    "Sum of input values exceeds maximum allowed amount",
-                )
-            })?;
-        let output_value =
-            sum_coins(self.iter_outputs().map(|output| output.value)).chain(|| {
-                (
-                    ErrorKind::VerifyError,
-                    "Sum of output values exceeds maximum allowed amount",
-                )
-            })?;
+        let input_value = self.total_input_amount()?;
+        let output_value = self.total_output_amount()?;
+
         // TODO: Include fee in calculation?
         if input_value < output_value {
             return Err(Error::new(
@@ -361,6 +378,27 @@ where
         }
 
         Ok(())
+    }
+
+    /// Returns the total amount of all inputs
+    pub fn total_input_amount(&self) -> Result<Coin> {
+        sum_coins(self.iter_inputs().map(|input| input.prev_tx_out.value))
+            .chain(|| {
+                (
+                    ErrorKind::VerifyError,
+                    "Sum of input values exceeds maximum allowed amount",
+                )
+            })
+    }
+
+    /// Returns the total amount of all outputs
+    pub fn total_output_amount(&self) -> Result<Coin> {
+        sum_coins(self.iter_outputs().map(|output| output.value)).chain(|| {
+            (
+                ErrorKind::VerifyError,
+                "Sum of output values exceeds maximum allowed amount",
+            )
+        })
     }
 
     /// Returns if the all inputs of the transaction are signed
@@ -909,7 +947,7 @@ mod raw_transfer_transaction_builder_tests {
         use super::*;
 
         #[test]
-        fn fee_should_return_error_when_raw_transaction_is_incompleted() {
+        fn should_return_error_when_raw_transaction_is_incompleted() {
             let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
             let builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
 
@@ -919,7 +957,62 @@ mod raw_transfer_transaction_builder_tests {
         }
 
         #[test]
-        fn estimate_fee_should_be_greater_than_or_equal_to_fee() {
+        fn should_return_difference_between_inputs_and_outputs() {
+            let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
+
+            let attributes = TxAttributes::default();
+            let fee_algorithm = create_testing_fee_algorithm();
+            let tx_obfuscation = MockTransactionCipher;
+            let mut builder =
+                RawTransferTransactionBuilder::new(attributes, fee_algorithm, tx_obfuscation);
+
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr.clone(), Coin::new(100).unwrap()),
+            ));
+            builder.add_input((
+                TxoPointer::new(random(), 0),
+                TxOut::new(transfer_addr, Coin::new(200).unwrap()),
+            ));
+
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(50).unwrap(),
+            ));
+            builder.add_output(TxOut::new(
+                ExtendedAddr::OrTree(random()),
+                Coin::new(100).unwrap(),
+            ));
+
+            let witness = create_public_key_witness(private_key, public_key, builder.tx_id());
+            builder
+                .add_witness(0, witness.clone())
+                .expect("should add witness to input index");
+            builder
+                .add_witness(1, witness)
+                .expect("should add witness to input index");
+
+            let fee = builder.fee().unwrap();
+
+            assert_eq!(fee, Coin::new(150).unwrap());
+        }
+    }
+
+    mod required_fee {
+        use super::*;
+
+        #[test]
+        fn should_return_error_when_raw_transaction_is_incompleted() {
+            let (_, _, transfer_addr) = create_key_pair_and_transfer_addr();
+            let builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
+
+            let err = builder.required_fee().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(err.message(), "Missing signature in inputs");
+        }
+
+        #[test]
+        fn estimate_fee_should_be_greater_than_or_equal_to_required_fee() {
             let (private_key, public_key, transfer_addr) = create_key_pair_and_transfer_addr();
             let mut builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
             let witness = create_public_key_witness(private_key, public_key, builder.tx_id());
@@ -930,10 +1023,10 @@ mod raw_transfer_transaction_builder_tests {
                 .add_witness(1, witness)
                 .expect("should add witness to input index");
 
-            let fee = builder.fee().unwrap();
+            let required_fee = builder.required_fee().unwrap();
             let estimated_fee = builder.estimate_fee().unwrap();
 
-            assert!(estimated_fee >= fee);
+            assert!(estimated_fee >= required_fee);
         }
     }
 

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -298,7 +298,18 @@ where
         transaction_obfuscation.encrypt(signed_transaction)
     }
 
-    /// Verify the raw transaction is valid
+    /// Verify the raw transaction has inputs and outputs
+    /// # Error
+    /// Returns VerifyError when the transaction has invalid inputs and outputs
+    pub fn verify_inputs_outputs(&self) -> Result<()> {
+        self.verify_inputs()?;
+        self.verify_outputs()?;
+        self.verify_output_does_not_exceed_input_amount()?;
+
+        Ok(())
+    }
+
+    /// Verify the raw transaction is valid to be broadcasted
     /// # Error
     /// Returns VerifyError when the transaction is invalid
     pub fn verify(&self) -> Result<()> {
@@ -309,9 +320,7 @@ where
             ));
         }
 
-        self.verify_inputs()?;
-        self.verify_outputs()?;
-        self.verify_output_does_not_exceed_input_amount()?;
+        self.verify_inputs_outputs()?;
         self.verify_input_witnesses()?;
 
         Ok(())

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -943,7 +943,7 @@ mod raw_transfer_transaction_builder_tests {
             let builder = create_2in2out_testing_raw_transaction_builder(transfer_addr);
 
             let err = builder.fee().unwrap_err();
-            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
             assert_eq!(err.message(), "Missing signature in inputs");
         }
 
@@ -998,7 +998,7 @@ mod raw_transfer_transaction_builder_tests {
 
             let tx_obfuscation = MockTransactionCipher;
             let err = builder.required_fee(tx_obfuscation).unwrap_err();
-            assert_eq!(err.kind(), ErrorKind::VerifyError);
+            assert_eq!(err.kind(), ErrorKind::InvalidInput);
             assert_eq!(err.message(), "Missing signature in inputs");
         }
 

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -60,24 +60,7 @@ pub(crate) struct Server {
 /// normal
 #[cfg(not(feature = "mock-enc-dec"))]
 fn get_tx_query(tendermint_client: WebsocketRpcClient) -> Result<DefaultTransactionObfuscation> {
-    let result = tendermint_client.query("txquery", &[])?.bytes()?;
-    let address = std::str::from_utf8(&result).chain(|| {
-        (
-            ErrorKind::ConnectionError,
-            "Unable to decode txquery address",
-        )
-    })?;
-    if let Some(hostname) = address.split(':').next() {
-        Ok(DefaultTransactionObfuscation::new(
-            address.to_string(),
-            hostname.to_string(),
-        ))
-    } else {
-        Err(client_common::Error::new(
-            ErrorKind::ConnectionError,
-            "Unable to decode txquery address",
-        ))
-    }
+    DefaultTransactionObfuscation::from_tx_query(&tendermint_client)
 }
 
 /// temporary


### PR DESCRIPTION
Solution: Refactor RawTransferTransactionBuilder and related functions

---

- Rename existing `fee` method to `required_fee`; `fee` method now calculates difference between inputs and outputs
- Extract `get_tx_query` method into DefaultTransactionObfuscation
- Extract transaction obfuscation to until needed
  - Creating incomplete transaction now does not require `TxObfuscation` and can be done offline