### PR TITLE
Problem: kvdb 0.4 fails to compile (fixes #1015)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396be0e5561ccd1bf7ff0b2007487cdd7a87a056873fe6ea906b35d4dbf7ed8"
+checksum = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
 dependencies = [
  "parity-bytes",
  "parity-util-mem",
@@ -1814,20 +1814,20 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25ef14155e418515c4839e9144c839de3506e68946f255a32b7f166095493d"
+checksum = "b9355274e5a9e0a7e8ef43916950eae3949024de2a8dffe4d5a6c13974a37c8e"
 dependencies = [
  "kvdb",
  "parity-util-mem",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.0",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1053e90a54421a842b6bf5d0e4a5cb5364c0bf570f713c58e44a9906f501d9"
+checksum = "af36fd66ccd99f3f771ae39b75aaba28b952372b6debfb971134bf1f03466ab2"
 dependencies = [
  "fs-swap",
  "interleaved-ordered",
@@ -1836,7 +1836,7 @@ dependencies = [
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.0",
  "regex",
  "rocksdb",
  "smallvec 1.2.0",
@@ -2227,14 +2227,14 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b04e4d2588668d5aa93144b3bd719be963542e60042d66c7586ca763838a5b"
+checksum = "ef1476e40bf8f5c6776e9600983435821ca86eb9819d74a6207cca69d091406a"
 dependencies = [
  "cfg-if",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.0",
  "smallvec 1.2.0",
  "winapi 0.3.8",
 ]

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -22,9 +22,9 @@ enclave-protocol = { path = "../enclave-protocol" }
 log = "0.4.8"
 env_logger = "0.7.1"
 bit-vec = { version = "0.6.1", features = ["serde_no_std"] }
-kvdb = "0.3"
-kvdb-rocksdb = "0.4"
-kvdb-memorydb = "0.3"
+kvdb = "0.4"
+kvdb-rocksdb = "0.5"
+kvdb-memorydb = "0.4"
 starling = "3.1.2"
 byteorder = "1.3.4"
 serde = "1.0"

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 blake2 = "0.8"
-kvdb = "0.3"
-kvdb-rocksdb = "0.4"
-kvdb-memorydb = "0.3"
+kvdb = "0.4"
+kvdb-rocksdb = "0.5"
+kvdb-memorydb = "0.4"
 chain-core = { path = "../chain-core" }
 bit-vec = { version = "0.6.1", features = ["serde_no_std"] }
 starling = "3.1.2"

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-kvdb-memorydb = "0.3"
+kvdb-memorydb = "0.4"
 dirs = "2.0.1"
 quest = "0.3"
 secstr = "0.4.0"

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -15,7 +15,7 @@ secstr = { version = "0.4.0", features = ["serde"] }
 lazy_static  = { version = "1.4", features = ["spin_no_std"] }
 signature = "1.0.0-pre.1"
 abci = "0.6"
-kvdb-memorydb = "0.3"
+kvdb-memorydb = "0.4"
 protobuf = "2.7.0"
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], version = "1.1" }


### PR DESCRIPTION
Solution: bumped versions of all three related crates