### PR TITLE
Problem (Fix #1095): Reward distribution don't increase staking account's nonce

### DIFF
--- a/chain-abci/src/app/rewards.rs
+++ b/chain-abci/src/app/rewards.rs
@@ -138,6 +138,7 @@ mod tests {
         let staking = state.validators.lookup_address(&env.validator_address(0));
         let acct = get_account(staking, &app);
         assert_eq!(acct.bonded, (env.share() + reward1).unwrap());
+        assert_eq!(acct.nonce, 1);
 
         // propose block by second validator.
         let reward2 = monetary_expansion(
@@ -160,6 +161,7 @@ mod tests {
         let staking = state.validators.lookup_address(&env.validator_address(1));
         let acct = get_account(staking, &app);
         assert_eq!(acct.bonded, (env.share() + reward2).unwrap());
+        assert_eq!(acct.nonce, 1);
 
         // rewards decrease
         assert!(reward2 > Coin::zero() && reward2 < reward1);

--- a/chain-abci/tests/validator_changes.rs
+++ b/chain-abci/tests/validator_changes.rs
@@ -200,7 +200,7 @@ fn check_rejoin() {
     // node join should be ok
     let validators_meta = &app.last_state.as_ref().expect("state").validators;
     assert!(validators_meta.is_scheduled_for_delete(&staking_address, &tm_address));
-    let tx_aux = env.join_tx(1, 0);
+    let tx_aux = env.join_tx(2, 0);
     let rsp_tx = app.deliver_tx(&RequestDeliverTx {
         tx: tx_aux.encode(),
         ..Default::default()

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -430,6 +430,7 @@ impl StakedState {
     }
 
     pub fn add_reward(&mut self, amount: Coin) -> Result<Coin, CoinError> {
+        self.nonce += 1;
         self.bonded = (self.bonded + amount)?;
         Ok(self.bonded)
     }


### PR DESCRIPTION
Solution:
- Increase nonce by one when add reward.