### PR TITLE
Problem: uncommitted chain-abci storage changes may persisted (fixes #885)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,8 @@ dependencies = [
  "parity-scale-codec",
  "secp256k1zkp",
  "secstr",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -325,7 +325,6 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             // The question is whether it really is -- e.g. if Tendermint/ABCI app crashes during DeliverTX
             // and then it tries to replay the block on the restart, will it cause problems
             // with the account storage (starling / MerkleBIT), because it already persisted those "future" / not-yet-committed account states?
-            // TODO: check-verify / test starling persistence safety?
             // TODO: most of these intermediate uncommitted tree roots aren't useful (not exposed for querying) -- prune them / the account storage?
             self.uncommitted_account_root_hash = next_account_root;
             let mut kvpair = KVPair::new();
@@ -344,7 +343,7 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
                 .expect("rewards pool + fee greater than max coin?");
             rewards_pool.period_bonus = new_remaining;
             self.rewards_pool_updated = true;
-            self.storage.write_buffered();
+            // updates in DeliverTx are not persisted -- only in-mem in self.storage
         }
         resp
     }

--- a/chain-abci/src/app/query.rs
+++ b/chain-abci/src/app/query.rs
@@ -40,7 +40,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
         key: &H256,
         log_message: &str,
     ) {
-        let v = self.storage.lookup_item(item, &key);
+        let v = self.storage.lookup_item(item, &key, false);
         match v {
             Some(uv) => {
                 resp.value = uv;
@@ -109,7 +109,9 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                     "tx not found",
                 );
                 if let (Some(txid), true) = (key, _req.prove) {
-                    let mwitness = self.storage.lookup_item(LookupItem::TxWitness, &txid);
+                    let mwitness = self
+                        .storage
+                        .lookup_item(LookupItem::TxWitness, &txid, false);
                     if let Some(witness) = mwitness {
                         let last_height: i64 =
                             self.last_state.as_ref().map_or(0, |x| x.last_block_height);
@@ -121,7 +123,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
                         let app_hash = self.storage.get_historical_app_hash(height).unwrap();
                         let data = self
                             .storage
-                            .lookup_item(LookupItem::TxsMerkle, &app_hash)
+                            .lookup_item(LookupItem::TxsMerkle, &app_hash, false)
                             .unwrap();
                         let tree = MerkleTree::decode(&mut data.as_slice()).expect("merkle tree");
 

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -59,6 +59,7 @@ impl ResponseWithCodeAndLog for ResponseDeliverTx {
 }
 
 impl<T: EnclaveProxy> ChainNodeApp<T> {
+    // TODO: CheckTx only against only committed states or a custom CheckTx sub-state?
     fn handle_tx(
         &mut self,
         txaux: &TxAux,

--- a/chain-abci/src/storage/mod.rs
+++ b/chain-abci/src/storage/mod.rs
@@ -39,7 +39,7 @@ fn check_spent_input_lookup(
     }
     let mut result = Vec::with_capacity(inputs.len());
     for txin in inputs.iter() {
-        let txo = storage.lookup_input(txin);
+        let txo = storage.lookup_input(txin, true);
         match txo {
             Err(InputError::InvalidIndex) => {
                 return Err(Error::InvalidInput);

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -668,11 +668,11 @@ fn valid_commit_should_persist() {
 
     assert!(app
         .storage
-        .lookup_item(LookupItem::TxSealed, &tx.id())
+        .lookup_item(LookupItem::TxSealed, &tx.id(), false)
         .is_none());
     assert!(app
         .storage
-        .lookup_item(LookupItem::TxWitness, &tx.id())
+        .lookup_item(LookupItem::TxWitness, &tx.id(), false)
         .is_none());
     let persisted_state =
         ChainNodeState::decode(&mut app.storage.get_last_app_state().unwrap().as_slice()).unwrap();
@@ -682,11 +682,11 @@ fn valid_commit_should_persist() {
     assert_eq!(0, app.delivered_txs.len());
     assert!(app
         .storage
-        .lookup_item(LookupItem::TxSealed, &tx.id())
+        .lookup_item(LookupItem::TxSealed, &tx.id(), false)
         .is_some());
     assert!(app
         .storage
-        .lookup_item(LookupItem::TxWitness, &tx.id())
+        .lookup_item(LookupItem::TxWitness, &tx.id(), false)
         .is_some());
     assert_eq!(10, app.last_state.as_ref().unwrap().last_block_height);
     assert_eq!(
@@ -707,13 +707,14 @@ fn valid_commit_should_persist() {
         .storage
         .lookup_item(
             LookupItem::TxsMerkle,
-            &app.last_state.as_ref().unwrap().last_apphash
+            &app.last_state.as_ref().unwrap().last_apphash,
+            false
         )
         .is_some());
     // TODO: check account
     let new_utxos = BitVec::from_bytes(
         &app.storage
-            .lookup_item(LookupItem::TxMetaSpent, &tx.id())
+            .lookup_item(LookupItem::TxMetaSpent, &tx.id(), false)
             .unwrap(),
     );
     assert!(!new_utxos.any());
@@ -785,7 +786,7 @@ pub fn get_account(account_address: &RedeemAddress, app: &ChainNodeApp<MockClien
 fn get_tx_meta(txid: &TxId, app: &ChainNodeApp<MockClient>) -> BitVec {
     BitVec::from_bytes(
         &app.storage
-            .lookup_item(LookupItem::TxMetaSpent, txid)
+            .lookup_item(LookupItem::TxMetaSpent, txid, false)
             .unwrap(),
     )
 }

--- a/chain-storage/src/tx.rs
+++ b/chain-storage/src/tx.rs
@@ -1,4 +1,4 @@
-use crate::{LookupItem, Storage, COL_BODIES, COL_MERKLE_PROOFS, COL_TX_META, COL_WITNESS};
+use crate::{LookupItem, Storage};
 use bit_vec::BitVec;
 use chain_core::common::H256;
 use chain_core::tx::data::input::{TxoIndex, TxoPointer};
@@ -19,64 +19,64 @@ pub enum InputError {
 impl Storage {
     /// Given a db and a DB transaction, it will go through TX inputs and mark them as spent
     /// in the TX_META storage.
+    /// (expects existing tx)
     pub fn spend_utxos(&mut self, txins: &[TxoPointer]) {
         let mut updated_txs = BTreeMap::new();
+        let col = LookupItem::TxMetaSpent;
         for txin in txins.iter() {
             updated_txs
                 .entry(txin.id)
                 .or_insert_with(|| {
-                    BitVec::from_bytes(&self.db.get(COL_TX_META, &txin.id[..]).unwrap().unwrap())
+                    BitVec::from_bytes(
+                        &self
+                            .lookup_item(col, &txin.id, true)
+                            .expect("tx meta create for existing utxo"),
+                    )
                 })
                 .set(txin.index as usize, true);
         }
-        let dbtx = self.get_or_create_tx();
         for (txid, bv) in &updated_txs {
-            dbtx.put(COL_TX_META, &txid[..], &bv.to_bytes());
+            self.insert_item(col, *txid, bv.to_bytes());
         }
     }
 
     pub fn create_utxo(&mut self, no_of_outputs: TxoIndex, txid: &TxId) {
-        let dbtx = self.get_or_create_tx();
-        dbtx.put(
-            COL_TX_META,
-            txid,
-            &BitVec::from_elem(no_of_outputs as usize, false).to_bytes(),
+        self.insert_item(
+            LookupItem::TxMetaSpent,
+            *txid,
+            BitVec::from_elem(no_of_outputs as usize, false).to_bytes(),
         );
     }
 
     pub fn store_sealed_log(&mut self, txid: &TxId, sealed_log: &[u8]) {
-        // FIXME
-        self.temp_sealed_tx_store.insert(*txid, sealed_log.to_vec());
+        self.insert_item(LookupItem::TxSealed, *txid, sealed_log.to_vec());
     }
 
     pub fn get_sealed_log(&self, txid: &TxId) -> Option<Vec<u8>> {
-        // FIXME
-        match self.temp_sealed_tx_store.get(txid) {
-            None => self.lookup_item(LookupItem::TxSealed, txid),
-            Some(x) => Some(x.clone()),
-        }
+        self.lookup_item(LookupItem::TxSealed, txid, true)
     }
 
     pub fn store_tx_body(&mut self, txid: &TxId, tx_payload: &[u8]) {
-        let dbtx = self.get_or_create_tx();
-        dbtx.put(COL_BODIES, txid, tx_payload);
+        self.insert_item(LookupItem::TxBody, *txid, tx_payload.to_vec());
     }
 
     pub fn store_tx_witness(&mut self, txid: &TxId, witness_payload: &[u8]) {
-        let dbtx = self.get_or_create_tx();
-        dbtx.put(COL_WITNESS, txid, witness_payload);
+        self.insert_item(LookupItem::TxWitness, *txid, witness_payload.to_vec());
     }
 
     pub fn store_txs_merkle_tree(&mut self, app_hash: &H256, tree_payload: &[u8]) {
-        let dbtx = self.get_or_create_tx();
-        dbtx.put(COL_MERKLE_PROOFS, app_hash, tree_payload);
+        self.insert_item(LookupItem::TxsMerkle, *app_hash, tree_payload.to_vec());
     }
 
     /// returns the status of the given input (transaction output of a different tx)
-    pub fn lookup_input(&self, txin: &TxoPointer) -> Result<InputStatus, InputError> {
-        let txo = self.db.get(COL_TX_META, &txin.id[..]);
+    pub fn lookup_input(
+        &self,
+        txin: &TxoPointer,
+        read_uncommitted: bool,
+    ) -> Result<InputStatus, InputError> {
+        let txo = self.lookup_item(LookupItem::TxMetaSpent, &txin.id, read_uncommitted);
         match txo {
-            Ok(Some(v)) => {
+            Some(v) => {
                 let input_index = txin.index as usize;
                 let bv = BitVec::from_bytes(&v).get(input_index);
                 match bv {
@@ -85,18 +85,7 @@ impl Storage {
                     Some(false) => Ok(InputStatus::Unspent),
                 }
             }
-            Ok(None) => Err(InputError::InvalidTxId),
-            Err(e) => Err(InputError::IoError(e)),
-        }
-    }
-
-    pub fn write_buffered(&mut self) {
-        let mtx = self.current_tx.take();
-        if let Some(tx) = mtx {
-            // this "buffered write" shouldn't persist (persistence done in commit)
-            // but should change it in-memory
-            // FIXME: https://github.com/crypto-com/chain/issues/885
-            self.db.write_buffered(tx)
+            None => Err(InputError::InvalidTxId),
         }
     }
 }


### PR DESCRIPTION
Solution: for the TX-related ops, added a temporary map in storage:
- insertions during delivertx will update the temporary map + insert entry into the current db tx
- at commit, the db tx is written and flushed
- lookup extended to indicate whether the caller wants to read the uncommitted change (as in delivertx
-- e.g. if two transactions in the same block want to spend the same utxo,
only the first one is valid, so processing needs to read the uncommitted change from the first one before processing the second one)
or committed change (e.g. in queries)

added two quick unit tests (the first one used to fail with "buffered_write" -- "buffered_write" was removed, as inserts are kind of buffered writes)
