### PR TITLE
Problem (#870): There are unfixed clippy suggestions on enclave code

### DIFF
--- a/chain-tx-enclave/enclave-t-common/src/lib.rs
+++ b/chain-tx-enclave/enclave-t-common/src/lib.rs
@@ -60,6 +60,8 @@ where
             return None;
         }
         let opt = unsafe {
+            // TODO check alignment correctness
+            #[allow(clippy::cast_ptr_alignment)]
             SgxSealedData::<[u8]>::from_raw_sealed_data_t(
                 sealed_log.as_mut_ptr() as *mut sgx_sealed_data_t,
                 sealed_log.len() as u32,

--- a/chain-tx-enclave/tx-query/enclave/src/attest.rs
+++ b/chain-tx-enclave/tx-query/enclave/src/attest.rs
@@ -26,13 +26,13 @@ use std::untrusted::time::SystemTimeEx;
 use std::vec::Vec;
 use zeroize::Zeroize;
 
-pub const IAS_HOSTNAME: &'static str = "api.trustedservices.intel.com";
+pub const IAS_HOSTNAME: &str = "api.trustedservices.intel.com";
 #[cfg(not(feature = "production"))]
-pub const API_SUFFIX: &'static str = "/sgx/dev";
+pub const API_SUFFIX: &str = "/sgx/dev";
 #[cfg(feature = "production")]
-pub const API_SUFFIX: &'static str = "/sgx";
-pub const SIGRL_SUFFIX: &'static str = "/attestation/v3/sigrl/";
-pub const REPORT_SUFFIX: &'static str = "/attestation/v3/report";
+pub const API_SUFFIX: &str = "/sgx";
+pub const SIGRL_SUFFIX: &str = "/attestation/v3/sigrl/";
+pub const REPORT_SUFFIX: &str = "/attestation/v3/report";
 
 extern "C" {
     pub fn ocall_sgx_init_quote(
@@ -382,9 +382,9 @@ fn create_attestation_report(
     // (2) Generate the report
     // Fill ecc256 public key into report_data
     let mut report_data: sgx_report_data_t = sgx_report_data_t::default();
-    let mut pub_k_gx = pub_k.gx.clone();
+    let mut pub_k_gx = pub_k.gx;
     pub_k_gx.reverse();
-    let mut pub_k_gy = pub_k.gy.clone();
+    let mut pub_k_gy = pub_k.gy;
     pub_k_gy.reverse();
     report_data.d[..32].clone_from_slice(&pub_k_gx);
     report_data.d[32..].clone_from_slice(&pub_k_gy);
@@ -420,7 +420,7 @@ fn create_attestation_report(
     //       7. [out]p_qe_report need further check
     //       8. [out]p_quote
     //       9. quote_size
-    let (p_sigrl, sigrl_len) = if sigrl_vec.len() == 0 {
+    let (p_sigrl, sigrl_len) = if sigrl_vec.is_empty() {
         (ptr::null(), 0)
     } else {
         (sigrl_vec.as_ptr(), sigrl_vec.len() as u32)

--- a/chain-tx-enclave/tx-query/enclave/src/cert.rs
+++ b/chain-tx-enclave/tx-query/enclave/src/cert.rs
@@ -64,9 +64,9 @@ pub fn gen_ecc_cert(
 ) -> Result<CertKeyPair, sgx_status_t> {
     // Generate public key bytes since both DER will use it
     let mut pub_key_bytes: Vec<u8> = vec![4];
-    let mut pk_gx = pub_k.gx.clone();
+    let mut pk_gx = pub_k.gx;
     pk_gx.reverse();
-    let mut pk_gy = pub_k.gy.clone();
+    let mut pk_gy = pub_k.gy;
     pk_gy.reverse();
     pub_key_bytes.extend_from_slice(&pk_gx);
     pub_key_bytes.extend_from_slice(&pk_gy);
@@ -148,7 +148,7 @@ pub fn gen_ecc_cert(
                         writer.write_sequence(|writer| {
                             writer.next().write_sequence(|writer| {
                                 writer.next().write_oid(&ObjectIdentifier::from_slice(&[
-                                    2, 16, 840, 1, 113730, 1, 13,
+                                    2, 16, 840, 1, 113_730, 1, 13,
                                 ]));
                                 writer.next().write_bytes(&payload.into_bytes());
                             });
@@ -168,9 +168,9 @@ pub fn gen_ecc_cert(
             };
             let sig_der = yasna::construct_der(|writer| {
                 writer.write_sequence(|writer| {
-                    let mut sig_x = sig.x.clone();
+                    let mut sig_x = sig.x;
                     sig_x.reverse();
-                    let mut sig_y = sig.y.clone();
+                    let mut sig_y = sig.y;
                     sig_y.reverse();
                     writer.next().write_biguint(&BigUint::from_slice(&sig_x));
                     writer.next().write_biguint(&BigUint::from_slice(&sig_y));
@@ -195,7 +195,7 @@ pub fn gen_ecc_cert(
             let inner_key_der = yasna::construct_der(|writer| {
                 writer.write_sequence(|writer| {
                     writer.next().write_u8(1);
-                    let mut prv_k_r = prv_k.r.clone();
+                    let mut prv_k_r = prv_k.r;
                     prv_k_r.reverse();
                     writer.next().write_bytes(&prv_k_r);
                     prv_k_r.zeroize();

--- a/chain-tx-enclave/tx-validation/app/src/server/mod.rs
+++ b/chain-tx-enclave/tx-validation/app/src/server/mod.rs
@@ -130,7 +130,7 @@ impl TxValidationServer {
                     Ok(EnclaveRequest::CommitBlock { app_hash, info }) => {
                         let _ = self.metadb.insert(LAST_APP_HASH_KEY, &app_hash);
                         let _ = self.metadb.insert(LAST_CHAIN_INFO_KEY, &info.encode()[..]);
-                        if let Ok(_) = self.flush_all() {
+                        if self.flush_all().is_ok() {
                             self.info = Some(info);
                             EnclaveResponse::CommitBlock(Ok(()))
                         } else {
@@ -156,9 +156,7 @@ impl TxValidationServer {
                         }
                     }
                     Ok(EnclaveRequest::GetSealedTxData { txids }) => {
-                        EnclaveResponse::GetSealedTxData(
-                            self.lookup_txids(txids.iter().map(|x| *x)),
-                        )
+                        EnclaveResponse::GetSealedTxData(self.lookup_txids(txids.iter().copied()))
                     }
                     Ok(EnclaveRequest::EncryptTx(req)) => {
                         let result = match self.info {

--- a/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
@@ -109,6 +109,8 @@ pub(crate) fn decrypt(tx: &TxObfuscated) -> Result<PlainTxAux, ()> {
 #[inline]
 fn unseal_request(request: &mut IntraEncryptRequest) -> Option<EncryptionRequest> {
     let opt = unsafe {
+        // TODO check alignment correctness
+        #[allow(clippy::cast_ptr_alignment)]
         SgxSealedData::<[u8]>::from_raw_sealed_data_t(
             request.sealed_enc_request.as_mut_ptr() as *mut sgx_sealed_data_t,
             request.sealed_enc_request.len() as u32,
@@ -176,7 +178,7 @@ pub(crate) fn handle_encrypt_request(
                 );
                 write_back_response(response, response_buf, response_len)
             } else {
-                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                sgx_status_t::SGX_ERROR_INVALID_PARAMETER
             }
         }
         (Some(EncryptionRequest::DepositStake(tx, witness)), Some(sealed_inputs)) => {
@@ -192,7 +194,7 @@ pub(crate) fn handle_encrypt_request(
                 );
                 write_back_response(response, response_buf, response_len)
             } else {
-                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                sgx_status_t::SGX_ERROR_INVALID_PARAMETER
             }
         }
         (Some(EncryptionRequest::WithdrawStake(tx, account, witness)), None) => {
@@ -208,13 +210,9 @@ pub(crate) fn handle_encrypt_request(
                     );
                     write_back_response(response, response_buf, response_len)
                 }
-                _ => {
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                }
+                _ => sgx_status_t::SGX_ERROR_INVALID_PARAMETER,
             }
         }
-        (_, _) => {
-            return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-        }
+        (_, _) => sgx_status_t::SGX_ERROR_INVALID_PARAMETER,
     }
 }

--- a/chain-tx-enclave/tx-validation/enclave/src/validate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/validate.rs
@@ -85,6 +85,8 @@ fn construct_sealed_response(
             let mut sealed_log: Vec<u8> = vec![0u8; sealed_log_size];
 
             unsafe {
+                // TODO check alignment correctness
+                #[allow(clippy::cast_ptr_alignment)]
                 let sealed_r = sealed_data.to_raw_sealed_data_t(
                     sealed_log.as_mut_ptr() as *mut sgx_sealed_data_t,
                     sealed_log_size as u32,
@@ -183,7 +185,7 @@ pub(crate) fn handle_validate_tx(
                 }
                 _ => {
                     log::error!("can not find plain transfer transaction or unsealed inputs");
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                    sgx_status_t::SGX_ERROR_INVALID_PARAMETER
                 }
             }
         }
@@ -198,7 +200,7 @@ pub(crate) fn handle_validate_tx(
                 }
                 _ => {
                     log::error!("can not get plain deposit stake transaction or unsealed inputs");
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                    sgx_status_t::SGX_ERROR_INVALID_PARAMETER
                 }
             }
         }
@@ -234,13 +236,13 @@ pub(crate) fn handle_validate_tx(
                 }
                 _ => {
                     log::error!("invalid parameter");
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+                    sgx_status_t::SGX_ERROR_INVALID_PARAMETER
                 }
             }
         }
         (_, _) => {
             log::error!("invalid parameter");
-            return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
+            sgx_status_t::SGX_ERROR_INVALID_PARAMETER
         }
     }
 }


### PR DESCRIPTION
Solution:
- Fix existing clippy suggestions.
- Can't add clippy on enclave into travis ci script yet due to lack of sgx sdk

The `cast_ptr_alignment` warning looks suspicious, the correctness dependents on the alignment of `Vec<u8>` pointer, I think normal allocator will produce aligned pointer, so it should be fine normally.

Run on linux:
```
$ cargo clippy -p tx-validation-app -p tx-query-app
$ cargo clippy -p tx-validation-enclave -p tx-query-enclave
```