### PR TITLE
Problem: client-cli sync hangs after sync complete

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -503,6 +503,7 @@ impl Command {
             syncer.reset_state()?;
         }
         syncer.sync()?;
+        std::mem::drop(syncer);
         let _ = handle.join();
         Ok(())
     }


### PR DESCRIPTION
Solution: Drop syncer before join progress reporting thread.