### PR TITLE
Problem (Fix #1028): no automation of release builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 !/chain-core
 !/chain-tx-filter
 !/chain-tx-validation
+!/chain-tx-enclave
+!/chain-storage
 !/client-cli
 !/client-common
 !/client-core
@@ -12,6 +14,7 @@
 !/test-common
 !/dev-utils
 !/enclave-protocol
+!/cro-clib
 !Carog.lock
 !Cargo.toml
 !/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -175,6 +175,30 @@ trigger:
   - push
 
 ---
+kind: pipeline
+name: publish
+
+steps:
+- name: docker
+  image: plugins/docker
+  settings:
+    dockerfile: docker/Dockerfile.new
+    auto_tag: true
+    repo:
+      from_secret: DOCKER_REPO
+    username:
+      from_secret: DOCKER_USERNAME
+    password:
+      from_secret: DOCKER_PASSWORD
+
+trigger:
+  branch:
+    - master
+  event:
+    - push
+    - tag
+
+---
 kind: signature
 hmac: 7a9c0c146be1e59a7a5f2a1af22f9bbcb238b2dfec553b8c8eb235df01c13d52
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ id_ecdsa
 
 # drone cache
 /drone
+/.drone.secret
 
 # integration tests temparary artifacts
 /integration-tests/*.so

--- a/docker/Dockerfile.new
+++ b/docker/Dockerfile.new
@@ -88,7 +88,7 @@ RUN set -e; \
       tx-query-app \
       tx_query_enclave.signed.so \
       tx_validation_enclave.signed.so ; \
-    do mv "./target/debug/${bin}" /output; done; \
+    do mv "./target/${BUILD_PROFILE}/${bin}" /output; done; \
     cargo clean;
 
 FROM RUNTIME_BASE


### PR DESCRIPTION
Solution:
- Add docker image build and publish in drone pipeline

Needs `DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DOCKER_REPO` to drone secret file.