### PR TITLE
Problem (Fix #1034): node with a jailed staked state remains/returns as an active validator

### DIFF
--- a/chain-abci/src/app/app_init/validator_state.rs
+++ b/chain-abci/src/app/app_init/validator_state.rs
@@ -337,6 +337,13 @@ impl ValidatorState {
                 let mut state = get_account(addr, &root, &accounts)
                     .expect("io error or validator account not exists");
 
+                if state.is_jailed() {
+                    log::error!(
+                        "Jailed validator should not have reward stats, will cause coins burned"
+                    );
+                    continue;
+                }
+
                 let amount = (share * count).unwrap();
                 let _balance = state.add_reward(amount).unwrap();
                 root = update_staked_state(state.clone(), &root, accounts).0;


### PR DESCRIPTION
Solution:
- Don't reward jailed account
