### PR TITLE
Problem:(fix #827)no import/export for non-HD keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "pbr",
  "quest",
  "secstr",
+ "serde_json",
  "structopt",
  "tiny-bip39",
  "unicase 2.6.0",

--- a/chain-tx-validation/src/lib.rs
+++ b/chain-tx-validation/src/lib.rs
@@ -273,11 +273,11 @@ pub fn verify_transfer(
         &extra_info,
         transaction_inputs,
     )?;
-    let outcoins = maintx.get_output_total();
-    if let Err(_coin_err) = outcoins {
-        return Err(Error::InvalidSum); // FIXME: Err(Error::InvalidSum(coin_err));
-    }
-    check_input_output_sums(incoins, outcoins.unwrap(), &extra_info)
+    let outcoins = maintx.get_output_total().map_err(|_| {
+        // FIXME: Err(Error::InvalidSum(coin_err));
+        Error::InvalidSum
+    })?;
+    check_input_output_sums(incoins, outcoins, &extra_info)
 }
 
 /// checks depositing to a staked state -- TODO: this will be moved to an enclave

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -25,4 +25,5 @@ env_logger = "0.7.1"
 cli-table = "0.2"
 zeroize = "1.1"
 base64 = "0.11"
+serde_json = "1.0"
 tiny-bip39 = { version = "0.7", default-features = false }

--- a/client-core/src/service.rs
+++ b/client-core/src/service.rs
@@ -17,7 +17,7 @@ pub use self::root_hash_service::RootHashService;
 pub use self::sync_state_service::{
     delete_sync_state, load_sync_state, save_sync_state, SyncState, SyncStateService,
 };
-pub use self::wallet_service::{load_wallet, save_wallet, Wallet, WalletService};
+pub use self::wallet_service::{load_wallet, save_wallet, Wallet, WalletInfo, WalletService};
 pub use self::wallet_state_service::{
     delete_wallet_state, load_wallet_state, modify_wallet_state, save_wallet_state, WalletState,
     WalletStateService,

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -6,9 +6,10 @@ use chain_core::common::{H256, HASH_SIZE_256};
 use chain_core::tx::data::Tx;
 use client_common::{Error, ErrorKind, PublicKey, Result as CommonResult, ResultExt, SecKey};
 use client_core::types::AddressType;
+use client_core::wallet::WalletRequest;
 use client_core::{MultiSigWalletClient, WalletClient};
 
-use crate::server::{to_rpc_error, WalletRequest};
+use crate::server::to_rpc_error;
 
 #[rpc]
 pub trait MultiSigRpc: Send + Sync {

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
-use crate::server::{rpc_error_from_string, to_rpc_error, WalletRequest};
+use crate::server::{rpc_error_from_string, to_rpc_error};
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{
     CouncilNode, StakedState, StakedStateAddress, StakedStateOpAttributes,
@@ -15,6 +15,7 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use client_common::{Error, ErrorKind, PublicKey, Result as CommonResult, ResultExt, Transaction};
+use client_core::wallet::WalletRequest;
 use client_core::{MultiSigWalletClient, WalletClient};
 use client_network::NetworkOpsClient;
 

--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -1,11 +1,12 @@
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
-use crate::server::{to_rpc_error, WalletRequest};
+use crate::server::to_rpc_error;
 use client_common::tendermint::Client;
 use client_common::Storage;
 use client_core::synchronizer::PollingSynchronizer;
 use client_core::wallet::syncer::{ObfuscationSyncerConfig, WalletSyncer};
+use client_core::wallet::WalletRequest;
 use client_core::TransactionObfuscation;
 
 #[rpc]

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -14,7 +14,7 @@ use chain_core::tx::fee::LinearFee;
 use client_common::storage::SledStorage;
 use client_common::tendermint::types::GenesisExt;
 use client_common::tendermint::{Client, WebsocketRpcClient};
-use client_common::{ErrorKind, Result, SecKey};
+use client_common::{ErrorKind, Result};
 #[cfg(not(feature = "mock-enc-dec"))]
 use client_core::cipher::DefaultTransactionObfuscation;
 #[cfg(feature = "mock-enc-dec")]
@@ -28,8 +28,6 @@ use jsonrpc_core::{self, IoHandler};
 use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
 #[cfg(feature = "mock-enc-dec")]
 use log::warn;
-use secstr::SecUtf8;
-use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "mock-enc-dec"))]
 type AppTransactionCipher = DefaultTransactionObfuscation;
@@ -233,16 +231,4 @@ pub(crate) fn rpc_error_from_string(error: String) -> jsonrpc_core::Error {
         message: error,
         data: None,
     }
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct CreateWalletRequest {
-    pub name: String,
-    pub passphrase: SecUtf8,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct WalletRequest {
-    pub name: String,
-    pub enckey: SecKey,
 }


### PR DESCRIPTION
Solution: 
* add `export` method to backup a wallet, and `import` method to store the wallet again, both in client-rpc and client-cli
* add unit test