### PR TITLE
Problem(fix #882):required tx-query environment vaiables are unchecked

### DIFF
--- a/chain-tx-enclave/tx-query/app/src/main.rs
+++ b/chain-tx-enclave/tx-query/app/src/main.rs
@@ -48,6 +48,10 @@ fn main() {
         error!("Please provide the address:port to listen on (e.g. \"0.0.0.0:3443\") as the first argument and the ZMQ connection string (e.g. \"ipc://enclave.ipc\" or \"tcp://127.0.0.1:25933\") of the tx-validation server as the second");
         std::process::exit(1);
     }
+    if env::var("SPID").is_err() || env::var("IAS_API_KEY").is_err() {
+        error!("the environment SPID and IAS_API_KEY should be set");
+        std::process::exit(1);
+    }
     init_connection(&args[2]);
 
     let enclave = start_enclave();

--- a/ci-scripts/run_tx_query.sh
+++ b/ci-scripts/run_tx_query.sh
@@ -11,16 +11,5 @@ echo "[aesm_service] Running in background ..."
 sleep 4
 
 # assumes SPID + IAS_API_KEY are set
-
-if [ x"${SPID}" == "x" ]; then
-  echo "the environment SPID should be set"
-  exit 1
-fi
-
-if [ x"${IAS_API_KEY}" == "x" ]; then
-  echo "the environment IAS_API_KEY should be set"
-  exit 1
-fi
-
 trap 'kill -TERM $PID' TERM INT
 RUST_LOG=${RUST_LOG} ./tx-query-app 0.0.0.0:${APP_PORT_QUERY} ${TX_VALIDATION_CONN} ${TX_QUERY_TIMEOUT}


### PR DESCRIPTION
Solution:  add environment check when the tx-query app starts, remove the environment check in the docker run script.