### PR TITLE
Problem: Unbonded or unjailed validator cannot rejoin the validator set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +697,18 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cro-clib"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chain-core 0.3.0",
+ "client-common 0.3.0",
+ "client-core 0.3.0",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4065,6 +4093,7 @@ dependencies = [
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+"checksum cbindgen 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1595ec41c4ad8109ad17eb2e38fa52af1244b2321c02144176b5aef0655d5f8e"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -1699,9 +1699,12 @@ fn test_nodejoin_fail() {
     }
     // DuplicateValidator
     {
-        let addresses = BTreeMap::new();
+        let tendermint_validator_address = tx.node_meta.get_tendermint_validator_address();
+
+        let mut addresses = BTreeMap::new();
+        addresses.insert(tendermint_validator_address, addr);
         let mut powers = BTreeMap::new();
-        powers.insert(addr, TendermintVotePower::zero());
+        powers.insert(addr, TendermintVotePower::new(10).unwrap());
         let node_info = NodeInfo {
             minimal_stake: Coin::one(),
             tendermint_validator_addresses: &addresses,

--- a/chain-abci/tests/validator_changes.rs
+++ b/chain-abci/tests/validator_changes.rs
@@ -44,7 +44,7 @@ fn check_unbonding_without_removing_validator() {
     );
 
     // End block
-    // Note: This should not remove validator from validator set. This should only change voting power of validator 1
+    // Note: This should not remove validator from validator set. This should only change voting power of validator
     let response_end_block = app.end_block(&RequestEndBlock {
         height: 1,
         ..Default::default()
@@ -59,7 +59,7 @@ fn check_unbonding_without_removing_validator() {
     );
 }
 
-/// Scenario 2: Unbond stake from validator 2 so that the remaining bonded amount becomes less than
+/// Scenario 2: Unbond stake from a validator so that the remaining bonded amount becomes less than
 /// `required_council_node_stake`. This should remove validator from validator set.
 #[test]
 fn check_unbonding_with_removing_validator() {
@@ -96,7 +96,7 @@ fn check_unbonding_with_removing_validator() {
     );
 
     // End block
-    // Note: This should not remove validator from validator set. This should only change voting power of validator 1
+    // Note: This should not remove validator from validator set. This should only change voting power of validator
     let response_end_block = app.end_block(&RequestEndBlock {
         height: 1,
         ..Default::default()
@@ -104,7 +104,4 @@ fn check_unbonding_with_removing_validator() {
 
     assert_eq!(1, response_end_block.validator_updates.to_vec().len());
     assert_eq!(0, response_end_block.validator_updates.to_vec()[0].power);
-
-    // Scenario 3: Unbond some stake from validator 2. Since validator 2 was already removed from validator set in
-    // scenario 2, this should not trigger and `power_changed_in_block`.
 }

--- a/chain-core/src/init/network.rs
+++ b/chain-core/src/init/network.rs
@@ -81,8 +81,8 @@ pub fn get_bip44_coin_type() -> u32 {
 }
 
 /// Returns bip44 cointype of the provided network
-/// 1     	0x80000001 	    	Testnet (all coins)
-/// 394 	0x8000018a 	CRO 	Crypto.com Chain
+/// 1         0x80000001             Testnet (all coins)
+/// 394       0x8000018a     CRO     Crypto.com Chain
 pub fn get_bip44_coin_type_from_network(network: Network) -> u32 {
     match network {
         Network::Mainnet => 394,

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -20,7 +20,9 @@ use std::str::FromStr;
 // TODO: switch to normal signatures + explicit public key
 #[cfg(not(feature = "mesalock_sgx"))]
 use crate::init::address::ErrorAddress;
-use crate::state::tendermint::{TendermintValidatorPubKey, TendermintVotePower};
+use crate::state::tendermint::{
+    TendermintValidatorAddress, TendermintValidatorPubKey, TendermintVotePower,
+};
 use secp256k1::recovery::{RecoverableSignature, RecoveryId};
 use std::convert::From;
 #[cfg(not(feature = "mesalock_sgx"))]
@@ -197,6 +199,11 @@ impl CouncilNode {
             security_contact,
             consensus_pubkey,
         }
+    }
+
+    #[inline]
+    pub fn get_tendermint_validator_address(&self) -> TendermintValidatorAddress {
+        TendermintValidatorAddress::from(&self.consensus_pubkey)
     }
 }
 


### PR DESCRIPTION
Solution: Modified transaction verification to allow existing validators with zero voting power. Fixes https://github.com/crypto-com/chain/issues/930