### PR TITLE
Problem: User may enter same view key multiple times in client-cli

### DIFF
--- a/chain-core/src/tx/data/access.rs
+++ b/chain-core/src/tx/data/access.rs
@@ -14,7 +14,7 @@ use crate::common::H264;
 
 /// What can be access in TX -- TODO: revisit when enforced by HW encryption / enclaves
 /// TODO: custom Encode/Decode when data structures are finalized (for backwards/forwards compatibility, encoders/decoders should be able to work with old formats)
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, PartialOrd, Ord)]
 #[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub enum TxAccess {
     AllData,
@@ -31,7 +31,7 @@ impl Default for TxAccess {
 }
 
 /// Specifies who can access what -- TODO: revisit when enforced by HW encryption / enclaves
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
 pub struct TxAccessPolicy {
     #[cfg_attr(

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use chain_core::common::{Timespec, HASH_SIZE_256};
@@ -174,19 +175,21 @@ fn new_withdraw_transaction<T: WalletClient, N: NetworkOpsClient>(
 
     let self_view_key = wallet_client.view_key(name, passphrase)?;
 
-    let mut access_policies = vec![TxAccessPolicy {
+    let mut access_policies = BTreeSet::new();
+    access_policies.insert(TxAccessPolicy {
         view_key: self_view_key.into(),
         access: TxAccess::AllData,
-    }];
+    });
 
     for key in view_keys.iter() {
-        access_policies.push(TxAccessPolicy {
+        access_policies.insert(TxAccessPolicy {
             view_key: key.into(),
             access: TxAccess::AllData,
         });
     }
 
-    let attributes = TxAttributes::new_with_access(get_network_id(), access_policies);
+    let attributes =
+        TxAttributes::new_with_access(get_network_id(), access_policies.into_iter().collect());
 
     network_ops_client.create_withdraw_all_unbonded_stake_transaction(
         name,
@@ -235,19 +238,21 @@ fn new_transfer_transaction<T: WalletClient>(
 
     let self_view_key = wallet_client.view_key(name, passphrase)?;
 
-    let mut access_policies = vec![TxAccessPolicy {
+    let mut access_policies = BTreeSet::new();
+    access_policies.insert(TxAccessPolicy {
         view_key: self_view_key.into(),
         access: TxAccess::AllData,
-    }];
+    });
 
     for key in view_keys.iter() {
-        access_policies.push(TxAccessPolicy {
+        access_policies.insert(TxAccessPolicy {
             view_key: key.into(),
             access: TxAccess::AllData,
         });
     }
 
-    let attributes = TxAttributes::new_with_access(get_network_id(), access_policies);
+    let attributes =
+        TxAttributes::new_with_access(get_network_id(), access_policies.into_iter().collect());
 
     let return_address = wallet_client.new_transfer_address(name, &passphrase)?;
 


### PR DESCRIPTION
Solution: Used `BTreeSet` instead of `Vec`. Fixes https://github.com/crypto-com/chain/issues/840