### PR TITLE
Problem (Fix #1050): No integration-tests CI running in the cloud automatically

### DIFF
--- a/.drone.mock.yml
+++ b/.drone.mock.yml
@@ -1,0 +1,59 @@
+---
+kind: pipeline
+name: default
+
+steps:
+- name: build
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export BUILD_MODE=mock
+  - export CARGO_HOME=$PWD/drone/cargo
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - ./docker/build.sh
+
+- name: unit-tests
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export BUILD_MODE=mock
+  - export CARGO_HOME=$PWD/drone/cargo
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - ./docker/unittest.sh
+
+- name: integration-tests
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export BUILD_MODE=mock
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - export PYTHON_VENV_DIR=$PWD/drone/venv
+  - ./integration-tests/run.sh
+
+- name: multinode-tests
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export BUILD_MODE=mock
+  - export CARGO_TARGET_DIR=$PWD/drone/target
+  - export PYTHON_VENV_DIR=$PWD/drone/venv
+  - ./integration-tests/run_multinode.sh
+
+- name: teardown
+  image: cryptocom/chain-test:latest
+  pull: if-not-exists
+  commands:
+  - export BUILD_MODE=mock
+  - ./integration-tests/cleanup.sh
+  when:
+    status:
+      - success
+      - failure
+
+trigger:
+  branch:
+  - master
+  - staging
+  - trying
+  event:
+  - push

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ id_ecdsa
 
 # drone cache
 /drone
-/.drone.env
+/.drone.secret
 
 # integration tests temparary artifacts
 /integration-tests/*.so

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -20,3 +20,7 @@ kvdb-memorydb = "0.3"
 dirs = "2.0.1"
 quest = "0.3"
 secstr = "0.4.0"
+
+[features]
+mock-enc-dec = ["chain-abci/mock-enc-dec"]
+mock-validation = ["chain-abci/mock-validation"]

--- a/docker/Dockerfile.new
+++ b/docker/Dockerfile.new
@@ -1,6 +1,34 @@
 ARG SGX_MODE=HW
 ARG NETWORK_ID=AB
 
+FROM ubuntu:18.04 AS KCOV_BUILDER
+
+RUN set -e; \
+    apt-get update; \
+    apt-get install -y \
+        binutils-dev \
+        build-essential \
+        cmake \
+        git \
+        curl \
+        libcurl4-openssl-dev \
+        libdw-dev \
+        libiberty-dev \
+        ninja-build \
+        python3 \
+        zlib1g-dev \
+        ; \
+    mkdir /src; \
+    cd /src; \
+    curl -sL https://github.com/SimonKagstrom/kcov/archive/38.tar.gz | tar xzf - -C /src
+
+RUN cd /src/kcov-38 && \
+    mkdir build && \
+    cd build && \
+    cmake -G 'Ninja' .. && \
+    cmake --build . && \
+    cmake --build . --target install
+
 FROM ubuntu:18.04 AS RUNTIME_BASE
 LABEL maintainer="blockchain@crypto.com"
 
@@ -32,7 +60,7 @@ ENV SGX_MODE=$SGX_MODE
 ENV NETWORK_ID=$NETWORK_ID
 
 RUN set -e; \
-    apt-get update -y; \
+    apt-get update; \
     apt-get install -y \
       cmake \
       libgflags-dev \
@@ -52,8 +80,12 @@ ARG NETWORK_ID
 ENV SGX_MODE=$SGX_MODE
 ENV NETWORK_ID=$NETWORK_ID
 
+# install kcov
+COPY --from=KCOV_BUILDER /usr/local/bin/kcov* /usr/bin/
+
+# install python3.8, nodejs
 RUN set -e; \
-    apt-get update -y; \
+    apt-get update; \
     apt-get install -y software-properties-common; \
     add-apt-repository -y ppa:deadsnakes/ppa; \
     apt-get install -y python3.8 python3-distutils; \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,17 +19,16 @@ fi
 
 cd ..
 
+echo "Build $BUILD_MODE $BUILD_PROFILE"
 if [ $BUILD_MODE == "sgx" ]; then
-    echo "Build sgx"
     cargo build $CARGO_ARGS
     cargo build $CARGO_ARGS -p tx-validation-app
     cargo build $CARGO_ARGS -p tx-query-app
     make -C chain-tx-enclave/tx-validation
     make -C chain-tx-enclave/tx-query
 else
-    echo "Build mock"
-    cargo build $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path chain-abci/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enc-dec  --manifest-path client-rpc/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enc-dec  --manifest-path client-cli/Cargo.toml
-    cargo build $CARGO_ARGS -p dev-utils
+    cargo build $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path dev-utils/Cargo.toml
+    cargo build $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path chain-abci/Cargo.toml
 fi

--- a/docker/unittest.sh
+++ b/docker/unittest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+BUILD_PROFILE=${BUILD_PROFILE:-debug}
+BUILD_MODE=${BUILD_MODE:-sgx}
+
+echo "Test $BUILD_MODE $BUILD_PROFILE"
+if [ $BUILD_MODE == "sgx" ]; then
+    cargo test $CARGO_ARGS
+else
+    cargo test $CARGO_ARGS --features mock-enc-dec  --manifest-path client-rpc/Cargo.toml
+    cargo test $CARGO_ARGS --features mock-enc-dec  --manifest-path client-cli/Cargo.toml
+    cargo test $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path dev-utils/Cargo.toml
+    cargo test $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path chain-abci/Cargo.toml
+fi

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -33,12 +33,15 @@ export CLIENT_RPC_ZEROFEE_PORT=$CLIENT_RPC_PORT
 export TENDERMINT_ZEROFEE_RPC_PORT=$TENDERMINT_RPC_PORT
 
 function wait_http() {
-    for i in $(seq 0 10);
+    echo "Wait for http port $1"
+    for i in $(seq 0 20);
     do
         curl -s "http://127.0.0.1:$1" > /dev/null
         if [ $? -eq 0 ]; then
+            echo "Http port $1 is available now"
             return 0
         fi
+        echo "[`date`] Http port $1 not available yet, sleep 2 seconds and retry"
         sleep 2
     done
     return 1
@@ -53,7 +56,6 @@ function runtest() {
     supervisord -n -c data/tasks.ini &
     if ! wait_http $CLIENT_RPC_PORT; then
         echo 'client-rpc still not ready, giveup.'
-        cat data/logs/*.log
         RETCODE=1
     else
         set +e

--- a/integration-tests/run_multinode.sh
+++ b/integration-tests/run_multinode.sh
@@ -30,12 +30,15 @@ export BASE_PORT=${BASE_PORT:-26650}
 export CLIENT_RPC_PORT=$(($BASE_PORT + 9))
 
 function wait_http() {
-    for i in $(seq 0 10);
+    echo "Wait for http port $1"
+    for i in $(seq 0 20);
     do
         curl -s "http://127.0.0.1:$1" > /dev/null
         if [ $? -eq 0 ]; then
+            echo "Http port $1 is available now"
             return 0
         fi
+        echo "[`date`] Http port $1 not available yet, sleep 2 seconds and retry"
         sleep 2
     done
     return 1
@@ -49,7 +52,6 @@ function runtest() {
     supervisord -n -c data/tasks.ini &
     if ! wait_http $CLIENT_RPC_PORT; then
         echo 'client-rpc of first node still not ready, giveup.'
-        cat data/logs/*.log
         RETCODE=1
     else
         set +e


### PR DESCRIPTION
Solution:
- Add mock drone to run integration-tests on cloud.drone.io
- Use cargo-make to do coverage
- Prebuilt kcov in chain-test image
- Change 127.0.0.1 -> localhost for executing test on cloud.drone.io

Needs to update image `cryptocom/chain-test:latest` first:
```
$ docker build -f docker/Dockerfile.new --target TEST -t cryptocom/chain-test:latest .
$ docker push cryptocom/chain-test:latest
```

Add `CODECOV_TOKEN` into drone secret for upload coverage report to codecov.io