### PR TITLE
Problem (Fix #906): mock mode integration tests not executed on CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !/chain-core
 !/chain-tx-filter
 !/chain-tx-validation
+!/chain-tx-enclave
 !/client-cli
 !/client-common
 !/client-core

--- a/.drone.yml
+++ b/.drone.yml
@@ -91,6 +91,80 @@ trigger:
 
 ---
 kind: pipeline
+name: mock-mode
+
+steps:
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: cache
+    path: /cache
+  settings:
+    restore: true
+    ttl: 1
+    mount:
+      - ./drone
+
+- name: build
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export CARGO_HOME=$PWD/drone/cargo
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - MOCK_CHAIN=1 ./docker/build.sh
+
+- name: unit-tests
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export CARGO_HOME=$PWD/drone/cargo
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - cargo test
+
+- name: integration-tests
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - export PYTHON_VENV_DIR=$PWD/drone/venv
+  - MOCK_CHAIN=1 ./integration-tests/run.sh
+
+- name: rebuild-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: cache
+    path: /cache
+  settings:
+    rebuild: true
+    ttl: 1
+    mount:
+      - ./drone
+
+- name: teardown
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - ./integration-tests/cleanup.sh
+  when:
+    status:
+      - success
+      - failure
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/drone-cache
+
+trigger:
+  branch:
+  - master
+  - staging
+  - trying
+  event:
+  - push
+
+---
+kind: pipeline
 type: exec
 name: sgx-cargo-1804-hw1
 

--- a/docker/Dockerfile.new
+++ b/docker/Dockerfile.new
@@ -1,5 +1,6 @@
 ARG SGX_MODE=HW
 ARG NETWORK_ID=AB
+ARG MOCK_CHAIN=0
 
 FROM ubuntu:18.04 AS RUNTIME_BASE
 LABEL maintainer="blockchain@crypto.com"
@@ -68,12 +69,15 @@ LABEL maintainer="blockchain@crypto.com"
 
 ARG SGX_MODE
 ARG NETWORK_ID
+ARG MOCK_CHAIN
 
 ENV SGX_MODE=$SGX_MODE
 ENV NETWORK_ID=$NETWORK_ID
+ENV MOCK_CHAIN=$MOCK_CHAIN
 
-COPY . /src 
+COPY . /src
 WORKDIR /src
+
 RUN set -e; \
     ./docker/build.sh; \
     mkdir /output; \
@@ -81,16 +85,19 @@ RUN set -e; \
       chain-abci \
       client-cli \
       client-rpc \
-      dev-utils \
+      dev-utils ; \
+    do mv "./target/debug/${bin}" /output; done; \
+    if [ "x$MOCK_CHAIN" = "x0" ]; then \
+    for bin in \
       tx-validation-app \
       tx-query-app \
       tx_query_enclave.signed.so \
       tx_validation_enclave.signed.so ; \
     do mv "./target/debug/${bin}" /output; done; \
+    fi; \
     cargo clean;
 
 FROM RUNTIME_BASE
-
 COPY --from=BUILDER /output/. /crypto-chain
 ENV PATH=/crypto-chain:$PATH
 WORKDIR /crypto-chain

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,11 +2,21 @@
 set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-source $SGX_SDK/environment
+MOCK_CHAIN=${MOCK_CHAIN:-0}
 
 cd ..
-cargo build
-cargo build -p tx-validation-app
-cargo build -p tx-query-app
-make -C chain-tx-enclave/tx-validation
-make -C chain-tx-enclave/tx-query
+if [ $MOCK_CHAIN -eq 1 ]; then
+    cargo build --features mock-enc-dec --manifest-path client-cli/Cargo.toml
+    cargo build --features mock-enc-dec --manifest-path client-rpc/Cargo.toml
+    cargo build --features mock-enc-dec --features mock-validation --manifest-path chain-abci/Cargo.toml
+    cargo build -p dev-utils
+else
+    SGX_SDK=${SGX_SDK-:/opt/intel/sgxsdk}
+    source $SGX_SDK/environment
+
+    cargo build
+    cargo build -p tx-validation-app
+    cargo build -p tx-query-app
+    make -C chain-tx-enclave/tx-validation
+    make -C chain-tx-enclave/tx-query
+fi

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -23,6 +23,13 @@ export TENDERMINT_RPC_PORT=$(($BASE_PORT + 7))
 export CLIENT_RPC_ZEROFEE_PORT=$CLIENT_RPC_PORT
 export TENDERMINT_ZEROFEE_RPC_PORT=$TENDERMINT_RPC_PORT
 
+MOCK_CHAIN=${MOCK_CHAIN:-"0"}
+if [ "x$MOCK_CHAIN" = "x1" ]; then
+    PREPARE_ARG="--mock_mode=True"
+else
+    PREPARE_ARG="--mock_mode=False"
+fi
+
 function wait_http() {
     for i in $(seq 0 10);
     do
@@ -38,7 +45,7 @@ function wait_http() {
 function runtest() {
     echo "Preparing... $1"
     LOWERED_TYPE=`echo $1 | tr "[:upper:]" "[:lower:]"`
-    chainbot.py prepare ${LOWERED_TYPE}_cluster.json --base_port $BASE_PORT
+    chainbot.py prepare ${LOWERED_TYPE}_cluster.json --base_port $BASE_PORT $PREPARE_ARG
 
     echo "Startup..."
     supervisord -n -c data/tasks.ini &


### PR DESCRIPTION
Solution:
- both `docker/build.sh` and `integration-tests/run.sh` recognize the `MOCK_CHAIN`
  environment variable, if the environment variable is 1, build and run in mock mode.
- setup a separate drone pipeline to run the mock mode.
- `Dockerfile.new` support `MOCK_CHAIN` build arg to build mock mode binary image.