### PR TITLE
Problem: no clear decision on ADR-001

### DIFF
--- a/architecture-docs/adr-001.md
+++ b/architecture-docs/adr-001.md
@@ -3,6 +3,7 @@
 ## Changelog
 * 10-12-2019: Initial Draft
 * 11-12-2019: Extra comments
+* 03-01-2020: Refinement of the decision based on early experiments + discussion on Slack
 
 ## Context
 Currently (not counting Tendermint's internal storage or wallets), two processes maintain their internal storage:
@@ -50,23 +51,38 @@ to do a more complete verification (currently there are a few hacks and workarou
 ## Decision
 This will be a bit big change, so it can be done in several steps:
 
-1. separate out the storage functionality from chain-abci into chain-storage crate
+* separate out the storage functionality from chain-abci into chain-storage crate
+https://github.com/crypto-com/chain/issues/753
+  * This should decouple the existing storage functionality from state machine logic
+  * The result should be more high-level APIs that can then be used or extended by the embedded tx-validation enclave app wrapper
+    (getSealedTx, insertSealedTx...) to encapsulate some of the low-level storage choices
 
-2. TBD: separate storage process? moving enclave app wrappers to chain-abci?
-
-3. change enclave-protocol for chain-abci/storage to add sealed transaction data, and TVE to return Ok(sealed transaction data) back to chain-abci/storage
-
-4. give TQE some way to talk to chain-abci/storage (TBD: another 0MQ socket or abci_query?)
-
-5. change the first flow of TQE to use that instead of talking to TVE
-
-6. TBD: change the second flow to go through chain-abci (it'd still need to forward to TVE)
-
-7. remove storage from TVE (as it should be all handled by chain-abci/storage)
-
+* embed tx-validation enclave app wrapper in chain-abci
+Based on early experiments in: https://github.com/crypto-com/chain/pull/738
+It will include several changes (in several sub-PRs):
+  * make more general SGX library loader (currently, it's been fixed to enclave.signed.so)
+  * extract out enclave-only tx-validation core functionality into a separate crate that would allow *optional* mock version (replacing the enclave-bridge)
+  * build process modifications: consolidating common functionality, making chain-abci's build process to expose URTS to tx-validation enclave
+  * chain-abci starting up tx-validation's zMQ server for the sole purpose of preserving current tx-query workflows (tx-query changes are out of scope of this ADR,
+e.g. having "insecure" test-only connection)
+  * replace the "embedded" tx-validation's sled storage with chain-storage (*addressing Problem 1*):
+    * store sealed transaction payloads in `COL_BODIES` (or a dedicated column if desired)
+    * for serving tx-query requests, just use chain-abci's latest committed state (for last block's time etc.)
+  * remove the redundant enclave-protocol variants of zMQ inter-communication message payloads (unused by tx-query):
+    * CheckChain: no need for the latest app hash checking (only one storage), can do the sanity check (the mainnet/testnet *.signed.so will be different) with direct call
+    * VerifyTx: can call directly (IntraEnclave)
+    * EndBlock: can call directly 
+    * CommitBlock: no need (both information stored / handled during normal chain-abci execution)
+  * modifications in tx-query protocol and client to allow complete verification verification of encryption requests (*addressing Problem 2*):
+    * `EncryptionRequest::WithdrawStake` doesn't need to include the StakedState information:
+      * tx-query will obtain the address from the signature payload and pass that to chain-abci / embedded tx-validation
+      * chain-abci (before calling the tx-validation ecall) should look up the staked state (if it doesn't exist, it'll return an error)
+  * move `SGX_TEST` tx-validation's SGX unit test (unfortunately the normal Rust unit tests don't work in Apache SGX SDK) under an optional flag in chain-abci
+  * along the way, update documentation, integration tests and integration test environment set ups
+  
 ## Status
 
-Proposed
+Accepted
 
 ## Consequences
 
@@ -74,19 +90,24 @@ Proposed
 
 * Only one place to store transaction data -- no need to keep storage of two processes in sync
 * Decoupling state machine logic (chain-abci) from the storage
-* As the second TQE flow may demand a full validation / more storage needs, it should be easier directly talking to abci.
+* Full validation of (existing) TQE requests
+* As TQE (and other non-yet-implemented enclave logic) evolves, it'll be beneficial to have one canonical Chain storage place (chain-storage / chain-abci)
+which TQE etc. can rely on
 
 ### Negative
-* Perhaps higher latency in some flows
-* If storage runs as a service (a la Libra architecture, see below, where it is a GRPC process), it'll be an extra complexity in deployment.
-* If enclave app wrappers are moved to chain-abci, development setup may be trickier on non-Linux platforms.
+* More complex chain-abci building process 
 
 ### Neutral
-* One more crate
-* Coupling TQE process to chain-abci or storage process
-* Storage space shared between chain-abci and "sub-abci" enclave applications: probably an extra column in RocksDB-like storage
+* A few more crates (storage crate + some of the enclave functionality may be extracted and abstracted out into existing or new crates)
+* Coupling TQE process to chain-abci
+* Storage space shared between chain-abci and "sub-abci" enclave applications: perhaps an extra column in RocksDB-like storage
+* Depending on how the tx-validation embedding into chain-abci and mocking is done, it may be a source of "silent" enclave only errors
+a developer would discover only after the full integration test, or worse at longer runs in SGX env (as it's not every edge case is covered by integration test and there's no fuzzing yet)
+* many documentation and script changes (as tx-validation wrapper app has been there for quite some time)
 
 ## References
 
 * moving app wrapers to chain-abci: https://github.com/crypto-com/chain/pull/665#discussion_r356377869
 * https://github.com/libra/libra/tree/master/storage/storage-service
+* more discussion pointing out other concerns in tx-query: https://github.com/crypto-com/chain/pull/741
+* early embedding tx-validation into chain-abci experiment: https://github.com/crypto-com/chain/pull/738


### PR DESCRIPTION
Solution: refined the ADR-001 based on the early experiments and
discussions where embedding tx-validation wrapper
app into chain-abci was preferred