### PR TITLE
Problem:(CRO-524) Client may create transactions with potentially spent utxos

### DIFF
--- a/client-core/src/transaction_builder.rs
+++ b/client-core/src/transaction_builder.rs
@@ -9,8 +9,10 @@ pub use unauthorized_wallet_transaction_builder::UnauthorizedWalletTransactionBu
 
 use secstr::SecUtf8;
 
+use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
 use client_common::{PrivateKey, Result, SignedTransaction, Transaction};
@@ -31,6 +33,11 @@ pub trait WalletTransactionBuilder: Send + Sync {
     /// - `outputs`: Transaction outputs
     /// - `return_address`: Address to which change amount will get returned
     /// - `attributes`: Transaction attributes,
+    ///
+    /// # return
+    /// - `TxAux`: obfuscated transaction
+    /// - `Vec<TxoPointer>`: the selected inputs
+    /// - `Coin`: the return amount of Coin
     fn build_transfer_tx(
         &self,
         name: &str,
@@ -39,7 +46,7 @@ pub trait WalletTransactionBuilder: Send + Sync {
         outputs: Vec<TxOut>,
         return_address: ExtendedAddr,
         attributes: TxAttributes,
-    ) -> Result<TxAux>;
+    ) -> Result<(TxAux, Vec<TxoPointer>, Coin)>;
 
     /// Obfuscates given signed transaction
     fn obfuscate(&self, signed_transaction: SignedTransaction) -> Result<TxAux>;

--- a/client-core/src/transaction_builder/unauthorized_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/unauthorized_wallet_transaction_builder.rs
@@ -1,7 +1,9 @@
 use secstr::SecUtf8;
 
+use chain_core::init::coin::Coin;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
+use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
 use client_common::{ErrorKind, PrivateKey, Result, SignedTransaction, Transaction};
@@ -23,7 +25,7 @@ impl WalletTransactionBuilder for UnauthorizedWalletTransactionBuilder {
         _: Vec<TxOut>,
         _: ExtendedAddr,
         _: TxAttributes,
-    ) -> Result<TxAux> {
+    ) -> Result<(TxAux, Vec<TxoPointer>, Coin)> {
         Err(ErrorKind::PermissionDenied.into())
     }
 

--- a/client-core/src/types.rs
+++ b/client-core/src/types.rs
@@ -7,6 +7,7 @@ pub mod transaction_change;
 pub use self::address_type::AddressType;
 #[doc(inline)]
 pub use self::transaction_change::{
-    BalanceChange, TransactionChange, TransactionInput, TransactionType,
+    BalanceChange, TransactionChange, TransactionInput, TransactionPending, TransactionType,
+    WalletBalance,
 };
 pub use self::wallet_type::WalletKind;

--- a/client-core/src/types/transaction_change.rs
+++ b/client-core/src/types/transaction_change.rs
@@ -12,6 +12,28 @@ use chain_core::{
 use client_common::tendermint::types::Time;
 use client_common::{ErrorKind, Result, ResultExt, Transaction};
 
+/// Wallet balance info
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct WalletBalance {
+    /// The total amount balance
+    pub total: Coin,
+    /// The available amount balance that can be currently used
+    pub available: Coin,
+    /// The pending amount balance
+    pub pending: Coin,
+}
+
+/// Transaction pending infomation
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct TransactionPending {
+    /// The selected inputs of the transaction
+    pub used_inputs: Vec<TxoPointer>,
+    /// The block height when broadcast the transaction
+    pub block_height: u64,
+    /// the return amount of the transaction
+    pub return_amount: Coin,
+}
+
 /// Transaction data with attached metadata
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransactionChange {

--- a/client-core/src/wallet/syncer_logic.rs
+++ b/client-core/src/wallet/syncer_logic.rs
@@ -128,6 +128,7 @@ pub(crate) fn handle_transaction(
         }
     }
 
+    memento.remove_pending_transaction(transaction_change.transaction_id);
     memento.add_transaction_change(transaction_change);
     Ok(())
 }
@@ -370,7 +371,6 @@ mod tests {
                 .expect("handle block for wallet2");
             states[1].apply_memento(&memento).expect("apply memento2");
         }
-        assert_eq!(states[0].balance, Coin::new(100).unwrap());
         assert_eq!(states[0].transaction_history.len(), 1);
         assert_eq!(states[0].unspent_transactions.len(), 1);
 
@@ -389,11 +389,17 @@ mod tests {
             states[1].apply_memento(&memento).expect("apply memento2");
         }
 
-        assert_eq!(states[0].balance, Coin::new(0).unwrap());
+        assert_eq!(
+            states[0].get_balance().unwrap().total,
+            Coin::new(0).unwrap()
+        );
         assert_eq!(states[0].transaction_history.len(), 2);
         assert_eq!(states[0].unspent_transactions.len(), 0);
 
-        assert_eq!(states[1].balance, Coin::new(100).unwrap());
+        assert_eq!(
+            states[1].get_balance().unwrap().total,
+            Coin::new(100).unwrap()
+        );
         assert_eq!(states[1].transaction_history.len(), 1);
         assert_eq!(states[1].unspent_transactions.len(), 1);
     }

