### PR TITLE
Problem (Fix #1121): Too tedious to create separated c apis for all client features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,11 @@ dependencies = [
  "chain-core",
  "client-common",
  "client-core",
+ "client-network",
+ "client-rpc",
  "hex 0.4.2",
+ "jsonrpc-core",
+ "libc",
  "parity-scale-codec",
  "secp256k1zkp",
  "secstr",
@@ -1878,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ default-members = [
     "test-common",
     "dev-utils",
     "enclave-protocol",
+    "cro-clib",
 ]

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -30,7 +30,7 @@ use chain_core::tx::{data::TxId, TransactionId};
 /// 7. Calculate `new_fees`.
 /// 8. If `new_fees > fees`, then change `fees = new_fees` and goto step 3, otherwise return signed transaction.
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DefaultWalletTransactionBuilder<S, F, O>
 where
     S: Storage,

--- a/client-rpc/src/lib.rs
+++ b/client-rpc/src/lib.rs
@@ -1,5 +1,6 @@
 mod program;
-mod rpc;
+/// Used by c api
+pub mod rpc;
 mod server;
 
 pub fn run() {

--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -94,3 +94,14 @@ where
         syncer.sync().map_err(to_rpc_error)
     }
 }
+
+impl<S, C, O> Drop for SyncRpcImpl<S, C, O>
+where
+    S: Storage,
+    C: Client,
+    O: TransactionObfuscation,
+{
+    fn drop(&mut self) {
+        self.polling_synchronizer.stop();
+    }
+}

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [lib]
 name = "cro_clib"
