### PR TITLE
Problem: (CRO-680) Latest sled fails to compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "sled 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sled 0.30.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendermint 0.10.0 (git+https://github.com/crypto-com/tendermint-rs.git?rev=db982c2437fe72c7a03942fc2bddf490f2332364)",
  "websocket 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2768,7 +2768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sled"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4005,7 +4005,7 @@ dependencies = [
 "checksum signatory-dalek 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e71296303f2f04a00ef9a3133627db900805a41de2c944cc64a31039afa366"
 "checksum signature 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0cfcdc45066661979294e965c21b60355da35eb5d638af8143e5aa83fdfce53"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum sled 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e69af75e95d5ed16e7e013f1696b1fec5f8bf2b355b275332ea8098033acfb1"
+"checksum sled 0.30.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb8c32cb0e34e67ad74fae1a77f4635d0cc7ffc873088a0136f3c4849336d71"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"

--- a/chain-tx-enclave/tx-validation/app/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/app/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 sgx-test = []
 
 [dependencies]
-sled = "0.30.1"
+sled = "0.30.3"
 zmq = "0.9"
 log = "0.4.8"
 env_logger = "0.7.0"

--- a/chain-tx-enclave/tx-validation/app/src/main.rs
+++ b/chain-tx-enclave/tx-validation/app/src/main.rs
@@ -7,7 +7,6 @@ use crate::server::TxValidationServer;
 use enclave_u_common::enclave_u::init_enclave;
 use enclave_u_common::{storage_path, META_KEYSPACE, TX_KEYSPACE};
 use log::{error, info};
-use sled::Db;
 use std::env;
 use std::thread;
 
@@ -24,7 +23,7 @@ fn main() {
         error!("Please provide the ZMQ connection string (e.g. \"tcp://127.0.0.1:25933\") as the first argument");
         return;
     }
-    let db = Db::open(storage_path()).expect("failed to open a storage path");
+    let db = sled::open(storage_path()).expect("failed to open a storage path");
     let metadb = db
         .open_tree(META_KEYSPACE)
         .expect("failed to open a meta keyspace");

--- a/chain-tx-enclave/tx-validation/app/src/test/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/test/mod.rs
@@ -106,7 +106,7 @@ pub fn test_sealing() {
         .filter(None, LevelFilter::Debug)
         .write_style(WriteStyle::Always)
         .init();
-    let mut db = Db::open(".enclave-test").expect("failed to open a storage path");
+    let mut db = sled::open(".enclave-test").expect("failed to open a storage path");
     let mut metadb = db
         .open_tree(crate::META_KEYSPACE)
         .expect("failed to open a meta keyspace");

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -18,7 +18,7 @@ secstr = { version = "0.3.2", features = ["serde"] }
 zeroize = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-sled = { version = "0.30.1", optional = true }
+sled = { version = "0.30.3", optional = true }
 jsonrpc = { version = "0.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 parity-scale-codec = { features = ["derive"], version = "1.1" }

--- a/client-common/src/storage/sled_storage.rs
+++ b/client-common/src/storage/sled_storage.rs
@@ -31,7 +31,7 @@ impl SledStorage {
                     })?,
             )))
         } else {
-            Ok(Self(Arc::new(Db::open(&path).chain(|| {
+            Ok(Self(Arc::new(sled::open(&path).chain(|| {
                 (
                     ErrorKind::InitializationError,
                     format!(


### PR DESCRIPTION
Solution: Changed `Db::open` to `sled::open`. `Db::open` is now deprecated.