### PR TITLE
Problem (Fix #1089): the upper bound of reward parameters are too restrictive

### DIFF
--- a/chain-abci/tests/validator_changes.rs
+++ b/chain-abci/tests/validator_changes.rs
@@ -147,10 +147,10 @@ fn check_rejoin() {
         |parameters| {
             // tweaking times + parameters, something more than 0.0... gets minted
             parameters.unbonding_period = 3600 * 24 * 10000;
-            parameters.rewards_config.reward_period_seconds = 3600 * 12 * 10000;
+            parameters.rewards_config.reward_period_seconds = 365 * 24 * 3600;
             parameters.required_council_node_stake = (Coin::max() / 4).unwrap();
             parameters.rewards_config.monetary_expansion_r0 = Milli::new(1, 0);
-            parameters.rewards_config.monetary_expansion_tau = 10_0000_0000_0000_0000;
+            parameters.rewards_config.monetary_expansion_tau = 1000_0000_0000_0000_0000;
             parameters.rewards_config.monetary_expansion_decay = 0;
         },
     );
@@ -191,7 +191,7 @@ fn check_rejoin() {
     // Begin block -- there should be a reward after this one
     app.begin_block(&RequestBeginBlock {
         last_commit_info: Some(env.last_commit_info(1, true)).into(),
-        ..env.req_begin_block_with_time(2, 1, 3600 * 12 * 10000 + 1)
+        ..env.req_begin_block_with_time(2, 1, 365 * 24 * 3600 + 1)
     });
 
     let acct = get_account(&staking_address, &app);

--- a/chain-core/src/init/params.rs
+++ b/chain-core/src/init/params.rs
@@ -203,8 +203,8 @@ impl RewardsParameters {
         if self.monetary_expansion_tau == 0 {
             return Err("tau can't == 0");
         }
-        if self.monetary_expansion_tau > 100_00000000_00000000_u64 {
-            return Err("tau too big");
+        if self.reward_period_seconds > 365 * 86400 {
+            return Err("reward period can't exceed 365 days");
         }
         if self.monetary_expansion_decay > 1_000_000 {
             return Err("decay can't > 1_000_000");


### PR DESCRIPTION
Solution:
  - Add more reasoning into the range of parameters.

The reasoning behind the choice:
https://github.com/crypto-com/chain/issues/1089#issuecomment-587327223