### PR TITLE
Problem:(CRO-647)integration test occasionally fails due to tx-query not started up

### DIFF
--- a/chain-tx-enclave/tx-query/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-query/enclave/Cargo.toml
@@ -16,7 +16,7 @@ sgx-test = []
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_types   = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd    = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["net"] }
+sgx_tstd    = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["net", "thread"] }
 sgx_tcrypto = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tse     = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_rand    = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/chain-tx-enclave/tx-query/enclave/Enclave.edl
+++ b/chain-tx-enclave/tx-query/enclave/Enclave.edl
@@ -4,6 +4,7 @@ enclave {
     from "sgx_net.edl" import *;
     from "sgx_time.edl" import *;
     from "sgx_tstdc.edl" import *;
+    from "sgx_thread.edl" import *;
 
     include "sgx_quote.h"
 


### PR DESCRIPTION
reason: tx-query fails and crash if the network connection to intel failed, this happens when generating a certification while the first request coming. So when the tx-query starts, using `wait-for-it.sh` to check will pass, but when the first request coming and if the network connection to intel error, tx-query will crash.

solution:  retry 3 times when `SGX_ERROR_BUSY` error happens.