-crate-type =["staticlib"]
+crate-type =["staticlib", "cdylib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,9 +18,15 @@ hex="0.4.2"
 chain-core = { path = "../chain-core" }
 client-common = { path = "../client-common" }
 client-core = { path = "../client-core" }
+client-network = { path = "../client-network" }
+client-rpc = { path = "../client-rpc" }
 secstr = { version = "0.4.0", features = ["serde"] }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+jsonrpc-core = "14.0"
+libc = "0.2.67"
 
 [build-dependencies]
 cbindgen = "0.13.0"
 
+[features]
+mock-enc-dec = ["client-rpc/mock-enc-dec"]

--- a/cro-clib/chain.h
+++ b/cro-clib/chain.h
@@ -272,6 +272,31 @@ CroResult cro_join(uint8_t network,
 
 /**
  * # Safety
+ *
+ * Should not be called with null pointers.
+ *
+ * c example:
+ *
+ * ```c
+ * char buf[BUFSIZE];
+ * const char* req = "{\"jsonrpc\": \"2.0\", \"method\": \"wallet_list\", \"params\": [], \"id\": 1}";
+ * int retcode = cro_jsonrpc_call("./data", "ws://...", 0xab, req, buf, sizeof(buf));
+ * if (retcode == 0) {
+ *     printf("response: %s\n", buf);
+ * } else {
+ *     printf("error: %s\n", buf);
+ * }
+ * ```
+ */
+CroResult cro_jsonrpc_call(const char *storage_dir,
+                           const char *websocket_url,
+                           uint8_t network_id,
+                           const char *request,
+                           char *buf,
+                           uintptr_t buf_size);
+
+/**
+ * # Safety
  */
 CroResult cro_restore_hdwallet(const char *mnemonics_string, CroHDWalletPtr *wallet_out);
 

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -1,0 +1,194 @@
+use jsonrpc_core::IoHandler;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+use chain_core::tx::fee::LinearFee;
+use client_common::storage::SledStorage;
+use client_common::tendermint::{types::GenesisExt, Client, WebsocketRpcClient};
+use client_common::{ErrorKind, Result, ResultExt};
+#[cfg(not(feature = "mock-enc-dec"))]
+use client_core::cipher::DefaultTransactionObfuscation;
+#[cfg(feature = "mock-enc-dec")]
+use client_core::cipher::MockAbciTransactionObfuscation;
+use client_core::signer::WalletSignerManager;
+use client_core::transaction_builder::DefaultWalletTransactionBuilder;
+use client_core::wallet::syncer::ObfuscationSyncerConfig;
+use client_core::wallet::DefaultWalletClient;
+use client_network::network_ops::DefaultNetworkOpsClient;
+use client_rpc::rpc::{
+    multisig_rpc::{MultiSigRpc, MultiSigRpcImpl},
+    staking_rpc::{StakingRpc, StakingRpcImpl},
+    sync_rpc::{SyncRpc, SyncRpcImpl},
+    transaction_rpc::{TransactionRpc, TransactionRpcImpl},
+    wallet_rpc::{WalletRpc, WalletRpcImpl},
+};
+
+use crate::types::CroResult;
+
+#[cfg(not(feature = "mock-enc-dec"))]
+type AppTransactionCipher = DefaultTransactionObfuscation;
+#[cfg(feature = "mock-enc-dec")]
+type AppTransactionCipher = MockAbciTransactionObfuscation<WebsocketRpcClient>;
+
+type AppTxBuilder = DefaultWalletTransactionBuilder<SledStorage, LinearFee, AppTransactionCipher>;
+type AppWalletClient = DefaultWalletClient<SledStorage, WebsocketRpcClient, AppTxBuilder>;
+type AppOpsClient = DefaultNetworkOpsClient<
+    AppWalletClient,
+    SledStorage,
+    WebsocketRpcClient,
+    LinearFee,
+    AppTransactionCipher,
+>;
+type AppSyncerConfig =
+    ObfuscationSyncerConfig<SledStorage, WebsocketRpcClient, AppTransactionCipher>;
+
+/// normal
+#[cfg(not(feature = "mock-enc-dec"))]
+fn get_tx_query(tendermint_client: WebsocketRpcClient) -> Result<DefaultTransactionObfuscation> {
+    DefaultTransactionObfuscation::from_tx_query(&tendermint_client)
+}
+
+/// temporary
+#[cfg(feature = "mock-enc-dec")]
+fn get_tx_query(
+    tendermint_client: WebsocketRpcClient,
+) -> Result<MockAbciTransactionObfuscation<WebsocketRpcClient>> {
+    Ok(MockAbciTransactionObfuscation::new(tendermint_client))
+}
+
+fn make_wallet_client(
+    storage: SledStorage,
+    tendermint_client: WebsocketRpcClient,
+) -> Result<AppWalletClient> {
+    let signer_manager = WalletSignerManager::new(storage.clone());
+    let transaction_cipher = get_tx_query(tendermint_client.clone())?;
+    let transaction_builder = DefaultWalletTransactionBuilder::new(
+        signer_manager,
+        tendermint_client.genesis().unwrap().fee_policy(),
+        transaction_cipher,
+    );
+    Ok(DefaultWalletClient::new(
+        storage,
+        tendermint_client,
+        transaction_builder,
+        Some(50),
+    ))
+}
+
+fn make_ops_client(
+    storage: SledStorage,
+    tendermint_client: WebsocketRpcClient,
+) -> Result<AppOpsClient> {
+    let transaction_cipher = get_tx_query(tendermint_client.clone())?;
+    let signer_manager = WalletSignerManager::new(storage.clone());
+    let fee_algorithm = tendermint_client.genesis().unwrap().fee_policy();
+    let wallet_client = make_wallet_client(storage, tendermint_client.clone())?;
+    Ok(DefaultNetworkOpsClient::new(
+        wallet_client,
+        signer_manager,
+        tendermint_client,
+        fee_algorithm,
+        transaction_cipher,
+    ))
+}
+
+fn make_syncer_config(
+    storage: SledStorage,
+    tendermint_client: WebsocketRpcClient,
+) -> Result<AppSyncerConfig> {
+    let transaction_cipher = get_tx_query(tendermint_client.clone())?;
+
+    Ok(AppSyncerConfig::new(
+        storage,
+        tendermint_client,
+        transaction_cipher,
+        true,
+        50,
+        50,
+    ))
+}
+
+fn do_jsonrpc_call(
+    storage_dir: &str,
+    websocket_url: &str,
+    network_id: u8,
+    json_request: &str,
+) -> Result<String> {
+    let mut io = IoHandler::new();
+    let storage = SledStorage::new(storage_dir)?;
+    let tendermint_client = WebsocketRpcClient::new(websocket_url)?;
+    let wallet_client = make_wallet_client(storage.clone(), tendermint_client.clone())?;
+    let ops_client = make_ops_client(storage.clone(), tendermint_client.clone())?;
+    let syncer_config = make_syncer_config(storage, tendermint_client)?;
+
+    let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
+    let transaction_rpc = TransactionRpcImpl::new(network_id);
+    let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
+    let sync_rpc = SyncRpcImpl::new(syncer_config);
+    let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
+
+    io.extend_with(multisig_rpc.to_delegate());
+    io.extend_with(transaction_rpc.to_delegate());
+    io.extend_with(staking_rpc.to_delegate());
+    io.extend_with(sync_rpc.to_delegate());
+    io.extend_with(wallet_rpc.to_delegate());
+
+    // let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
+    io.handle_request_sync(json_request)
+        .err_kind(ErrorKind::InvalidInput, || {
+            "stateful command execute failed"
+        })
+}
+
+/// # Safety
+///
+/// Should not be called with null pointers.
+///
+/// c example:
+///
+/// ```c
+/// char buf[BUFSIZE];
+/// const char* req = "{\"jsonrpc\": \"2.0\", \"method\": \"wallet_list\", \"params\": [], \"id\": 1}";
+/// int retcode = cro_jsonrpc_call("./data", "ws://...", 0xab, req, buf, sizeof(buf));
+/// if (retcode == 0) {
+///     printf("response: %s\n", buf);
+/// } else {
+///     printf("error: %s\n", buf);
+/// }
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn cro_jsonrpc_call(
+    storage_dir: *const c_char,
+    websocket_url: *const c_char,
+    network_id: u8,
+    request: *const c_char,
+    buf: *mut c_char,
+    buf_size: usize,
+) -> CroResult {
+    let res = do_jsonrpc_call(
+        CStr::from_ptr(storage_dir)
+            .to_str()
+            .expect("storage_dir should be utf-8"),
+        CStr::from_ptr(websocket_url)
+            .to_str()
+            .expect("storage_dir should be utf-8"),
+        network_id,
+        CStr::from_ptr(request)
+            .to_str()
+            .expect("storage_dir should be utf-8"),
+    );
+    match res {
+        Err(e) => {
+            libc::strncpy(
+                buf,
+                CString::new(e.to_string()).unwrap().into_raw(),
+                buf_size,
+            );
+            CroResult::fail()
+        }
+        Ok(s) => {
+            libc::strncpy(buf, CString::new(s).unwrap().into_raw(), buf_size);
+            CroResult::success()
+        }
+    }
+}

--- a/cro-clib/src/lib.rs
+++ b/cro-clib/src/lib.rs
@@ -5,6 +5,7 @@ pub mod types;
 pub mod wallet;
 pub use chain_core::init::network::Network;
 pub mod fee;
+pub mod jsonrpc;
 pub mod transaction;
 pub mod transaction_deposit;
 pub mod transaction_staking;

--- a/cro-clib/src/transaction_staking.rs
+++ b/cro-clib/src/transaction_staking.rs
@@ -114,7 +114,7 @@ fn create_encoded_signed_join(
         consensus_pubkey: pubkey,
     };
     let transaction: NodeJoinRequestTx = NodeJoinRequestTx {
-        nonce: nonce,
+        nonce,
         address: to_address,
         attributes,
         node_meta: node_metadata,

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -28,6 +28,7 @@ if [ $BUILD_MODE == "sgx" ]; then
 else
     cargo build $CARGO_ARGS --features mock-enc-dec  --manifest-path client-rpc/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enc-dec  --manifest-path client-cli/Cargo.toml
+    cargo build $CARGO_ARGS --features mock-enc-dec  --manifest-path cro-clib/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path dev-utils/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enc-dec --features mock-validation --manifest-path chain-abci/Cargo.toml
 fi


### PR DESCRIPTION
Solution:
- create `jsonrpc_call` api to encapulate all commands of `client-rpc`.