### PR TITLE
Problem: sgx-cargo-1804-* tests failures not reflected in CI (fix #904)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,7 @@ steps:
     path: /cache
   settings:
     restore: true
+    ttl: 1
     mount:
       - ./drone
 
@@ -58,6 +59,7 @@ steps:
     path: /cache
   settings:
     rebuild: true
+    ttl: 1
     mount:
       - ./drone
 
@@ -156,6 +158,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 0c58269524d8cee0b1ce9aa1cf614b35ef440a6bf42aa03b0ff4b932c706e2f6
+hmac: d3631077bca617f42c0eedd82c5fd79ad14c9c3c5318d64ae6610d54211d7422
 
 ...

--- a/chain-tx-enclave/tx-query/app/src/main.rs
+++ b/chain-tx-enclave/tx-query/app/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     };
     if args.len() < 3 {
         error!("Please provide the address:port to listen on (e.g. \"0.0.0.0:3443\") as the first argument and the ZMQ connection string (e.g. \"ipc://enclave.ipc\" or \"tcp://127.0.0.1:25933\") of the tx-validation server as the second");
-        return;
+        std::process::exit(1);
     }
     init_connection(&args[2]);
 

--- a/chain-tx-enclave/tx-validation/app/src/main.rs
+++ b/chain-tx-enclave/tx-validation/app/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         error!("Please provide the ZMQ connection string (e.g. \"tcp://127.0.0.1:25933\") as the first argument");
-        return;
+        std::process::exit(1);
     }
     let db = sled::open(storage_path()).expect("failed to open a storage path");
     let metadb = db

--- a/ci-scripts/tx-query-hw-test.sh
+++ b/ci-scripts/tx-query-hw-test.sh
@@ -21,15 +21,17 @@ sleep 1
 cd /chain/chain-tx-enclave/tx-validation
 make clean
 make
+cargo build -p tx-validation-app
 
 export SGX_TEST=1
 cd /chain/chain-tx-enclave/tx-query
 make clean
 make
-cargo build -p tx-query-app
+cd app
+cargo build --features sgx-test
 
 export TX_VALIDATION_BIN_DIR=/chain/target/debug
 export TX_QUERY_APP_PORT=`/chain/ci-scripts/find-free-port.sh`
-cd ../../target/debug
+cd ../../../target/debug
 # assumes SPID + IAS_API_KEY environment variables are set from outside / docker
 ./tx-query-app

--- a/ci-scripts/tx-validation-hw-test.sh
+++ b/ci-scripts/tx-validation-hw-test.sh
@@ -21,6 +21,7 @@ sleep 1
 cd /chain/chain-tx-enclave/tx-validation
 make clean
 make
-cargo build -p tx-validation-app
-cd ../../target/debug
+cd app
+cargo build --features sgx-test
+cd ../../../target/debug
 ./tx-validation-app


### PR DESCRIPTION
Solution:
- exiting enclave wrapper apps with status code on error
- fixed CI scripts to build wrapper apps with sgx-test feature (not possible in the workspace :( )
- signed the pipeline + added ttl
