### PR TITLE
Problem (Fix: #912): python integration tests not executed in CI

### DIFF
--- a/integration-tests/cleanup.sh
+++ b/integration-tests/cleanup.sh
@@ -2,10 +2,19 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [ -f data/supervisord.pid ]; then
-    kill -QUIT `cat data/supervisord.pid` && sleep 3
+    echo 'Quit supervisord...'
+    kill -QUIT `cat data/supervisord.pid` 2> /dev/null && sleep 3
 fi
-rm supervisord.log 2> /dev/null
-rm -r data 2> /dev/null
-rm tx_query_enclave.signed.so 2> /dev/null
-rm tx_validation_enclave.signed.so 2> /dev/null
+if [ -f supervisord.log ]; then
+    rm -f supervisord.log
+fi
+if [ -d data ]; then
+    rm -rf data
+fi
+if [ -f tx_query_enclave.signed.so ]; then
+    rm tx_query_enclave.signed.so
+fi
+if [ -f tx_validation_enclave.signed.so ]; then
+    rm tx_validation_enclave.signed.so
+fi
 exit 0

--- a/integration-tests/deps.sh
+++ b/integration-tests/deps.sh
@@ -13,7 +13,7 @@ else
     source $PYTHON_VENV_DIR/bin/activate
 fi
 pip3 install -e .
-pip3 install supervisor
+pip3 install supervisor pytest
 popd
 
 pushd client-rpc; npm install; popd

--- a/integration-tests/pytests/conftest.py
+++ b/integration-tests/pytests/conftest.py
@@ -31,6 +31,8 @@ def addresses():
         rpc.wallet.sync()
         balance = rpc.wallet.balance()
         assert int(balance["total"]) > 0
+    else:
+        balance = rpc.wallet.balance()
     # wait for the pending amount become available
     loop = 0
     while int(balance["pending"]) != 0 and loop < 60:

--- a/integration-tests/pytests/test_watch_only_wallet.py
+++ b/integration-tests/pytests/test_watch_only_wallet.py
@@ -1,4 +1,3 @@
-import os
 import time
 from chainrpc import RPC
 from uuid import uuid1
@@ -9,22 +8,27 @@ rpc = RPC()
 def test_watch_only_wallet(addresses):
     name = str(uuid1())
     print('name', name)
-    enckey, _ = rpc.wallet.create(name)
 
+    enckey, _ = rpc.wallet.create(name)
     view_key_pub = rpc.wallet.view_key(name, enckey=enckey)
     view_key_priv = rpc.wallet.view_key(name, private=True, enckey=enckey)
     transfer_pubkey = rpc.wallet.list_pubkey(name, enckey=enckey)[0]
     transfer_addr = rpc.address.list(name, type='transfer', enckey=enckey)[0]
+    rpc.wallet.delete(name)
 
-    name = 'watch_' + name
     enckey = rpc.wallet.restore_basic(view_key_priv, name=name)
     assert rpc.wallet.view_key(name, enckey=enckey) == view_key_pub
 
-    assert rpc.address.create_watch(transfer_pubkey, name=name, type='transfer', enckey=enckey) == transfer_addr
+    assert rpc.address.create_watch(
+        transfer_pubkey,
+        name=name,
+        type='transfer',
+        enckey=enckey
+    ) == transfer_addr
 
     amount = 10000000
-    rpc.wallet.send(transfer_addr, amount, view_keys=[view_key_pub], enckey=enckey)
-    time.sleep(1)  # wait the block to pop up
+    rpc.wallet.send(transfer_addr, amount, view_keys=[view_key_pub])
+    time.sleep(1)  # wait for the block to pop up, FIXME do it more gracefully
     rpc.wallet.sync()
     rpc.wallet.sync(name, enckey=enckey)
     assert int(rpc.wallet.balance(name, enckey=enckey)["total"]) == amount


### PR DESCRIPTION
Solution:
- Add python integration tests to the `run` script
- moved the python tests directory to `integration-tests/pytests`
- fix the python test

This one is based on https://github.com/crypto-com/chain/pull/916, after that one is merged, rebase this one.