### PR TITLE
Problem: drone check status name collides with the cloud version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -176,6 +176,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 7a9c0c146be1e59a7a5f2a1af22f9bbcb238b2dfec553b8c8eb235df01c13d52
+hmac: 4ffc692e5e8f67c7eb37a5f594e7bbb0edc78959d19547613c87b95021ad1331
 
 ...

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "continuous-integration/travis-ci/push",
-  "continuous-integration/drone/push"
+  "drone-hw/push"
 ]
 
 timeout_sec = 7200


### PR DESCRIPTION
Solution: renamed the custom drone to "drone-hw" + updated the pipeline sig after restart
