### PR TITLE
Problem:(cro-1046)no c-api bindings for ios

### DIFF
--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [lib]
 name = "cro_clib"
-crate-type =["cdylib"]
+crate-type =["staticlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cro-clib/Makefile
+++ b/cro-clib/Makefile
@@ -1,0 +1,8 @@
+all:
+	cd ./examples && make
+ios: ios_install ios_compile
+ios_install:
+	cargo install cargo-lipo
+	rustup target add aarch64-apple-ios x86_64-apple-ios
+ios_compile:
+	cargo lipo -p cro-clib --release


### PR DESCRIPTION
Solution: add ios compile script
this builds ios cro-clib on mac
1. install xcode
2. run `make ios` in cro-clib folder

