### PR TITLE
Problem(Fix #991): mock mode doesn't build

### DIFF
--- a/chain-storage/src/tx.rs
+++ b/chain-storage/src/tx.rs
@@ -49,7 +49,7 @@ impl Storage {
         self.temp_sealed_tx_store.insert(*txid, sealed_log.to_vec());
     }
 
-    pub fn get_sealed_log(&mut self, txid: &TxId) -> Option<Vec<u8>> {
+    pub fn get_sealed_log(&self, txid: &TxId) -> Option<Vec<u8>> {
         // FIXME
         match self.temp_sealed_tx_store.get(txid) {
             None => self.lookup_item(LookupItem::TxBody, txid),

--- a/integration-tests/deps.sh
+++ b/integration-tests/deps.sh
@@ -8,7 +8,7 @@ if [ ! -d $PYTHON_VENV_DIR ];
 then
     python3 -mvenv --without-pip $PYTHON_VENV_DIR
     source $PYTHON_VENV_DIR/bin/activate
-    curl https://bootstrap.pypa.io/get-pip.py | python
+    curl -sL https://bootstrap.pypa.io/get-pip.py | python
 else
     source $PYTHON_VENV_DIR/bin/activate
 fi


### PR DESCRIPTION
Solution:
- make mock mode build again.
- add a chainbot option to support mock mode.

The integration tests run successfully locally with the mock mode.

```
# Build mock mode
$ docker/build.sh mock

# Prepare with mock mode, complete instructions please refer to integration-tests/README.md
$ cd integration-tests
$ chainbot.py prepare zero_fee_cluster.json --mock-mode
$ ...
```