--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -15,6 +15,7 @@ use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
 use client_common::Result;
+use client_core::types::TransactionPending;
 
 /// Interface for performing network operations on Crypto.com Chain
 pub trait NetworkOpsClient: Send + Sync {
@@ -46,7 +47,7 @@ pub trait NetworkOpsClient: Send + Sync {
         from_address: &StakedStateAddress,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
-    ) -> Result<TxAux>;
+    ) -> Result<(TxAux, TransactionPending)>;
 
     /// Creates a new transaction for withdrawing all unbonded stake from an account
     fn create_withdraw_all_unbonded_stake_transaction(
@@ -56,7 +57,7 @@ pub trait NetworkOpsClient: Send + Sync {
         from_address: &StakedStateAddress,
         to_address: ExtendedAddr,
         attributes: TxAttributes,
-    ) -> Result<TxAux>;
+    ) -> Result<(TxAux, TransactionPending)>;
 
     /// Creates a new transaction for un-jailing a previously jailed account
     fn create_unjail_transaction(

--- a/client-rpc/src/program.rs
+++ b/client-rpc/src/program.rs
@@ -62,6 +62,13 @@ pub struct Options {
         help = "Number of requests per batch when syncing wallet"
     )]
     pub batch_size: usize,
+    #[structopt(
+        name = "block_height_ensure",
+        long,
+        default_value = "50",
+        help = "Number of block height to rollback the utxos in the pending transactions"
+    )]
+    pub block_height_ensure: u64,
 }
 
 #[allow(dead_code)]

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -208,7 +208,7 @@ where
 
         let attributes = TxAttributes::new_with_access(self.network_id, access_policies);
 
-        let transaction = self
+        let (transaction, tx_pending) = self
             .ops_client
             .create_withdraw_all_unbonded_stake_transaction(
                 &request.name,
@@ -222,7 +222,15 @@ where
         self.client
             .broadcast_transaction(&transaction)
             .map_err(to_rpc_error)?;
-
+        // update the wallet pending transaction state
+        self.client
+            .update_tx_pending_state(
+                &request.name,
+                &request.passphrase,
+                transaction.tx_id(),
+                tx_pending,
+            )
+            .map_err(to_rpc_error)?;
         Ok(hex::encode(transaction.tx_id()))
     }
 

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -54,6 +54,7 @@ pub(crate) struct Server {
     websocket_url: String,
     enable_fast_forward: bool,
     batch_size: usize,
+    block_height_ensure: u64,
 }
 
 /// normal
@@ -85,6 +86,7 @@ impl Server {
             websocket_url: options.websocket_url,
             enable_fast_forward: !options.disable_fast_forward,
             batch_size: options.batch_size,
+            block_height_ensure: options.block_height_ensure,
         })
     }
 
@@ -138,6 +140,7 @@ impl Server {
             transaction_cipher,
             self.enable_fast_forward,
             self.batch_size,
+            self.block_height_ensure,
         ))
     }
 

--- a/integration-tests/bot/chainrpc.py
+++ b/integration-tests/bot/chainrpc.py
@@ -87,9 +87,9 @@ class Address:
 
 class Wallet:
     def balance(self, name=DEFAULT_WALLET):
