### PR TITLE
Problem: (CRO-300) No easy way to find client's environment variables

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -45,7 +45,14 @@ use crate::{ask_passphrase, storage_path, tendermint_url};
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "client-cli",
-    about = "Basic CLI tool for interacting with Crypto.com Chain"
+    about = r#"Basic CLI tool for interacting with Crypto.com Chain
+
+ENVIRONMENT VARIABLES:
+    CRYPTO_CLIENT_DEBUG             Set to `true` for detailed error messages (Default: `false`)
+    CRYPTO_CHAIN_ID                 Chain ID of Crypto.com Chain
+    CRYPTO_CLIENT_STORAGE           Storage directory (Default: `.storage`)
+    CRYPTO_CLIENT_TENDERMINT        Websocket endpoint for tendermint (Default: `ws://localhost:26657/websocket`)
+"#
 )]
 pub enum Command {
     #[structopt(name = "wallet", about = "Wallet operations")]


### PR DESCRIPTION
Solution: Added documentation for all environment variables in help command

New help message:
```
client-cli 0.1.1
Basic CLI tool for interacting with Crypto.com Chain

ENVIRONMENT VARIABLES:
    CRYPTO_CLIENT_DEBUG             Set to `true` for detailed error messages (Default: `false`)
    CRYPTO_CHAIN_ID                 Chain ID of Crypto.com Chain
    CRYPTO_CLIENT_STORAGE           Storage directory (Default: `.storage`)
    CRYPTO_CLIENT_TENDERMINT        Websocket endpoint for tendermint (Default: `ws://localhost:26657/websocket`)

USAGE:
    client-cli <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    address        Address operations
    balance        Get balance of a wallet
    help           Prints this message or the help of the given subcommand(s)
    history        Get transaction history of a wallet
    state          Get staked state of an address
    sync           Synchronize client with Crypto.com Chain
    transaction    Transaction operations
    view-key       Shows the view key of a wallet
    wallet         Wallet operations
```