### PR TITLE
Problem: unbonded or unjailed validator cannot rejoin the validator set (fix #930)

### DIFF
--- a/chain-abci/src/app/end_block.rs
+++ b/chain-abci/src/app/end_block.rs
@@ -33,7 +33,8 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
         self.last_state.as_mut().map(|mut state| {
         if let Some(validators) = state.validators.get_validator_updates(
             state.top_level.network_params.get_block_signing_window(),
-            state.top_level.network_params.get_max_validators()) {
+            state.top_level.network_params.get_max_validators(),
+            state.block_time + (state.top_level.network_params.get_unbonding_period() as u64)) {
             resp.set_validator_updates(RepeatedField::from(validators));
         }
         state.last_block_height = _req.height;

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -95,7 +95,7 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             .expect("executing begin block, but no app state stored (i.e. no initchain or recovery was executed)");
 
         last_state.block_time = block_time.try_into().expect("invalid block time");
-
+        last_state.validators.metadata_clean(last_state.block_time);
         if block_height > 1 {
             if let Some(last_commit_info) = req.last_commit_info.as_ref() {
                 // liveness will always be updated for previous block, i.e., `block_height - 1`
@@ -286,10 +286,7 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
                     let state = fee_acc
                         .1
                         .expect("staked state returned in node join verification");
-                    last_state
-                        .validators
-                        .validator_state_helper
-                        .new_valid_node_join_update(&state);
+                    last_state.validators.new_valid_node_join_update(&state);
                     update_staked_state(
                         state,
                         &self.uncommitted_account_root_hash,

--- a/chain-abci/src/app/rewards.rs
+++ b/chain-abci/src/app/rewards.rs
@@ -1,12 +1,11 @@
 use std::cmp::min;
 
+use crate::app::ChainNodeApp;
+use crate::enclave_bridge::EnclaveProxy;
 use chain_core::common::fixed::monetary_expansion;
 use chain_core::init::coin::Coin;
 use chain_core::state::account::StakedStateAddress;
 use chain_core::state::tendermint::{TendermintValidatorAddress, TendermintVotePower};
-
-use crate::app::ChainNodeApp;
-use crate::enclave_bridge::EnclaveProxy;
 
 // rate < 1_000_000, no overflow.
 fn mul_micro(n: u64, rate: u64) -> u64 {
@@ -79,12 +78,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             share,
             &self.uncommitted_account_root_hash,
             &mut self.accounts,
-            TendermintVotePower::from(
-                state
-                    .top_level
-                    .network_params
-                    .get_required_council_node_stake(),
-            ),
+            TendermintVotePower::from(state.minimum_effective()),
         );
 
         self.uncommitted_account_root_hash = root;

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -151,7 +151,7 @@ fn get_dummy_network_params() -> NetworkParameters {
     NetworkParameters::Genesis(InitNetworkParameters {
         initial_fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
         required_council_node_stake: Coin::unit(),
-        unbonding_period: 1,
+        unbonding_period: 86400,
         jailing_config: JailingParameters {
             jail_duration: 86400,
             block_signing_window: 100,
@@ -169,7 +169,7 @@ fn get_dummy_network_params() -> NetworkParameters {
             monetary_expansion_tau: 166_666_600,
             monetary_expansion_decay: 999_860,
         },
-        max_validators: 1,
+        max_validators: 2,
     })
 }
 

--- a/chain-abci/tests/punishment.rs
+++ b/chain-abci/tests/punishment.rs
@@ -4,7 +4,6 @@ use protobuf::well_known_types::Timestamp;
 
 use chain_core::init::coin::Coin;
 use chain_core::state::account::PunishmentKind;
-use chain_core::state::tendermint::TendermintVotePower;
 use test_common::chain_env::{get_account, ChainEnv};
 
 #[test]
@@ -49,14 +48,6 @@ fn end_block_should_update_liveness_tracker() {
         .validator_state_helper
         .validator_voting_power
         .contains_key(&env.accounts[0].staking_address()));
-    let zero_key = (
-        TendermintVotePower::zero(),
-        env.accounts[0].staking_address(),
-    );
-    assert!(state
-        .validators
-        .council_nodes_by_power
-        .contains_key(&zero_key));
     assert!(!state.validators.is_tracked(&validator_address));
 }
 

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -158,6 +158,14 @@ impl NodeChecker for NodeInfoWrap {
     fn is_current_validator_stake(&self, address: &StakedStateAddress) -> bool {
         self.2.contains_key(address)
     }
+
+    fn is_current_previous_unbond(
+        &self,
+        _address: &StakedStateAddress,
+        _tm_address: &TendermintValidatorAddress,
+    ) -> bool {
+        false
+    }
 }
 
 fn prepate_init_tx(

--- a/chain-abci/tests/validator_changes.rs
+++ b/chain-abci/tests/validator_changes.rs
@@ -1,8 +1,9 @@
 use abci::*;
 use chain_core::init::coin::Coin;
 use chain_core::state::tendermint::TendermintVotePower;
+use chain_core::tx::fee::Milli;
 use parity_scale_codec::Encode;
-use test_common::chain_env::ChainEnv;
+use test_common::chain_env::{get_account, ChainEnv};
 
 /// Scenario 1: Unbond stake from a validator so that remaining bonded amount is still greater than
 /// `required_council_node_stake`. This should not remove validator from validator set.
@@ -61,7 +62,9 @@ fn check_unbonding_with_removing_validator() {
         });
     let mut app = env.chain_node(storage, account_storage);
     let _rsp = app.init_chain(&env.req_init_chain());
-
+    let state = app.last_state.as_ref().unwrap();
+    let tm_address = &env.validator_address(0);
+    let staking_address = state.validators.lookup_address(&tm_address).clone();
     // Note: At this point, there are two validators with `Coin::max() / 2` staked amount each.
     // Also, `required_council_node_stake` is set to `Coin::max() / 10`.
 
@@ -79,7 +82,7 @@ fn check_unbonding_with_removing_validator() {
     assert_eq!(0, rsp_tx.code);
 
     // End block
-    // Note: This should not remove validator from validator set. This should only change voting power of validator 1
+    // Note: This should remove validator from validator set.
     let response_end_block = app.end_block(&RequestEndBlock {
         height: 1,
         ..Default::default()
@@ -88,6 +91,133 @@ fn check_unbonding_with_removing_validator() {
     assert_eq!(1, response_end_block.validator_updates.to_vec().len());
     assert_eq!(0, response_end_block.validator_updates.to_vec()[0].power);
 
+    app.commit(&RequestCommit::new());
     // Scenario 3: Unbond some stake from validator 2. Since validator 2 was already removed from validator set in
-    // scenario 2, this should not trigger and `power_changed_in_block`.
+    // scenario 2, this should not trigger any updates
+    // Begin Block
+    app.begin_block(&RequestBeginBlock {
+        last_commit_info: Some(env.last_commit_info(1, true)).into(),
+        ..env.req_begin_block(2, 1)
+    });
+
+    let amount = Coin::one();
+    let tx_aux = env.unbond_tx(amount, 1, 0);
+    let rsp_tx = app.deliver_tx(&RequestDeliverTx {
+        tx: tx_aux.encode(),
+        ..Default::default()
+    });
+
+    assert_eq!(0, rsp_tx.code);
+
+    // End block
+    // Note: This should not do any updates
+    let response_end_block = app.end_block(&RequestEndBlock {
+        height: 2,
+        ..Default::default()
+    });
+
+    assert_eq!(0, response_end_block.validator_updates.to_vec().len());
+    app.commit(&RequestCommit::new());
+    // as default Timestamp in these block headers is 0 (< time + unbonding period), some validator metadata should still be there
+    let validators_meta = &app.last_state.as_ref().expect("state").validators;
+    assert!(validators_meta.is_scheduled_for_delete(&staking_address, &tm_address));
+
+    assert!(validators_meta.is_current_validator(&env.validator_address(0)));
+    // after unbonding period (in unit testing -- 61), it should be cleaned
+    app.begin_block(&RequestBeginBlock {
+        last_commit_info: Some(env.last_commit_info(1, true)).into(),
+        ..env.req_begin_block_with_time(3, 1, 120)
+    });
+    let validators_meta = &app.last_state.as_ref().expect("state").validators;
+    assert!(!validators_meta.is_current_validator(&env.validator_address(0)));
+    assert!(!validators_meta.is_scheduled_for_delete(&staking_address, &tm_address));
+}
+
+/// Scenario 4: Unbond stake from validator 2 so that the remaining bonded amount becomes less than
+/// `required_council_node_stake` after it proposed block(s). This should remove validator from validator set.
+/// After it has received reward, its bonded amount should be > the required one --
+/// at that time, it should be possible for the validator to rejoin + validator metadata shouldn't be deleted after unbonding period
+#[test]
+fn check_rejoin() {
+    // Init Chain
+    let (env, storage, account_storage) = ChainEnv::new_with_customizer(
+        (Coin::max() / 2).unwrap(),
+        (Coin::max() / 2).unwrap(),
+        2,
+        |parameters| {
+            // tweaking times + parameters, something more than 0.0... gets minted
+            parameters.unbonding_period = 3600 * 24 * 10000;
+            parameters.rewards_config.reward_period_seconds = 3600 * 12 * 10000;
+            parameters.required_council_node_stake = (Coin::max() / 4).unwrap();
+            parameters.rewards_config.monetary_expansion_r0 = Milli::new(1, 0);
+            parameters.rewards_config.monetary_expansion_tau = 10_0000_0000_0000_0000;
+            parameters.rewards_config.monetary_expansion_decay = 0;
+        },
+    );
+    let mut app = env.chain_node(storage, account_storage);
+    let _rsp = app.init_chain(&env.req_init_chain());
+    let state = app.last_state.as_ref().unwrap();
+    let tm_address = &env.validator_address(0);
+    let staking_address = state.validators.lookup_address(&tm_address).clone();
+    // Begin Block
+    app.begin_block(&env.req_begin_block(1, 0));
+
+    // Unbond Transaction (this'll change voting power to zero)
+    let amount = Coin::one();
+    let tx_aux = env.unbond_tx(amount, 0, 0);
+    let rsp_tx = app.deliver_tx(&RequestDeliverTx {
+        tx: tx_aux.encode(),
+        ..Default::default()
+    });
+
+    assert_eq!(0, rsp_tx.code);
+
+    // End block
+    // Note: This should not remove validator from validator set. This should only change voting power of validator 1
+    let response_end_block = app.end_block(&RequestEndBlock {
+        height: 1,
+        ..Default::default()
+    });
+    let required_stake = (Coin::max() / 4).unwrap();
+    let acct = get_account(&staking_address, &app);
+    assert!(acct.bonded < required_stake);
+
+    assert_eq!(1, response_end_block.validator_updates.to_vec().len());
+    assert_eq!(0, response_end_block.validator_updates.to_vec()[0].power);
+    app.commit(&RequestCommit::new());
+    let validators_meta = &app.last_state.as_ref().expect("state").validators;
+    assert!(validators_meta.is_scheduled_for_delete(&staking_address, &tm_address));
+
+    // Begin block -- there should be a reward after this one
+    app.begin_block(&RequestBeginBlock {
+        last_commit_info: Some(env.last_commit_info(1, true)).into(),
+        ..env.req_begin_block_with_time(2, 1, 3600 * 12 * 10000 + 1)
+    });
+
+    let acct = get_account(&staking_address, &app);
+    assert!(acct.bonded > required_stake);
+
+    // node join should be ok
+    let validators_meta = &app.last_state.as_ref().expect("state").validators;
+    assert!(validators_meta.is_scheduled_for_delete(&staking_address, &tm_address));
+    let tx_aux = env.join_tx(1, 0);
+    let rsp_tx = app.deliver_tx(&RequestDeliverTx {
+        tx: tx_aux.encode(),
+        ..Default::default()
+    });
+    assert_eq!(0, rsp_tx.code);
+    // it should no longer be planned to be deleted
+    let validators_meta = &app.last_state.as_ref().expect("state").validators;
+    assert!(!validators_meta.is_scheduled_for_delete(&staking_address, &tm_address));
+    // End block
+    // Note: This should bring back the validator to the validator set.
+    let response_end_block = app.end_block(&RequestEndBlock {
+        height: 2,
+        ..Default::default()
+    });
+
+    // validator bonded amount changed after rewards + node join
+    assert_eq!(2, response_end_block.validator_updates.to_vec().len());
+    assert_ne!(0, response_end_block.validator_updates.to_vec()[0].power);
+    assert_ne!(0, response_end_block.validator_updates.to_vec()[1].power);
 }

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -61,7 +61,7 @@ impl fmt::Display for DistributionError {
                 write!(f, "Invalid voting power")
             },
             DistributionError::InvalidPunishmentConfiguration => {
-                write!(f, "Invalid punishment configuration (maybe slash_wait_period >= jail_duration)")
+                write!(f, "Invalid punishment configuration (maybe slash_wait_period >= jail_duration or jail_duration > unbond period)")
             }
             DistributionError::InvalidRewardsParamter(err) => {
                 write!(f, "Invalid rewards parameters: {}", err)
@@ -235,6 +235,10 @@ impl InitConfig {
         if self.network_params.slashing_config.slash_wait_period
             >= self.network_params.jailing_config.jail_duration
         {
+            return Err(DistributionError::InvalidPunishmentConfiguration);
+        }
+
+        if self.network_params.jailing_config.jail_duration > self.network_params.unbonding_period {
             return Err(DistributionError::InvalidPunishmentConfiguration);
         }
 

--- a/client-common/src/tendermint/mock.rs
+++ b/client-common/src/tendermint/mock.rs
@@ -56,7 +56,7 @@ const DEFAULT_GENESIS_JSON: &str = r#"{
                 "coefficient": 0
             },
             "required_council_node_stake": "1250000000000000000",
-            "unbonding_period": 15,
+            "unbonding_period": 86400,
             "jailing_config": {
                 "jail_duration": 86400,
                 "block_signing_window": 100,

--- a/dev-utils/example-dev-conf.json
+++ b/dev-utils/example-dev-conf.json
@@ -3,7 +3,7 @@
         "0x9ca76144cbea76bc47d47a8a016d215eb2831885": "2500000000000000000",
         "0x3ae55c16800dc4bd0e3397a9d7806fb1f11639de": "1250000000000000000"
     },
-    "unbonding_period": 60,
+    "unbonding_period": 86400,
     "required_council_node_stake": "1250000000000000000",
     "jailing_config": {
         "jail_duration": 86400,

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -33,7 +33,7 @@ impl GenesisDevConfig {
     pub fn new(expansion_cap: Coin) -> Self {
         GenesisDevConfig {
             distribution: BTreeMap::new(),
-            unbonding_period: 60,
+            unbonding_period: 86400,
             required_council_node_stake: Coin::new(1_250_000_000_000_000_000).unwrap(),
             jailing_config: JailingParameters {
                 jail_duration: 86400,

--- a/integration-tests/bot/chainbot.py
+++ b/integration-tests/bot/chainbot.py
@@ -173,17 +173,17 @@ def extract_enckey(s):
 def app_state_cfg(cfg):
     return {
         "distribution": gen_distribution(cfg),
-        "unbonding_period": 60,
+        "unbonding_period": 20,
         "required_council_node_stake": "1",
         "jailing_config": {
-            "jail_duration": 86400,
+            "jail_duration": 18,
             "block_signing_window": 100,
             "missed_block_threshold": 50
         },
         "slashing_config": {
             "liveness_slash_percent": "0.1",
             "byzantine_slash_percent": "0.2",
-            "slash_wait_period": 10800
+            "slash_wait_period": 15
         },
         "rewards_config": {
             "monetary_expansion_cap": str(cfg['expansion_cap']),

--- a/integration-tests/multinode/jail_test.py
+++ b/integration-tests/multinode/jail_test.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 import iso8601
 from chainrpc import RPC
-# from chainbot import SigningKey
+from chainbot import SigningKey
 from common import UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, wait_for_blocks, stop_node
 
 '''
@@ -76,18 +76,17 @@ print('Unjail', TARGET_NODE)
 print(rpc.staking.unjail(addr, name='target', enckey=enckey))
 wait_for_blocks(rpc, 1)
 
-# FIXME after #930 fixed
-# print('Join', TARGET_NODE)
-# txid = rpc.staking.join(
-#     TARGET_NODE,
-#     SigningKey(TARGET_NODE_VALIDATOR_SEED).pub_key_base64(),
-#     addr,
-#     enckey=enckey,
-#     name='target',
-# )
-# 
-# print('Wait for 3 blocks')
-# wait_for_blocks(rpc, 3)
-# 
-# print('validators', len(rpc.chain.validators()['validators']))
-# assert len(rpc.chain.validators()['validators']) == 3
+print('Join', TARGET_NODE)
+txid = rpc.staking.join(
+    TARGET_NODE,
+    SigningKey(TARGET_NODE_VALIDATOR_SEED).pub_key_base64(),
+    addr,
+    enckey=enckey,
+    name='target',
+)
+
+print('Wait for 3 blocks')
+wait_for_blocks(rpc, 3)
+
+print('validators', len(rpc.chain.validators()['validators']))
+assert len(rpc.chain.validators()['validators']) == 3

--- a/integration-tests/with_fee_cluster.json
+++ b/integration-tests/with_fee_cluster.json
@@ -28,11 +28,6 @@
             "op": "replace",
             "path": "/initial_fee_policy/per_byte_fee",
             "value": "1.25"
-        },
-        {
-            "op": "replace",
-            "path": "/unbonding_period",
-            "value": 15
         }
     ],
     "tendermint_config_patch": [

--- a/integration-tests/zero_fee_cluster.json
+++ b/integration-tests/zero_fee_cluster.json
@@ -28,11 +28,6 @@
             "op": "replace",
             "path": "/initial_fee_policy/per_byte_fee",
             "value": "0.0"
-        },
-        {
-            "op": "replace",
-            "path": "/unbonding_period",
-            "value": 15
         }
     ],
     "tendermint_config_patch": [

--- a/test-common/src/block_generator.rs
+++ b/test-common/src/block_generator.rs
@@ -579,7 +579,7 @@ fn gen_network_params(
             coefficient: per_byte_fee,
         },
         required_council_node_stake: Coin::unit(),
-        unbonding_period: 60,
+        unbonding_period: 86400,
         jailing_config: params::JailingParameters {
             jail_duration: 86400,
             block_signing_window: 100,


### PR DESCRIPTION
Solution:
based on https://github.com/crypto-com/chain-docs/pull/66/files
- tx validation of node join takes into account minimum effective stake
- added unbonding period check against jail
- validator data is cleaned after end block update generation + for data that can't be deleted yet (e.g. for later byzantine validator lookups), it's scheduled to be deleted after unbonding period
- if (non-jailed) validator re-joins with the same key, the deletion schedule is cancelled
- updated the test configs

NOTE: genesis files in docker/config/* may need updating

