### PR TITLE
Problem:(CRO-557) no way to import transactions (without a view key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ of Rust SGX SDK (0.1.0 used a beta version of 1.1.0).
 
 ### Breaking changes
 * *client* [703](https://github.com/crypto-com/chain/pull/703): HD wallet generate view key with a different account index.
+* *client* [695](https://github.com/crypto-com/chain/pull/695): export and import transaction -- transactions that do not include receiver's view key can be exported, giving a base64 encoded plain transaction string which can be imported by the receiver.
 
 ### Improvements
 * *dev-utils* [692](https://github.com/crypto-com/chain/pull/692): dev-utils init command logs error when it goes wrong
@@ -25,6 +26,7 @@ of Rust SGX SDK (0.1.0 used a beta version of 1.1.0).
 
 The release is a more complete alpha version meant to be deployed on the second iteration of the public testnet.
 There are no guarantees on future API and binary compatibility at this stage.
+
 
 ## v0.1.0
 

--- a/chain-core/src/tx/data/input.rs
+++ b/chain-core/src/tx/data/input.rs
@@ -2,7 +2,11 @@ use std::fmt;
 
 use parity_scale_codec::{Decode, Encode};
 #[cfg(not(feature = "mesalock_sgx"))]
-use serde::de;
+use serde::de::{
+    self,
+    value::{Error as ValueError, StrDeserializer},
+    IntoDeserializer,
+};
 #[cfg(not(feature = "mesalock_sgx"))]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -56,7 +60,7 @@ where
         }
 
         #[inline]
-        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
         where
             E: de::Error,
         {
@@ -93,4 +97,10 @@ impl TxoPointer {
             index: index as TxoIndex,
         }
     }
+}
+
+#[cfg(not(feature = "mesalock_sgx"))]
+pub fn str2txid<S: AsRef<str>>(s: S) -> Result<TxId, ValueError> {
+    let deserializer: StrDeserializer<ValueError> = s.as_ref().into_deserializer();
+    deserialize_transaction_id(deserializer)
 }

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -17,7 +17,7 @@ pub use multi_sig_address::MultiSigAddress;
 #[doc(inline)]
 pub use storage::{SecureStorage, Storage};
 #[doc(inline)]
-pub use transaction::{SignedTransaction, Transaction};
+pub use transaction::{SignedTransaction, Transaction, TransactionInfo};
 
 use secp256k1::{All, Secp256k1};
 

--- a/client-common/src/transaction.rs
+++ b/client-common/src/transaction.rs
@@ -10,6 +10,15 @@ use chain_core::tx::data::{Tx, TxId};
 use chain_core::tx::witness::TxWitness;
 use chain_core::tx::TransactionId;
 
+/// A struct which the sender can download and the receiver can import
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
+pub struct TransactionInfo {
+    /// enum Transaction type
+    pub tx: Transaction,
+    /// block height when the tx broadcast
+    pub block_height: u64,
+}
+
 /// Enum containing different types of transactions
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
 #[serde(tag = "type")]

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use parity_scale_codec::{Decode, Encode};
 use secstr::SecUtf8;
 
+use crate::service::{load_wallet_state, WalletState};
 use chain_core::common::H256;
 use chain_core::init::address::RedeemAddress;
 use chain_core::state::account::StakedStateAddress;
@@ -104,11 +105,19 @@ where
         WalletService { storage }
     }
 
-    /// Load wallet
+    /// Get the wallet from storage
     pub fn get_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<Wallet> {
         load_wallet(&self.storage, name, passphrase)?.err_kind(ErrorKind::InvalidInput, || {
             format!("Wallet with name ({}) not found", name)
         })
+    }
+
+    /// Get the wallet state from storage
+    pub fn get_wallet_state(&self, name: &str, passphrase: &SecUtf8) -> Result<WalletState> {
+        load_wallet_state(&self.storage, name, passphrase)?
+            .err_kind(ErrorKind::InvalidInput, || {
+                format!("WalletState with name ({}) not found", name)
+            })
     }
 
     fn set_wallet(&self, name: &str, passphrase: &SecUtf8, wallet: Wallet) -> Result<()> {

--- a/client-core/src/transaction_builder.rs
+++ b/client-core/src/transaction_builder.rs
@@ -13,9 +13,10 @@ use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
-use client_common::{Result, SignedTransaction};
+use client_common::{PrivateKey, Result, SignedTransaction, Transaction};
 
 use crate::UnspentTransactions;
+use chain_core::tx::data::TxId;
 
 /// Interface for wallet transaction building from output addresses and amount.
 /// This trait is also responsible for UTXO selection.
@@ -42,4 +43,7 @@ pub trait WalletTransactionBuilder: Send + Sync {
 
     /// Obfuscates given signed transaction
     fn obfuscate(&self, signed_transaction: SignedTransaction) -> Result<TxAux>;
+
+    /// Get a decrypted transaction by a given tx_id
+    fn decrypt_tx(&self, txid: TxId, private_key: &PrivateKey) -> Result<Transaction>;
 }

--- a/client-core/src/transaction_builder/unauthorized_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/unauthorized_wallet_transaction_builder.rs
@@ -4,9 +4,10 @@ use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
-use client_common::{ErrorKind, Result, SignedTransaction};
+use client_common::{ErrorKind, PrivateKey, Result, SignedTransaction, Transaction};
 
 use crate::{UnspentTransactions, WalletTransactionBuilder};
+use chain_core::tx::data::TxId;
 
 /// Implementation of `WalletTransactionBuilder` which always returns
 /// permission denied
@@ -27,6 +28,10 @@ impl WalletTransactionBuilder for UnauthorizedWalletTransactionBuilder {
     }
 
     fn obfuscate(&self, _: SignedTransaction) -> Result<TxAux> {
+        Err(ErrorKind::PermissionDenied.into())
+    }
+
+    fn decrypt_tx(&self, _txid: TxId, _private_key: &PrivateKey) -> Result<Transaction> {
         Err(ErrorKind::PermissionDenied.into())
     }
 }

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -219,6 +219,21 @@ pub trait WalletClient: Send + Sync {
 
     /// Broadcasts a transaction to Crypto.com Chain
     fn broadcast_transaction(&self, tx_aux: &TxAux) -> Result<BroadcastTxResponse>;
+
+    /// When receiver's view key not included in the transaction, the receiver can't collect the outputs.
+    /// The sender have to get the plain transaction and send it to the receiver by email or something
+    /// so that the receiver can sync it into the wallet DB and get the outputs.
+    ///
+    /// # Return
+    ///
+    /// base64 encoded of `Transaction` json string
+    fn export_plain_tx(&self, name: &str, passphras: &SecUtf8, txid: &str) -> Result<String>;
+
+    /// import a plain transaction, put the outputs of the transaction into wallet DB
+    ///
+    /// # Return
+    /// the sum of unused outputs coin
+    fn import_plain_tx(&self, name: &str, passphrase: &SecUtf8, tx_str: &str) -> Result<Coin>;
 }
 
 /// Interface for a generic wallet for multi-signature transactions

--- a/client-core/src/wallet/syncer.rs
+++ b/client-core/src/wallet/syncer.rs
@@ -260,14 +260,19 @@ impl<'a, S: SecureStorage, C: Client, D: TxDecryptor> WalletSyncerImpl<'a, S, C,
         }
     }
 
