### PR TITLE
Problem (Fix #1007): liveness tracker doesn't contain information about some nodes in multi-node integration test

### DIFF
--- a/chain-abci/src/app/app_init/validator_state.rs
+++ b/chain-abci/src/app/app_init/validator_state.rs
@@ -385,7 +385,18 @@ impl ValidatorState {
                 liveness_tracker.update(block_height, signed);
             }
             None => {
-                log::warn!("Validator in `last_commit_info` not found in liveness tracker");
+                if let Some(staking_address) = self.tendermint_validator_addresses.get(tm_address) {
+                    log::info!(
+                        "Validator in `last_commit_info` not found in liveness tracker: {}: {}",
+                        tm_address,
+                        staking_address
+                    );
+                } else {
+                    log::error!(
+                        "Validator in `last_commit_info` is cleaned up/non-existent: {}",
+                        tm_address
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Solution:
- Check `tendermint_validator_addresses` when `liveness_tracker` not found, if cleaned up, log error otherwise log info.