### PR TITLE
Problem (CRO-642): no "watch-only" wallet mode in client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /chain-abci/target
 **/*.rs.bk
+/.cargo
 
 # Storage
 /.storage

--- a/ci-scripts/run-integration-tests.sh
+++ b/ci-scripts/run-integration-tests.sh
@@ -24,3 +24,10 @@ docker-compose -p "${DOCKER_COMPOSE_PREFIX}" up -d || (docker ps; exit 1)
 cd client-rpc
 npm install
 npm run test || (docker ps; docker-compose -p "${DOCKER_COMPOSE_PREFIX}" logs -t --tail="all"; exit 1)
+
+# Python integration tests. prisoned for now, waiting for it's hero.
+# cd ../bot
+# pip3 install -e .
+# pip3 install pytest
+# export PASSPHRASE=${WALLET_PASSPHRASE:-123456}
+# CHAIN_RPC_URL=http://127.0.0.1:$TENDERMINT_ZEROFEE_RPC_PORT CLIENT_RPC_URL=http://127.0.0.1:$CLIENT_RPC_ZEROFEE_PORT pytest tests

--- a/client-cli/src/command/address_command.rs
+++ b/client-cli/src/command/address_command.rs
@@ -48,6 +48,13 @@ pub enum AddressCommand {
         #[structopt(name = "type", short, long, help = "Type of address to create")]
         address_type: AddressType,
     },
+    #[structopt(name = "list_pub_key", about = "Shows the public keys of a wallet")]
+    ListPubKey {
+        #[structopt(name = "name", short, long, help = "Name of wallet")]
+        name: String,
+        #[structopt(name = "type", short, long, help = "Type of public keys to show")]
+        address_type: AddressType,
+    },
 }
 
 impl AddressCommand {
@@ -58,6 +65,9 @@ impl AddressCommand {
             }
             AddressCommand::List { name, address_type } => {
                 Self::list_addresses(wallet_client, name, address_type)
+            }
+            AddressCommand::ListPubKey { name, address_type } => {
+                Self::list_pubkeys(wallet_client, name, address_type)
             }
         }
     }
@@ -115,6 +125,24 @@ impl AddressCommand {
                     success("No addresses found!")
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    fn list_pubkeys<T: WalletClient>(
+        wallet_client: T,
+        name: &str,
+        address_type: &AddressType,
+    ) -> Result<()> {
+        let passphrase = ask_passphrase(None)?;
+
+        let pub_keys = match address_type {
+            AddressType::Staking => wallet_client.staking_keys(name, &passphrase)?,
+            AddressType::Transfer => wallet_client.public_keys(name, &passphrase)?,
+        };
+        for pubkey in pub_keys.iter() {
+            println!("{}", pubkey);
         }
 
         Ok(())

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -104,7 +104,8 @@ where
         WalletService { storage }
     }
 
-    fn get_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<Wallet> {
+    /// Load wallet
+    pub fn get_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<Wallet> {
         load_wallet(&self.storage, name, passphrase)?.err_kind(ErrorKind::InvalidInput, || {
             format!("Wallet with name ({}) not found", name)
         })

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -44,8 +44,19 @@ pub trait WalletClient: Send + Sync {
     /// Restores a HD wallet from given mnemonic
     fn restore_wallet(&self, name: &str, passphrase: &SecUtf8, mnemonic: &Mnemonic) -> Result<()>;
 
+    /// Restore a watch only wallet with view key
+    fn restore_basic_wallet(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        view_key: &PrivateKey,
+    ) -> Result<()>;
+
     /// Retrieves view key corresponding to a given wallet
     fn view_key(&self, name: &str, passphrase: &SecUtf8) -> Result<PublicKey>;
+
+    /// Retrieves private view key corresponding to a given wallet
+    fn view_key_private(&self, name: &str, passphrase: &SecUtf8) -> Result<PrivateKey>;
 
     /// Retrieves all public keys corresponding to given wallet
     fn public_keys(&self, name: &str, passphrase: &SecUtf8) -> Result<BTreeSet<PublicKey>>;
@@ -107,6 +118,22 @@ pub trait WalletClient: Send + Sync {
     /// Generates a new 1-of-1 transfer address
     fn new_transfer_address(&self, name: &str, passphrase: &SecUtf8) -> Result<ExtendedAddr>;
 
+    /// Add watch only staking address
+    fn new_watch_staking_address(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        public_key: &PublicKey,
+    ) -> Result<StakedStateAddress>;
+
+    /// Add watch only transfer address
+    fn new_watch_transfer_address(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        public_key: &PublicKey,
+    ) -> Result<ExtendedAddr>;
+
     /// Generates a new multi-sig transfer address for creating m-of-n transactions
     ///
     /// # Arguments
@@ -146,7 +173,14 @@ pub trait WalletClient: Send + Sync {
     fn balance(&self, name: &str, passphrase: &SecUtf8) -> Result<Coin>;
 
     /// Retrieves transaction history of wallet
-    fn history(&self, name: &str, passphrase: &SecUtf8) -> Result<Vec<TransactionChange>>;
+    fn history(
+        &self,
+        name: &str,
+        passphrase: &SecUtf8,
+        limit: usize,
+        offset: usize,
+        reversed: bool,
+    ) -> Result<Vec<TransactionChange>>;
 
     /// Retrieves all unspent transactions of wallet
     fn unspent_transactions(&self, name: &str, passphrase: &SecUtf8)

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -107,6 +107,16 @@ where
     ) -> Result<String> {
         let public_keys = parse_public_keys(public_keys).map_err(to_rpc_error)?;
         let self_public_key = parse_public_key(self_public_key).map_err(to_rpc_error)?;
+        // Check if self public key belongs to current wallet
+        self.client
+            .private_key(&request.passphrase, &self_public_key)
+            .chain(|| {
+                (
+                    ErrorKind::InvalidInput,
+                    "Self public key does not belong to current wallet",
+                )
+            })
+            .map_err(to_rpc_error)?;
         let extended_address = self
             .client
             .new_multisig_transfer_address(

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
+use secstr::SecUtf8;
 
 use chain_core::init::coin::Coin;
 use chain_core::tx::data::access::{TxAccess, TxAccessPolicy};
@@ -11,10 +12,10 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxObfuscated;
 use chain_core::tx::{TxAux, TxEnclaveAux};
-use client_common::{PublicKey, Result as CommonResult};
+use client_common::{PrivateKey, PublicKey, Result as CommonResult};
 use client_core::types::WalletKind;
 use client_core::types::{AddressType, TransactionChange};
-use client_core::{Mnemonic, MultiSigWalletClient, WalletClient};
+use client_core::{Mnemonic, MultiSigWalletClient, UnspentTransactions, WalletClient};
 
 use crate::server::{rpc_error_from_string, to_rpc_error, WalletRequest};
 
@@ -29,17 +30,34 @@ pub trait WalletRpc: Send + Sync {
     #[rpc(name = "wallet_restore")]
     fn restore(&self, request: WalletRequest, mnemonics: Mnemonic) -> Result<String>;
 
+    #[rpc(name = "wallet_restoreBasic")]
+    fn restore_basic(&self, request: WalletRequest, view_key: SecUtf8) -> Result<String>;
+
     #[rpc(name = "wallet_newMultiSigAddressPublicKey")]
     fn new_multi_sig_address_public_key(&self, request: WalletRequest) -> Result<String>;
 
     #[rpc(name = "wallet_createStakingAddress")]
     fn create_staking_address(&self, request: WalletRequest) -> Result<String>;
 
+    #[rpc(name = "wallet_createWatchStakingAddress")]
+    fn create_watch_staking_address(
+        &self,
+        request: WalletRequest,
+        public_key: PublicKey,
+    ) -> Result<String>;
+
     #[rpc(name = "wallet_createTransferAddress")]
     fn create_transfer_address(&self, request: WalletRequest) -> Result<String>;
 
+    #[rpc(name = "wallet_createWatchTransferAddress")]
+    fn create_watch_transfer_address(
+        &self,
+        request: WalletRequest,
+        public_key: PublicKey,
+    ) -> Result<String>;
+
     #[rpc(name = "wallet_getViewKey")]
-    fn get_view_key(&self, request: WalletRequest) -> Result<String>;
+    fn get_view_key(&self, request: WalletRequest, private: bool) -> Result<String>;
 
     #[rpc(name = "wallet_list")]
     fn list(&self) -> Result<Vec<String>>;
@@ -53,6 +71,9 @@ pub trait WalletRpc: Send + Sync {
     #[rpc(name = "wallet_listTransferAddresses")]
     fn list_transfer_addresses(&self, request: WalletRequest) -> Result<BTreeSet<String>>;
 
+    #[rpc(name = "wallet_listUTxO")]
+    fn list_utxo(&self, request: WalletRequest) -> Result<UnspentTransactions>;
+
     #[rpc(name = "wallet_sendToAddress")]
     fn send_to_address(
         &self,
@@ -63,7 +84,13 @@ pub trait WalletRpc: Send + Sync {
     ) -> Result<String>;
 
     #[rpc(name = "wallet_transactions")]
-    fn transactions(&self, request: WalletRequest) -> Result<Vec<TransactionChange>>;
+    fn transactions(
+        &self,
+        request: WalletRequest,
+        offset: usize,
+        limit: usize,
+        reversed: bool,
+    ) -> Result<Vec<TransactionChange>>;
 }
 
 pub struct WalletRpcImpl<T>
@@ -132,6 +159,17 @@ where
         Ok(request.name)
     }
 
+    fn restore_basic(&self, request: WalletRequest, view_key: SecUtf8) -> Result<String> {
+        let view_key =
+            PrivateKey::deserialize_from(&hex::decode(view_key.unsecure()).map_err(to_rpc_error)?)
+                .map_err(to_rpc_error)?;
+        self.client
+            .restore_basic_wallet(&request.name, &request.passphrase, &view_key)
+            .map_err(to_rpc_error)?;
+
+        Ok(request.name)
+    }
+
     fn new_multi_sig_address_public_key(&self, request: WalletRequest) -> Result<String> {
         self.client
             .new_public_key(
@@ -150,6 +188,17 @@ where
             .map_err(to_rpc_error)
     }
 
+    fn create_watch_staking_address(
+        &self,
+        request: WalletRequest,
+        public_key: PublicKey,
+    ) -> Result<String> {
+        self.client
+            .new_watch_staking_address(&request.name, &request.passphrase, &public_key)
+            .map(|staked_state_addr| staked_state_addr.to_string())
+            .map_err(to_rpc_error)
+    }
+
     fn create_transfer_address(&self, request: WalletRequest) -> Result<String> {
         let extended_address = self
             .client
@@ -159,12 +208,35 @@ where
         Ok(extended_address.to_string())
     }
 
-    fn get_view_key(&self, request: WalletRequest) -> Result<String> {
-        let public_key = self
+    fn create_watch_transfer_address(
+        &self,
+        request: WalletRequest,
+        public_key: PublicKey,
+    ) -> Result<String> {
+        let extended_address = self
             .client
-            .view_key(&request.name, &request.passphrase)
+            .new_watch_transfer_address(&request.name, &request.passphrase, &public_key)
             .map_err(to_rpc_error)?;
-        Ok(public_key.to_string())
+
+        Ok(extended_address.to_string())
+    }
+
+    fn get_view_key(&self, request: WalletRequest, private: bool) -> Result<String> {
+        let s = if private {
+            hex::encode(
+                &self
+                    .client
+                    .view_key_private(&request.name, &request.passphrase)
+                    .map_err(to_rpc_error)?
+                    .serialize(),
+            )
+        } else {
+            self.client
+                .view_key(&request.name, &request.passphrase)
+                .map_err(to_rpc_error)?
+                .to_string()
+        };
+        Ok(s)
     }
 
     fn list(&self) -> Result<Vec<String>> {
@@ -188,6 +260,12 @@ where
         self.client
             .transfer_addresses(&request.name, &request.passphrase)
             .map(|addresses| addresses.iter().map(ToString::to_string).collect())
+            .map_err(to_rpc_error)
+    }
+
+    fn list_utxo(&self, request: WalletRequest) -> Result<UnspentTransactions> {
+        self.client
+            .unspent_transactions(&request.name, &request.passphrase)
             .map_err(to_rpc_error)
     }
 
@@ -262,9 +340,15 @@ where
         }
     }
 
-    fn transactions(&self, request: WalletRequest) -> Result<Vec<TransactionChange>> {
+    fn transactions(
+        &self,
+        request: WalletRequest,
+        offset: usize,
+        limit: usize,
+        reversed: bool,
+    ) -> Result<Vec<TransactionChange>> {
         self.client
-            .history(&request.name, &request.passphrase)
+            .history(&request.name, &request.passphrase, offset, limit, reversed)
             .map_err(to_rpc_error)
     }
 }
@@ -636,7 +720,7 @@ pub mod tests {
 
         assert_eq!(
             wallet_rpc
-                .get_view_key(wallet_request.clone())
+                .get_view_key(wallet_request.clone(), false)
                 .unwrap()
                 .len(),
             66
@@ -682,7 +766,7 @@ pub mod tests {
         assert_eq!(
             0,
             wallet_rpc
-                .transactions(wallet_request.clone())
+                .transactions(wallet_request.clone(), 0, 100, false)
                 .unwrap()
                 .len()
         )
@@ -766,7 +850,9 @@ pub mod tests {
             to_result.to_string()
         );
 
-        let viewkey = wallet_rpc.get_view_key(wallet_request.clone()).unwrap();
+        let viewkey = wallet_rpc
+            .get_view_key(wallet_request.clone(), false)
+            .unwrap();
 
         let send_result = wallet_rpc.send_to_address(
             wallet_request.clone(),

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -4,6 +4,7 @@ use crate::rpc::staking_rpc::{StakingRpc, StakingRpcImpl};
 use crate::rpc::sync_rpc::{SyncRpc, SyncRpcImpl};
 use crate::rpc::transaction_rpc::{TransactionRpc, TransactionRpcImpl};
 use crate::rpc::wallet_rpc::{WalletRpc, WalletRpcImpl};
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::thread;
 use std::time::Duration;
@@ -11,10 +12,9 @@ use std::time::Duration;
 use chain_core::init::network::{get_network, get_network_id, init_chain_id};
 use chain_core::tx::fee::LinearFee;
 use client_common::storage::SledStorage;
-#[cfg(not(feature = "mock-enc-dec"))]
 use client_common::tendermint::types::GenesisExt;
 use client_common::tendermint::{Client, WebsocketRpcClient};
-use client_common::{Error, ErrorKind, Result};
+use client_common::{ErrorKind, Result};
 #[cfg(not(feature = "mock-enc-dec"))]
 use client_core::cipher::DefaultTransactionObfuscation;
 #[cfg(feature = "mock-enc-dec")]
@@ -214,7 +214,7 @@ impl Server {
     }
 }
 
-pub(crate) fn to_rpc_error(error: Error) -> jsonrpc_core::Error {
+pub(crate) fn to_rpc_error<E: ToString + Debug>(error: E) -> jsonrpc_core::Error {
     log::error!("{:?}", error);
     jsonrpc_core::Error {
         code: jsonrpc_core::ErrorCode::InternalError,

--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,1 +1,2 @@
 address-state.json
+__pycache__

--- a/integration-tests/bot/tests/conftest.py
+++ b/integration-tests/bot/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from chainrpc import RPC
+
+
+class TestAddresses:
+    def __init__(self, staking, transfer1, transfer2):
+        self.staking = staking
+        self.transfer1 = transfer1
+        self.transfer2 = transfer2
+
+
+@pytest.fixture
+def addresses():
+    rpc = RPC()
+    rpc.wallet.sync()
+    addrs = TestAddresses(
+        rpc.address.list(type='staking')[1],
+        rpc.address.list(type='transfer')[0],
+        rpc.address.list(type='transfer')[1],
+    )
+
+    state = rpc.staking.state(addrs.staking)
+    if int(state['unbonded']) > 0:
+        rpc.staking.withdraw_all_unbonded(addrs.staking,
+                                          addrs.transfer1)
+        rpc.wallet.sync()
+        assert rpc.wallet.balance() > 0
+    return addrs

--- a/integration-tests/bot/tests/test_watch_only_wallet.py
+++ b/integration-tests/bot/tests/test_watch_only_wallet.py
@@ -1,0 +1,29 @@
+import time
+from chainrpc import RPC
+from uuid import uuid1
+
+rpc = RPC()
+
+
+def test_watch_only_wallet(addresses):
+    name = str(uuid1())
+    print('name', name)
+    assert rpc.wallet.create(name) == name
+
+    view_key_pub = rpc.wallet.view_key(name)
+    view_key_priv = rpc.wallet.view_key(name, private=True)
+    transfer_pubkey = rpc.wallet.list_pubkey(name)[0]
+    transfer_addr = rpc.address.list(name, type='transfer')[0]
+
+    name = 'watch_' + name
+    assert rpc.wallet.restore_basic(view_key_priv, name=name) == name
+    assert rpc.wallet.view_key(name) == view_key_pub
+
+    assert rpc.address.create_watch(transfer_pubkey, name=name, type='transfer') == transfer_addr
+
+    amount = 10000000
+    rpc.wallet.send(transfer_addr, amount, view_keys=[view_key_pub])
+    time.sleep(1)  # wait the block to pop up
+    rpc.wallet.sync()
+    rpc.wallet.sync(name)
+    assert rpc.wallet.balance(name) == amount

--- a/integration-tests/client-rpc/test/core/utils.ts
+++ b/integration-tests/client-rpc/test/core/utils.ts
@@ -81,3 +81,5 @@ export const asyncMiddleman = async (
 		throw Error(`${errorMessage}: ${err.message}`);
 	}
 };
+
+export const TRANSACTION_HISTORY_LIMIT = 1000;

--- a/integration-tests/client-rpc/test/hdrestore-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/hdrestore-auto-sync.test.ts
@@ -14,6 +14,7 @@ import {
 	FEE_SCHEMA,
 	asyncMiddleman,
 	newZeroFeeTendermintClient,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 import { syncWallet, waitTxIdConfirmed } from "./core/rpc";
 import { TendermintClient } from "./core/tendermint-client";
@@ -61,7 +62,7 @@ describe("Wallet Auto-sync", () => {
 		);
 
 		const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving sender wallet transactions before send",
 		);
 		const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -76,7 +77,7 @@ describe("Wallet Auto-sync", () => {
 			"Error when creating receiver wallet transfer address",
 		);
 		const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving receiver wallet transactions before receive",
 		);
 		const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -84,7 +85,7 @@ describe("Wallet Auto-sync", () => {
 			"Error when retrieving receiver wallet balance before receive",
 		);
 		const receiverViewKey = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 			"Error when retrieving receiver view key",
 		);
 
@@ -117,12 +118,12 @@ describe("Wallet Auto-sync", () => {
 		while (true) {
 			console.log(`[Log] Checking for wallet sync status`);
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions after send",
 			);
 
@@ -139,7 +140,7 @@ describe("Wallet Auto-sync", () => {
 		}
 
 		const senderWalletTransactionListAfterSend = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving sender wallet transactions after send",
 		);
 
@@ -172,7 +173,7 @@ describe("Wallet Auto-sync", () => {
 		);
 
 		const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving receiver wallet transactions after receive",
 		);
 		expect(receiverWalletTransactionListAfterReceive.length).to.eq(

--- a/integration-tests/client-rpc/test/hdrestore-transaction.test.ts
+++ b/integration-tests/client-rpc/test/hdrestore-transaction.test.ts
@@ -13,12 +13,12 @@ import {
 	generateWalletName,
 	newZeroFeeRpcClient,
 	newWithFeeRpcClient,
-	sleep,
 	shouldTest,
 	FEE_SCHEMA,
 	newZeroFeeTendermintClient,
 	newWithFeeTendermintClient,
 	asyncMiddleman,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 import { TendermintClient } from "./core/tendermint-client";
 import { waitTxIdConfirmed, syncWallet } from "./core/rpc";
@@ -75,7 +75,7 @@ describe("Wallet transaction", () => {
 
 
 			const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions before send",
 			);
 			const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -90,7 +90,7 @@ describe("Wallet transaction", () => {
 				"Error when creating receiver transfer address",
 			);
 			const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions before receive",
 			);
 			const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -98,7 +98,7 @@ describe("Wallet transaction", () => {
 				"Error when retrieving reciever wallet balance before receive",
 			);
 			const receiverViewKey = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 				"Error when retrieving receiver view key",
 			);
 
@@ -131,7 +131,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 
@@ -164,7 +164,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transaction after receive",
 			);
 			expect(receiverWalletTransactionListAfterReceive.length).to.eq(
@@ -218,7 +218,7 @@ describe("Wallet transaction", () => {
 
 
 			const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transaction before send",
 			);
 			const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -233,7 +233,7 @@ describe("Wallet transaction", () => {
 				"Error when creating receiver transfer address",
 			);
 			const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transaction before receive",
 			);
 			const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -241,7 +241,7 @@ describe("Wallet transaction", () => {
 				"Error when retrieving receiver wallet balance before receive",
 			);
 			const receiverViewKey = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 				"Error when retrieving receiver view key",
 			);
 
@@ -274,7 +274,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 			expect(senderWalletTransactionListAfterSend.length).to.eq(
@@ -313,7 +313,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions after receive",
 			);
 			expect(receiverWalletTransactionListAfterReceive.length).to.eq(

--- a/integration-tests/client-rpc/test/hdwallet-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-auto-sync.test.ts
@@ -14,6 +14,7 @@ import {
 	FEE_SCHEMA,
 	asyncMiddleman,
 	newZeroFeeTendermintClient,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 import { syncWallet, waitTxIdConfirmed } from "./core/rpc";
 import { TendermintClient } from "./core/tendermint-client";
@@ -60,7 +61,7 @@ describe("Wallet Auto-sync", () => {
 		);
 
 		const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving sender wallet transactions before send",
 		);
 		const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -75,7 +76,7 @@ describe("Wallet Auto-sync", () => {
 			"Error when creating receiver wallet transfer address",
 		);
 		const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving receiver wallet transactions before receive",
 		);
 		const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -83,7 +84,7 @@ describe("Wallet Auto-sync", () => {
 			"Error when retrieving receiver wallet balance before receive",
 		);
 		const receiverViewKey = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 			"Error when retrieving receiver view key",
 		);
 
@@ -116,12 +117,12 @@ describe("Wallet Auto-sync", () => {
 		while (true) {
 			console.log(`[Log] Checking for wallet sync status`);
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions after send",
 			);
 
@@ -138,7 +139,7 @@ describe("Wallet Auto-sync", () => {
 		}
 
 		const senderWalletTransactionListAfterSend = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving sender wallet transactions after send",
 		);
 
@@ -171,7 +172,7 @@ describe("Wallet Auto-sync", () => {
 		);
 
 		const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving receiver wallet transactions after receive",
 		);
 		expect(receiverWalletTransactionListAfterReceive.length).to.eq(

--- a/integration-tests/client-rpc/test/hdwallet-management.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-management.test.ts
@@ -10,6 +10,7 @@ import {
 	shouldTest,
 	FEE_SCHEMA,
 	newWithFeeRpcClient,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 chaiUse(chaiAsPromised);
 
@@ -63,7 +64,7 @@ describe("Wallet management", () => {
 			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
 		);
 		await expect(
-			client.request("wallet_transactions", [nonExistingWalletRequest]),
+			client.request("wallet_transactions", [nonExistingWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 		).to.eventually.rejectedWith(
 			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
 		);
@@ -157,7 +158,7 @@ describe("Wallet management", () => {
 			client.request("wallet_balance", [incorrectWalletRequest]),
 		).to.eventually.rejectedWith("Decryption error");
 		await expect(
-			client.request("wallet_transactions", [incorrectWalletRequest]),
+			client.request("wallet_transactions", [incorrectWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 		).to.eventually.rejectedWith("Decryption error");
 	});
 

--- a/integration-tests/client-rpc/test/hdwallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-transaction.test.ts
@@ -13,12 +13,12 @@ import {
 	generateWalletName,
 	newZeroFeeRpcClient,
 	newWithFeeRpcClient,
-	sleep,
 	shouldTest,
 	FEE_SCHEMA,
 	newZeroFeeTendermintClient,
 	newWithFeeTendermintClient,
 	asyncMiddleman,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 import { TendermintClient } from "./core/tendermint-client";
 import { waitTxIdConfirmed, syncWallet } from "./core/rpc";
@@ -74,7 +74,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions before send",
 			);
 			const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -89,7 +89,7 @@ describe("Wallet transaction", () => {
 				"Error when creating receiver transfer address",
 			);
 			const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions before receive",
 			);
 			const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -97,7 +97,7 @@ describe("Wallet transaction", () => {
 				"Error when retrieving reciever wallet balance before receive",
 			);
 			const receiverViewKey = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 				"Error when retrieving receiver view key",
 			);
 
@@ -130,7 +130,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 
@@ -163,7 +163,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transaction after receive",
 			);
 			expect(receiverWalletTransactionListAfterReceive.length).to.eq(
@@ -214,7 +214,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transaction before send",
 			);
 			const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -229,7 +229,7 @@ describe("Wallet transaction", () => {
 				"Error when creating receiver transfer address",
 			);
 			const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transaction before receive",
 			);
 			const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -237,7 +237,7 @@ describe("Wallet transaction", () => {
 				"Error when retrieving receiver wallet balance before receive",
 			);
 			const receiverViewKey = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 				"Error when retrieving receiver view key",
 			);
 
@@ -270,7 +270,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 			expect(senderWalletTransactionListAfterSend.length).to.eq(
@@ -309,7 +309,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions after receive",
 			);
 			expect(receiverWalletTransactionListAfterReceive.length).to.eq(

--- a/integration-tests/client-rpc/test/network-ops.test.ts
+++ b/integration-tests/client-rpc/test/network-ops.test.ts
@@ -144,7 +144,7 @@ describe("Staking", () => {
 			"Error when creating transfer address",
 		);
 		const viewKey = await asyncMiddleman(
-			rpcClient.request("wallet_getViewKey", [walletRequest]),
+			rpcClient.request("wallet_getViewKey", [walletRequest, false]),
 			"Error when retrieving wallet view key",
 		);
 

--- a/integration-tests/client-rpc/test/wallet-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/wallet-auto-sync.test.ts
@@ -14,6 +14,7 @@ import {
 	FEE_SCHEMA,
 	asyncMiddleman,
 	newZeroFeeTendermintClient,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 import { syncWallet, waitTxIdConfirmed } from "./core/rpc";
 import { TendermintClient } from "./core/tendermint-client";
@@ -60,7 +61,7 @@ describe("Wallet Auto-sync", () => {
 		);
 
 		const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving sender wallet transactions before send",
 		);
 		const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -75,7 +76,7 @@ describe("Wallet Auto-sync", () => {
 			"Error when creating receiver wallet transfer address",
 		);
 		const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving receiver wallet transactions before receive",
 		);
 		const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -83,7 +84,7 @@ describe("Wallet Auto-sync", () => {
 			"Error when retrieving receiver wallet balance before receive",
 		);
 		const receiverViewKey = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 			"Error when retrieving receiver view key",
 		);
 
@@ -116,12 +117,12 @@ describe("Wallet Auto-sync", () => {
 		while (true) {
 			console.log(`[Log] Checking for wallet sync status`);
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions after send",
 			);
 
@@ -138,7 +139,7 @@ describe("Wallet Auto-sync", () => {
 		}
 
 		const senderWalletTransactionListAfterSend = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving sender wallet transactions after send",
 		);
 
@@ -171,7 +172,7 @@ describe("Wallet Auto-sync", () => {
 		);
 
 		const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+			zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 			"Error when retrieving receiver wallet transactions after receive",
 		);
 		expect(receiverWalletTransactionListAfterReceive.length).to.eq(

--- a/integration-tests/client-rpc/test/wallet-management.test.ts
+++ b/integration-tests/client-rpc/test/wallet-management.test.ts
@@ -10,6 +10,7 @@ import {
 	shouldTest,
 	FEE_SCHEMA,
 	newWithFeeRpcClient,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 chaiUse(chaiAsPromised);
 
@@ -47,7 +48,7 @@ describe("Wallet management", () => {
 			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
 		);
 		await expect(
-			client.request("wallet_transactions", [nonExistingWalletRequest]),
+			client.request("wallet_transactions", [nonExistingWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 		).to.eventually.rejectedWith(
 			`Invalid input: Wallet with name (${nonExistingWalletName}) not found`,
 		);
@@ -132,7 +133,7 @@ describe("Wallet management", () => {
 			client.request("wallet_balance", [incorrectWalletRequest]),
 		).to.eventually.rejectedWith("Decryption error");
 		await expect(
-			client.request("wallet_transactions", [incorrectWalletRequest]),
+			client.request("wallet_transactions", [incorrectWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 		).to.eventually.rejectedWith("Decryption error");
 	});
 

--- a/integration-tests/client-rpc/test/wallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/wallet-transaction.test.ts
@@ -13,12 +13,12 @@ import {
 	generateWalletName,
 	newZeroFeeRpcClient,
 	newWithFeeRpcClient,
-	sleep,
 	shouldTest,
 	FEE_SCHEMA,
 	newZeroFeeTendermintClient,
 	newWithFeeTendermintClient,
 	asyncMiddleman,
+	TRANSACTION_HISTORY_LIMIT,
 } from "./core/utils";
 import { TendermintClient } from "./core/tendermint-client";
 import { waitTxIdConfirmed, syncWallet } from "./core/rpc";
@@ -74,7 +74,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions before send",
 			);
 			const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -89,7 +89,7 @@ describe("Wallet transaction", () => {
 				"Error when creating receiver transfer address",
 			);
 			const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions before receive",
 			);
 			const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -97,7 +97,7 @@ describe("Wallet transaction", () => {
 				"Error when retrieving reciever wallet balance before receive",
 			);
 			const receiverViewKey = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 				"Error when retrieving receiver view key",
 			);
 
@@ -130,7 +130,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 
@@ -163,7 +163,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				zeroFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transaction after receive",
 			);
 			expect(receiverWalletTransactionListAfterReceive.length).to.eq(
@@ -214,7 +214,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListBeforeSend = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transaction before send",
 			);
 			const senderWalletBalanceBeforeSend = await asyncMiddleman(
@@ -229,7 +229,7 @@ describe("Wallet transaction", () => {
 				"Error when creating receiver transfer address",
 			);
 			const receiverWalletTransactionListBeforeReceive = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transaction before receive",
 			);
 			const receiverWalletBalanceBeforeReceive = await asyncMiddleman(
@@ -237,7 +237,7 @@ describe("Wallet transaction", () => {
 				"Error when retrieving receiver wallet balance before receive",
 			);
 			const receiverViewKey = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_getViewKey", [receiverWalletRequest, false]),
 				"Error when retrieving receiver view key",
 			);
 
@@ -270,7 +270,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const senderWalletTransactionListAfterSend = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [senderWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving sender wallet transactions after send",
 			);
 			expect(senderWalletTransactionListAfterSend.length).to.eq(
@@ -309,7 +309,7 @@ describe("Wallet transaction", () => {
 			);
 
 			const receiverWalletTransactionListAfterReceive = await asyncMiddleman(
-				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest]),
+				withFeeRpcClient.request("wallet_transactions", [receiverWalletRequest, 0, TRANSACTION_HISTORY_LIMIT, true]),
 				"Error when retrieving receiver wallet transactions after receive",
 			);
 			expect(receiverWalletTransactionListAfterReceive.length).to.eq(


### PR DESCRIPTION
Solution:
- Add these apis to client-rpc:
  - restoreBasic(WalletRequest, String[hex encoded private view key])
  - createStakingWatchAddress(WalletRequest, PublicKey)
  - createTransferWatchAddress(WalletRequest, PublicKey)
  - listUTxO(WalletRequest)
- Add several paramters to transactions api:
  - transactions(WalletRequest, offset: usize, limit: usize, reversed: bool)
- Makes several api changes for testing convinience:
  - Add private option to `view_key` to get private view key.
  - Add `list_pub_key` command to client-cli to list public keys of
transfer addresses.
  - Also record the public key in wallet when creating transfer address.

Implemented integration tests in python.