### PR TITLE
Problem: (CRO-678) Tendermint HttpRpcClient compilation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ rust: &rust
 
   script:
     - cargo build
+    - cargo build --features http-rpc --manifest-path client-common/Cargo.toml
     - cargo test
     - |
       if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then

--- a/before_push.sh
+++ b/before_push.sh
@@ -59,8 +59,8 @@ function command_suite() {
         CMD="${1}"
     else
         CMD="${2}"
-        print_step "${CMD}"
     fi
+    print_step "[RUNNING] ${CMD}"
 
     set +e
     eval "${CMD}"


### PR DESCRIPTION
Solution: Fix compilation error

---
- Add `cargo build` test in TravisCI
- Port changes from `WebSocketRpcClient` to `HttpRpcClient` to fix compilation error