### PR TITLE
Problem: unclear client error message when tx-query not set

### DIFF
--- a/client-common/src/tendermint/websocket_rpc_client.rs
+++ b/client-common/src/tendermint/websocket_rpc_client.rs
@@ -427,7 +427,11 @@ impl Client for WebsocketRpcClient {
                 } else {
                     Err(Error::new(
                         ErrorKind::InvalidInput,
-                        "abci query return error",
+                        format!(
+                            "abci query fail: {}, {}",
+                            rsp.response.code.value(),
+                            rsp.response.log,
+                        ),
                     ))
                 }
             })


### PR DESCRIPTION
Solution:
- Include the error message returned by chain-abci.

The error message is: `Invalid input: abci query fail: 1, tx query address not set`