-    fn save(&mut self, memento: &WalletStateMemento) -> Result<()> {
-        service::save_sync_state(&self.env.storage, &self.env.name, &self.sync_state)?;
+    fn update_state(&mut self, memento: &WalletStateMemento) -> Result<()> {
         self.wallet_state = service::modify_wallet_state(
             &self.env.storage,
             &self.env.name,
             &self.env.passphrase,
             |state| state.apply_memento(memento),
         )?;
+        Ok(())
+    }
+
+    fn save(&mut self, memento: &WalletStateMemento) -> Result<()> {
+        service::save_sync_state(&self.env.storage, &self.env.name, &self.sync_state)?;
+        self.update_state(memento)?;
         Ok(())
     }
 
@@ -370,7 +375,6 @@ impl<'a, S: SecureStorage, C: Client, D: TxDecryptor> WalletSyncerImpl<'a, S, C,
                 self.handle_batch(non_empty_batch)?;
             }
         }
-
         Ok(())
     }
 

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -91,6 +91,12 @@ pub trait WalletRpc: Send + Sync {
         limit: usize,
         reversed: bool,
     ) -> Result<Vec<TransactionChange>>;
+
+    #[rpc(name = "wallet_exportTransaction")]
+    fn export_plain_tx(&self, request: WalletRequest, txid: String) -> Result<String>;
+
+    #[rpc(name = "wallet_importTransaction")]
+    fn import_plain_tx(&self, request: WalletRequest, tx: String) -> Result<Coin>;
 }
 
 pub struct WalletRpcImpl<T>
@@ -338,6 +344,18 @@ where
                 "Transaction is not transfer transaction",
             )))
         }
+    }
+
+    fn export_plain_tx(&self, request: WalletRequest, txid: String) -> Result<String> {
+        self.client
+            .export_plain_tx(&request.name, &request.passphrase, &txid)
+            .map_err(to_rpc_error)
+    }
+
+    fn import_plain_tx(&self, request: WalletRequest, tx: String) -> Result<Coin> {
+        self.client
+            .import_plain_tx(&request.name, &request.passphrase, &tx)
+            .map_err(to_rpc_error)
     }
 
     fn transactions(


### PR DESCRIPTION
solution:
- add a interface `export_tx` for sender to get the plain transaction
- add a interface `import_tx` for receiver to import the plain transaction and get the output UTXO