-        '''Get balance of wallet
+        '''Get balance details of wallet
         :param name: Name of the wallet. [default: Default]'''
-        return int(call('wallet_balance', [name, get_passphrase()]))
+        return call('wallet_balance', [name, get_passphrase()])
 
     def list(self):
         return call('wallet_list')

--- a/integration-tests/bot/tests/test_watch_only_wallet.py
+++ b/integration-tests/bot/tests/test_watch_only_wallet.py
@@ -26,4 +26,5 @@ def test_watch_only_wallet(addresses):
     time.sleep(1)  # wait the block to pop up
     rpc.wallet.sync()
     rpc.wallet.sync(name)
-    assert rpc.wallet.balance(name) == amount
+    assert int(rpc.wallet.balance(name)["total"])== amount
+    assert int(rpc.wallet.balance(name)["available"])== amount

--- a/integration-tests/client-rpc/test/core/setup.ts
+++ b/integration-tests/client-rpc/test/core/setup.ts
@@ -54,7 +54,7 @@ const unbondAndWithdrawStakeFromClient = async (
 		"Error when retrieving Default wallet balance",
 	);
 	console.info(`[Info] Wallet balance: ${walletBalance}`);
-	if (new BigNumber(walletBalance).isGreaterThan("0")) {
+	if (new BigNumber(walletBalance.total).isGreaterThan("0")) {
 		console.info("[Init] Bonded funds already withdrew");
 		return;
 	}

--- a/integration-tests/client-rpc/test/hdwallet-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-auto-sync.test.ts
@@ -38,7 +38,7 @@ describe("Wallet Auto-sync", () => {
 		return;
 	}
 
-	it("can auto-sync unlocked wallets", async function() {
+	it("can auto-sync unlocked wallets", async function () {
 		this.timeout(300000);
 
 		const receiverWalletName = generateWalletName("Receive");
@@ -128,9 +128,9 @@ describe("Wallet Auto-sync", () => {
 
 			if (
 				senderWalletTransactionListAfterSend.length ===
-					senderWalletTransactionListBeforeSend.length + 1 &&
+				senderWalletTransactionListBeforeSend.length + 1 &&
 				receiverWalletTransactionListAfterReceive.length ===
-					receiverWalletTransactionListBeforeReceive.length + 1
+				receiverWalletTransactionListBeforeReceive.length + 1
 			) {
 				console.log(`[Log] Auto-sync caught up with latest transactions`);
 				break;
@@ -160,14 +160,21 @@ describe("Wallet Auto-sync", () => {
 			"Sender should have one Outgoing transaction",
 		);
 
-		const senderWalletBalanceAfterSend = await asyncMiddleman(
+		const senderWalletBalanceAfterSync = await asyncMiddleman(
 			zeroFeeRpcClient.request("wallet_balance", [senderWalletRequest]),
 			"Error when retrieving sender wallet balance after send",
 		);
-		expect(senderWalletBalanceAfterSend).to.eq(
-			new BigNumber(senderWalletBalanceBeforeSend)
-				.minus(transferAmount)
-				.toString(10),
+		// after sync, the sender's pending balance will become available
+		const returnAmount = new BigNumber(senderWalletBalanceBeforeSend.total)
+			.minus(transferAmount)
+			.toString(10);
+		const expectedBalanceAfterSync = {
+			total: returnAmount,
+			pending: "0",
+			available: returnAmount,
+		};
+		expect(senderWalletBalanceAfterSync).to.deep.eq(
+			expectedBalanceAfterSync,
 			"Sender balance should be deducted by transfer amount",
 		);
 
@@ -196,10 +203,16 @@ describe("Wallet Auto-sync", () => {
 			zeroFeeRpcClient.request("wallet_balance", [receiverWalletRequest]),
 			"Error when retrieving receiver wallet balance after receive",
 		);
-		expect(receiverWalletBalanceAfterReceive).to.eq(
-			new BigNumber(receiverWalletBalanceBeforeReceive)
-				.plus(transferAmount)
-				.toString(10),
+		const receiverTotalAmount = new BigNumber(receiverWalletBalanceBeforeReceive.total)
+			.plus(transferAmount)
+			.toString(10);
+		const expectedBalanceAfterReceive = {
+			total: receiverTotalAmount,
+			available: receiverTotalAmount,
+			pending: "0",
+		};
+		expect(receiverWalletBalanceAfterReceive).to.deep.eq(
+			expectedBalanceAfterReceive,
 			"Receiver balance should be increased by transfer amount",
 		);
 	});

--- a/integration-tests/client-rpc/test/hdwallet-management.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-management.test.ts
@@ -78,7 +78,7 @@ describe("Wallet management", () => {
 			walletRequest
 			, "HD"
 		]);
-		let res= walletCreateResult.split(" ");
+		let res = walletCreateResult.split(" ");
 		expect(res.length).to.deep.eq(24);
 
 		const walletList = await client.request("wallet_list");
@@ -90,9 +90,9 @@ describe("Wallet management", () => {
 		const walletRequest = newWalletRequest(walletName, "123456");
 
 		const walletCreateResponse = await client.request("wallet_create", [
-			walletRequest, "HD"  
+			walletRequest, "HD"
 		]);
-		let res= walletCreateResponse.split(" ");
+		let res = walletCreateResponse.split(" ");
 		expect(res.length).to.deep.eq(24);
 
 
@@ -111,19 +111,19 @@ describe("Wallet management", () => {
 		expect(walletTransferAddresses.length).to.eq(1);
 	});
 
-	
+
 	it("cannot create duplicated wallet", async () => {
 		const walletName = generateWalletName();
 		const walletRequest = newWalletRequest(walletName, "123456");
 
 		const walletCreateResponse = await client.request("wallet_create", [
-			walletRequest,"HD"
+			walletRequest, "HD"
 		]);
-		let res= walletCreateResponse.split(" ");
+		let res = walletCreateResponse.split(" ");
 		expect(res.length).to.deep.eq(24);
 
 		return expect(
-			client.request("wallet_create", [walletRequest,"HD"]),
+			client.request("wallet_create", [walletRequest, "HD"]),
 		).to.eventually.rejectedWith(
 			`HD Key with given name already exists`,
 		);
@@ -135,9 +135,9 @@ describe("Wallet management", () => {
 		const walletRequest = newWalletRequest(walletName, walletPassphrase);
 
 		const walletCreateResponse = await client.request("wallet_create", [
-			walletRequest,"HD"
+			walletRequest, "HD"
 		]);
-		let res= walletCreateResponse.split(" ");
+		let res = walletCreateResponse.split(" ");
 		expect(res.length).to.deep.eq(24);
 
 
@@ -167,11 +167,11 @@ describe("Wallet management", () => {
 		const walletPassphrase = "passphrase";
 		const walletRequest = newWalletRequest(walletName, walletPassphrase);
 
-		
+
 		const walletCreateResponse = await client.request("wallet_create", [
-			walletRequest,"HD"
+			walletRequest, "HD"
 		]);
-		let res= walletCreateResponse.split(" ");
+		let res = walletCreateResponse.split(" ");
 		expect(res.length).to.deep.eq(24);
 
 		const transferAddress = await client.request("wallet_createTransferAddress", [
@@ -186,17 +186,16 @@ describe("Wallet management", () => {
 		expect(transferAddressList).to.include(transferAddress);
 	});
 
-	
+
 	it("Create a staking address and then list it", async () => {
 		const walletName = generateWalletName();
 		const walletPassphrase = "passphrase";
 		const walletRequest = newWalletRequest(walletName, walletPassphrase);
 
-		
 		const walletCreateResponse = await client.request("wallet_create", [
-			walletRequest,"HD"
+			walletRequest, "HD"
 		]);
-		let res= walletCreateResponse.split(" ");
+		let res = walletCreateResponse.split(" ");
 		expect(res.length).to.deep.eq(24);
 
 		const stakingAddress = await client.request("wallet_createStakingAddress", [
@@ -210,5 +209,5 @@ describe("Wallet management", () => {
 		expect(stakingAddressList).to.be.an("array");
 		expect(stakingAddressList).to.include(stakingAddress);
 	});
-	
+
 });

--- a/integration-tests/client-rpc/test/hdwallet-transaction.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-transaction.test.ts
@@ -69,7 +69,7 @@ describe("Wallet transaction", () => {
 			const transferAmount = "1000";
 
 			await asyncMiddleman(
-				zeroFeeRpcClient.request("wallet_create", [receiverWalletRequest,"HD"]),
+				zeroFeeRpcClient.request("wallet_create", [receiverWalletRequest, "HD"]),
 				"Error when creating receiver wallet",
 			);
 
@@ -114,6 +114,23 @@ describe("Wallet transaction", () => {
 				64,
 				"wallet_sendToAddress should return transaction id",
 			);
+			// after send and before sync, the sender's return amount will be pending
+			const returnAmount = new BigNumber(senderWalletBalanceBeforeSend.total)
+				.minus(transferAmount)
+				.toString(10);
+			const expectedBalanceBeforeSync = {
+				total: returnAmount,
+				pending: returnAmount,
+				available: "0",
+			};
+			const senderWalletBalanceBeforeSync = await asyncMiddleman(
+				zeroFeeRpcClient.request("wallet_balance", [senderWalletRequest]),
+				"Error when retrieving sender wallet balance after send",
+			);
+			expect(senderWalletBalanceBeforeSync).to.deep.eq(
+				expectedBalanceBeforeSync,
+				"Sender balance should be deducted by transfer amount",
+			);
 
 			await asyncMiddleman(
 				waitTxIdConfirmed(zeroFeeTendermintClient, txId),
@@ -151,14 +168,18 @@ describe("Wallet transaction", () => {
 				"Sender should have one Outgoing transaction",
 			);
 
-			const senderWalletBalanceAfterSend = await asyncMiddleman(
+			const senderWalletBalanceAfterSync = await asyncMiddleman(
 				zeroFeeRpcClient.request("wallet_balance", [senderWalletRequest]),
 				"Error when retrieving sender wallet balance after send",
 			);
-			expect(senderWalletBalanceAfterSend).to.eq(
-				new BigNumber(senderWalletBalanceBeforeSend)
-					.minus(transferAmount)
-					.toString(10),
+			// after sync, the pending balance will become available
+			const expectedBalanceAfterSync = {
+				total: returnAmount,
+				pending: "0",
+				available: returnAmount,
+			};
+			expect(senderWalletBalanceAfterSync).to.deep.eq(
+				expectedBalanceAfterSync,
 				"Sender balance should be deducted by transfer amount",
 			);
 
@@ -187,10 +208,16 @@ describe("Wallet transaction", () => {
 				zeroFeeRpcClient.request("wallet_balance", [receiverWalletRequest]),
 				"Error when retrieving receiver wallet balance after receive",
 			);
-			expect(receiverWalletBalanceAfterReceive).to.eq(
-				new BigNumber(receiverWalletBalanceBeforeReceive)
-					.plus(transferAmount)
-					.toString(10),
+			const receiverTotalAmount = new BigNumber(receiverWalletBalanceBeforeReceive.total)
+				.plus(transferAmount)
+				.toString(10);
+			const expectedBalanceAfterReceive = {
+				total: receiverTotalAmount,
+				available: receiverTotalAmount,
+				pending: "0",
+			}
+			expect(receiverWalletBalanceAfterReceive).to.deep.eq(
+				expectedBalanceAfterReceive,
 				"Receiver balance should be increased by transfer amount",
 			);
 		});
@@ -209,7 +236,7 @@ describe("Wallet transaction", () => {
 			const transferAmount = "1000";
 
 			await asyncMiddleman(
-				withFeeRpcClient.request("wallet_create", [receiverWalletRequest,"HD"]),
+				withFeeRpcClient.request("wallet_create", [receiverWalletRequest, "HD"]),
 				"Error when creating receive wallet",
 			);
 
@@ -300,8 +327,8 @@ describe("Wallet transaction", () => {
 				"Error when retrieving sender wallet balance after send",
 			);
 			expect(
-				new BigNumber(senderWalletBalanceAfterSend).isLessThan(
-					new BigNumber(senderWalletBalanceBeforeSend).minus(transferAmount),
+				new BigNumber(senderWalletBalanceAfterSend.total).isLessThan(
+					new BigNumber(senderWalletBalanceBeforeSend.available).minus(transferAmount),
 				),
 			).to.eq(
 				true,
@@ -333,10 +360,16 @@ describe("Wallet transaction", () => {
 				withFeeRpcClient.request("wallet_balance", [receiverWalletRequest]),
 				"Error when retrieving receiver wallet balance after receive",
 			);
-			expect(receiverWalletBalanceAfterReceive).to.eq(
-				new BigNumber(receiverWalletBalanceBeforeReceive)
-					.plus(transferAmount)
-					.toString(10),
+			const receiverTotalAmount = new BigNumber(receiverWalletBalanceBeforeReceive.total)
+				.plus(transferAmount)
+				.toString(10);
+			const expectedBalanceAfterReceive = {
+				total: receiverTotalAmount,
+				available: receiverTotalAmount,
+				pending: "0",
+			};
+			expect(receiverWalletBalanceAfterReceive).to.deep.eq(
+				expectedBalanceAfterReceive,
 				"Receiver balance should be increased by the exact transfer amount",
 			);
 		});

--- a/integration-tests/client-rpc/test/network-ops.test.ts
+++ b/integration-tests/client-rpc/test/network-ops.test.ts
@@ -31,7 +31,7 @@ describe("Staking", () => {
 		tendermintClient = newZeroFeeTendermintClient();
 	});
 
-	it("unbond of same amount and nonce from different account should have different txid", async function() {
+	it("unbond of same amount and nonce from different account should have different txid", async function () {
 		this.timeout(300000);
 
 		const stakingAmount = "10000";
@@ -95,7 +95,7 @@ describe("Staking", () => {
 		);
 	});
 
-	it("should support staking, unbonding and withdrawing", async function() {
+	it("should support staking, unbonding and withdrawing", async function () {
 		this.timeout(300000);
 
 		const walletContext = await prepareWalletContext(tendermintClient, rpcClient);
@@ -107,7 +107,6 @@ describe("Staking", () => {
 
 		const stakingAmount = "10000";
 		const unbondAmount = "5000";
-
 		const depositStakeTxId = await testTransferAndStakeBaseUnit(
 			walletContext,
 			stakingAmount,
@@ -203,10 +202,16 @@ describe("Staking", () => {
 			"Error when synchronizing wallet",
 		);
 
+		// after sync
+		const expectedWalletBalanceAfterSync = {
+			total: stakingAmount,
+			pending: "0",
+			available: stakingAmount,
+		}
 		await expect(
 			rpcClient.request("wallet_balance", [walletRequest]),
 		).to.eventually.deep.eq(
-			stakingAmount,
+			expectedWalletBalanceAfterSync,
 			"Wallet should be funded with staking amount for staking deposit",
 		);
 
@@ -262,10 +267,15 @@ describe("Staking", () => {
 			syncWallet(rpcClient, walletRequest),
 			"Error when synchronizing wallet",
 		);
+		const expectedBalance = {
+			total: "0",
+			pending: "0",
+			available: "0",
+		};
 		await expect(
 			rpcClient.request("wallet_balance", [walletRequest]),
 		).to.eventually.deep.eq(
-			"0",
+			expectedBalance,
 			"Wallet balance should be deducted after deposit stake",
 		);
 	};
@@ -417,10 +427,15 @@ describe("Staking", () => {
 			"Error when synchronizing wallet",
 		);
 
+		const expectedBalance = {
+			total: unbondAmount,
+			pending: "0",
+			available: unbondAmount,
+		};
 		return expect(
 			rpcClient.request("wallet_balance", [walletRequest]),
 		).to.eventually.deep.eq(
-			unbondAmount,
+			expectedBalance,
 			"Wallet balance should be credited after withdraw stake",
 		);
 	};

--- a/integration-tests/client-rpc/test/wallet-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/wallet-auto-sync.test.ts
@@ -38,7 +38,7 @@ describe("Wallet Auto-sync", () => {
 		return;
 	}
 
-	it("can auto-sync unlocked wallets", async function() {
+	it("can auto-sync unlocked wallets", async function () {
 		this.timeout(300000);
 
 		const receiverWalletName = generateWalletName("Receive");
@@ -128,9 +128,9 @@ describe("Wallet Auto-sync", () => {
 
 			if (
 				senderWalletTransactionListAfterSend.length ===
-					senderWalletTransactionListBeforeSend.length + 1 &&
+				senderWalletTransactionListBeforeSend.length + 1 &&
 				receiverWalletTransactionListAfterReceive.length ===
-					receiverWalletTransactionListBeforeReceive.length + 1
+				receiverWalletTransactionListBeforeReceive.length + 1
 			) {
 				console.log(`[Log] Auto-sync caught up with latest transactions`);
 				break;
@@ -160,14 +160,20 @@ describe("Wallet Auto-sync", () => {
 			"Sender should have one Outgoing transaction",
 		);
 
-		const senderWalletBalanceAfterSend = await asyncMiddleman(
+		const senderWalletBalanceAfterSync = await asyncMiddleman(
 			zeroFeeRpcClient.request("wallet_balance", [senderWalletRequest]),
 			"Error when retrieving sender wallet balance after send",
 		);
-		expect(senderWalletBalanceAfterSend).to.eq(
-			new BigNumber(senderWalletBalanceBeforeSend)
-				.minus(transferAmount)
-				.toString(10),
+		const returnAmount = new BigNumber(senderWalletBalanceBeforeSend.total)
+			.minus(transferAmount)
+			.toString(10);
+		const expectedBalanceAfterSync = {
+			total: returnAmount,
+			pending: "0",
+			available: returnAmount,
+		};
+		expect(senderWalletBalanceAfterSync).to.deep.eq(
+			expectedBalanceAfterSync,
 			"Sender balance should be deducted by transfer amount",
 		);
 
@@ -196,10 +202,17 @@ describe("Wallet Auto-sync", () => {
 			zeroFeeRpcClient.request("wallet_balance", [receiverWalletRequest]),
 			"Error when retrieving receiver wallet balance after receive",
 		);
-		expect(receiverWalletBalanceAfterReceive).to.eq(
-			new BigNumber(receiverWalletBalanceBeforeReceive)
-				.plus(transferAmount)
-				.toString(10),
+		const receiverTotalAmount = new BigNumber(receiverWalletBalanceBeforeReceive.total)
+			.plus(transferAmount)
+			.toString(10);
+		const expectedBalanceAfterReceive = {
+			total: receiverTotalAmount,
+			available: receiverTotalAmount,
+			pending: "0",
+		};
+
+		expect(receiverWalletBalanceAfterReceive).to.deep.eq(
+			expectedBalanceAfterReceive,
 			"Receiver balance should be increased by transfer amount",
 		);
 	});

--- a/integration-tests/client-rpc/test/wallet-management.test.ts
+++ b/integration-tests/client-rpc/test/wallet-management.test.ts
@@ -97,12 +97,12 @@ describe("Wallet management", () => {
 		const walletRequest = newWalletRequest(walletName, "123456");
 
 		const walletCreateResponse = await client.request("wallet_create", [
-			walletRequest,"Basic"
+			walletRequest, "Basic"
 		]);
 		expect(walletCreateResponse).to.deep.eq(walletName);
 
 		return expect(
-			client.request("wallet_create", [walletRequest,"Basic"]),
+			client.request("wallet_create", [walletRequest, "Basic"]),
 		).to.eventually.rejectedWith(
 			`Invalid input: Wallet with name (${walletName}) already exists`,
 		);
@@ -114,7 +114,7 @@ describe("Wallet management", () => {
 		const walletRequest = newWalletRequest(walletName, walletPassphrase);
 
 		await expect(
-			client.request("wallet_create", [walletRequest,"Basic"]),
+			client.request("wallet_create", [walletRequest, "Basic"]),
 		).to.eventually.deep.eq(walletName);
 
 		const incorrectWalletPassphrase = "different_passphrase";
@@ -161,7 +161,7 @@ describe("Wallet management", () => {
 		const walletPassphrase = "passphrase";
 		const walletRequest = newWalletRequest(walletName, walletPassphrase);
 
-		await client.request("wallet_create", [walletRequest,"Basic"]);
+		await client.request("wallet_create", [walletRequest, "Basic"]);
 
 		const stakingAddress = await client.request("wallet_createStakingAddress", [
 			walletRequest,


### PR DESCRIPTION
solution:
- add a `pending_transaction` in wallet state, it's a BTreepMap of `txid` -> `pending_info`
- the pending_info includes the `current block height` when the tx broadcast, the returned coin amount and the used `inputs`
- after broadcast a transaction, we update the `pending_transaction`
- when make a new transaction, we select the inputs which are in `unspent_transactions` and not in `pending_transactions`
- we remove the `txid` from the `pending_transaction` when we find it in `sync`
- we also remove the `txid` after `sync` finished if it can not be found in the latest `BLOCK_HEIGHT_ENSURE`(which is 50) blocks after it broadcast
- change the wallet balance into 3 types: `total`, `pending`, `available`, we can only use the coins amount which is in `available` when we make a new transaction.