### PR TITLE
Problem: Client CLI does not show transaction type in history

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -131,8 +131,9 @@ pub enum Command {
         )]
         disable_fast_forward: bool,
         #[structopt(
-            name = "block_height_ensure",
+            name = "block-height-ensure",
             long,
+            default_value = "50",
             help = "Number of block height to rollback the utxos in pending transactions"
         )]
         block_height_ensure: u64,
@@ -436,6 +437,7 @@ impl Command {
                 Cell::new("In/Out", bold),
                 Cell::new("Amount", bold),
                 Cell::new("Fee", bold),
+                Cell::new("Transaction Type", bold),
                 Cell::new("Block Height", bold),
                 Cell::new("Block Time", bold),
             ]));
@@ -469,6 +471,7 @@ impl Command {
                             .unwrap_or_else(|| "-".to_owned()),
                         right_justify,
                     ),
+                    Cell::new(&change.transaction_type, Default::default()),
                     Cell::new(&change.block_height, right_justify),
                     Cell::new(&change.block_time, Default::default()),
                 ]));

--- a/client-core/src/types/transaction_change.rs
+++ b/client-core/src/types/transaction_change.rs
@@ -1,4 +1,5 @@
 //! Types for tracking balance change in a wallet
+use std::fmt;
 use std::ops::Add;
 use std::str::FromStr;
 
@@ -77,6 +78,17 @@ pub enum TransactionType {
     Unbond,
     /// Deposit transaction
     Deposit,
+}
+
+impl fmt::Display for TransactionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransactionType::Transfer => write!(f, "Transfer"),
+            TransactionType::Withdraw => write!(f, "Withdraw"),
+            TransactionType::Unbond => write!(f, "Unbond"),
+            TransactionType::Deposit => write!(f, "Deposit"),
+        }
+    }
 }
 
 /// Balance change a transaction has caused

--- a/client-rpc/src/program.rs
+++ b/client-rpc/src/program.rs
@@ -63,7 +63,7 @@ pub struct Options {
     )]
     pub batch_size: usize,
     #[structopt(
-        name = "block_height_ensure",
+        name = "block-height-ensure",
         long,
         default_value = "50",
         help = "Number of block height to rollback the utxos in the pending transactions"


### PR DESCRIPTION
Solution: Show transaction type in history. This addresses a part of https://github.com/crypto-com/chain/issues/846

Sample output after this change:
```
+------------------------------------------------------------------+--------+----------------------+-----+------------------+--------------+--------------------------------+
| Transaction ID                                                   | In/Out | Amount               | Fee | Transaction Type | Block Height | Block Time                     |
+------------------------------------------------------------------+--------+----------------------+-----+------------------+--------------+--------------------------------+
| cc88d0ca2cbcd6ce167a6db426f40c3da034deb5b4e4f09e5ec01f39af80c0ea | IN     | 24999999999.99999703 |   - | Withdraw         |           92 | 2020-01-07T10:14:17.764748000Z |
+------------------------------------------------------------------+--------+----------------------+-----+------------------+--------------+--------------------------------+
```