### PR TITLE
Problem (Fix #850): no automated test for jailing using byzantine faults

### DIFF
--- a/integration-tests/multinode/byzantine_cluster.json
+++ b/integration-tests/multinode/byzantine_cluster.json
@@ -1,0 +1,62 @@
+{
+    "root_path": "./data",
+    "chain_id": "test-chain-y3m1e6-AB",
+    "genesis_time": "2019-11-20T08:56:48.618137Z",
+    "expansion_cap": 40000000000000000,
+    "nodes": [
+        {
+            "name": "node0",
+            "hostname": "127.0.0.1",
+            "mnemonic": "must sunny destroy cousin ladder survey wrong employ illness thing divert under ready purpose elegant",
+            "validator_seed": "3d96c3c476e463bdcd751c9bf1715b7da37229ac00be33f34496797ca892b68a",
+            "node_seed": "208ff2032ea90646cecee2b21de3488593f8c3a0b9c78ab02bfbf9aa15ab35b4",
+            "bonded_coin": 0,
+            "unbonded_coin": 100000000000000000,
+            "base_port": 26650
+        },
+        {
+            "name": "node1",
+            "hostname": "127.0.0.1",
+            "mnemonic": "push main gun wish camera tree unaware name season hospital ripple account beef invest dwarf",
+            "validator_seed": "3d96c3c476e463bdcd751c9bf1715b7da37229ac00be33f34496797ca892b68a",
+            "node_seed": "9f36cc1f8a2b08895394fd093f3c4b5583b57993c080942145f46a3737c83630",
+            "bonded_coin": 0,
+            "unbonded_coin": 100000000000000000,
+            "base_port": 26660
+        },
+        {
+            "name": "node2",
+            "hostname": "127.0.0.1",
+            "mnemonic": "symptom labor zone shrug chicken bargain hood define tornado mass inquiry rural step color guitar",
+            "validator_seed": "5c1b9c06ae7485cd0f9d75819f964db3b1306ebd397f5bbdc1dd386a32b7c1c0",
+            "node_seed": "d40ed56a5fcfa9f196f12d4a7d347774e4ab10de7ec0d173a926ea1f2451a0e4",
+            "bonded_coin": 90000000000000000,
+            "unbonded_coin": 90000000000000000,
+            "base_port": 26670
+        }
+    ],
+    "chain_config_patch": [
+        {
+            "op": "replace",
+            "path": "/initial_fee_policy/base_fee",
+            "value": "0.0"
+        },
+        {
+            "op": "replace",
+            "path": "/initial_fee_policy/per_byte_fee",
+            "value": "0.0"
+        }
+    ],
+    "tendermint_config_patch": [
+        {
+            "op": "replace",
+            "path": "/consensus/create_empty_blocks",
+            "value": true
+        },
+        {
+            "op": "add",
+            "path": "/consensus/create_empty_blocks_interval",
+            "value": "0s"
+        }
+    ]
+}

--- a/integration-tests/multinode/byzantine_test.py
+++ b/integration-tests/multinode/byzantine_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import os
+import time
+from chainrpc import RPC
+from chainbot import SigningKey
+from common import UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, wait_for_blocks, stop_node, wait_for_tx
+
+'''
+- 3 nodes
+- node2 has more than 2/3 voting powers
+- node0 and node1 have same validator seed, both have 0 bonded coins initially, only unbonded coins.
+- start the nodes, and stop node1 immediately.
+- withdraw, deposit and join node0.
+- start node1, check node0 punished with byzantine fault.
+'''
+
+# keep these values same as jail_cluster.json
+VALIDATOR_SEED = '3d96c3c476e463bdcd751c9bf1715b7da37229ac00be33f34496797ca892b68a'
+BASE_PORT = int(os.environ.get('BASE_PORT', 25560))
+TARGET_PORT = BASE_PORT + 2 * 10
+
+supervisor = UnixStreamXMLRPCClient('data/supervisor.sock')
+rpc = RPC(BASE_PORT)
+
+# stop node1
+print('Stop node1')
+time.sleep(5)  # FIXME, remove after adr-001 implemented
+stop_node(supervisor, 'node1')
+
+print('Wait for 1 validators online')
+wait_for_validators(rpc, 1)
+
+enckey = rpc.wallet.enckey()
+os.environ['ENCKEY'] = enckey
+bonded_staking, unbonded_staking = rpc.address.list()[:2]
+transfer = rpc.address.list(type='transfer')[0]
+
+txid = rpc.staking.withdraw_all_unbonded(unbonded_staking, transfer)
+wait_for_tx(rpc, txid)
+rpc.wallet.sync()
+
+txid = rpc.staking.deposit(bonded_staking, [{'id': txid, 'index': 0}])
+wait_for_tx(rpc, txid)
+rpc.wallet.sync()
+
+wait_for_blocks(rpc, 3)
+
+print('Join node0')
+txid = rpc.staking.join(
+    'node0',
+    SigningKey(VALIDATOR_SEED).pub_key_base64(),
+    bonded_staking
+)
+
+wait_for_tx(rpc, txid)
+
+wait_for_blocks(rpc, 3)
+assert len(rpc.chain.validators()['validators']) == 2
+
+# start node1
+supervisor.supervisor.startProcessGroup('node1')
+wait_for_port(BASE_PORT + 10 + 9)
+
+wait_for_blocks(rpc, 13)
+punishment = rpc.staking.state(bonded_staking)['punishment']
+print('punishment', punishment)
+assert punishment['kind'] == 'ByzantineFault'

--- a/integration-tests/run_multinode.sh
+++ b/integration-tests/run_multinode.sh
@@ -78,5 +78,6 @@ fi
 
 runtest "jail"
 runtest "join"
+runtest "byzantine"
 
 ./cleanup.sh


### PR DESCRIPTION
Solution:
- test procedure:
      - 3 nodes
      - node2 has more than 2/3 voting powers
      - node0 and node1 have same validator seed, both have 0 bonded coins initially, only unbonded coins.
      - start the nodes, and stop node1 immediately.
      - withdraw, deposit and join node0.
      - start node1, check node0 punished with byzantine fault.