### PR TITLE
Problem: 0.3.1 not reflected in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,21 @@
 *Unreleased*
 
 ## v0.4.0
-...
+
+### Breaking changes
+* *chain-abci* [1090](https://github.com/crypto-com/chain/pull/1090): upper bounds of reward parameters changed
+* *chain-abci* [1100](https://github.com/crypto-com/chain/pull/1100): account nonce increased after reward distribution
+
+### Features
+* *client* [1072](https://github.com/crypto-com/chain/pull/1072): airgap-friendly workflow for client
+
+### Improvements
+* *client* [1099](https://github.com/crypto-com/chain/pull/1099): client-cli asks to confirm the value
+* *client* [1074](https://github.com/crypto-com/chain/pull/1074): watch-only mode can be used in client-cli
+
+### Bug Fixes
+* *chain-abci* [1092](https://github.com/crypto-com/chain/pull/1092): rewards may be recorded for inactive validators
+* *chain-abci* [1116](https://github.com/crypto-com/chain/pull/1116): uncommitted changes may be persisted
 
 ## v0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 *Unreleased*
 
-## v0.?.?
+## v0.4.0
 ...
+
+## v0.3.1
+
+*February 24, 2020*
+
+This release contains a hotfix for two client issues in the 0.3.0 release (the binaries for chain-abci, enclaves, and dev-utils remain the same).
+
+### Bug Fixes
+* *client* [1117](https://github.com/crypto-com/chain/pull/1117): lightweight verification may fail with blocks with multiple transactions due to a different order of txids in btreemap
+* *client* [1118](https://github.com/crypto-com/chain/pull/1118): incorrect fee estimation
 
 *February 16, 2020*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chain-abci"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "abci",
  "base64 0.11.0",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "chain-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aead",
  "base64 0.11.0",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "chain-storage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bit-vec 0.6.1",
  "blake2",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "chain-tx-filter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bit-vec 0.6.1",
  "chain-core",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "chain-tx-validation"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chain-core",
  "parity-scale-codec",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "client-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "client-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "aes-gcm-siv",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "client-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base58",
  "base64 0.11.0",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "client-network"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "client-rpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dev-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chain-abci",
  "chain-core",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chain-core",
  "chain-tx-validation",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "test-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "abci",
  "base64 0.11.0",
@@ -3890,7 +3890,7 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tx-query-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cc",
  "chain-core",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "tx-query-enclave"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "bit-vec 0.6.1",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "tx-validation-enclave"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aead",
  "aes-gcm-siv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chain-abci"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "abci",
  "base64 0.11.0",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "chain-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aead",
  "base64 0.11.0",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "chain-storage"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bit-vec 0.6.1",
  "blake2",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "chain-tx-filter"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bit-vec 0.6.1",
  "chain-core",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "chain-tx-validation"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chain-core",
  "parity-scale-codec",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "client-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "client-common"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aes",
  "aes-gcm-siv",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "client-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base58",
  "base64 0.11.0",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "client-network"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "client-rpc"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dev-utils"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chain-abci",
  "chain-core",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-protocol"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chain-core",
  "chain-tx-validation",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "test-common"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "abci",
  "base64 0.11.0",
@@ -3890,7 +3890,7 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tx-query-app"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cc",
  "chain-core",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "tx-query-enclave"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "bit-vec 0.6.1",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "tx-validation-enclave"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aead",
  "aes-gcm-siv",

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-abci"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Pre-alpha version prototype of Crypto.com Chain node (Tendermint ABCI application)"
 readme = "README.md"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-abci"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Pre-alpha version prototype of Crypto.com Chain node (Tendermint ABCI application)"
 readme = "README.md"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library with core types and serialization for the use in external tools"
 readme = "../README.md"

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-core"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library with core types and serialization for the use in external tools"
 readme = "../README.md"

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-storage"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Storage of Crypto.com Chain node (Merkle trie, transaction metadata etc.)"
 readme = "README.md"

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-storage"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Storage of Crypto.com Chain node (Merkle trie, transaction metadata etc.)"
 readme = "README.md"

--- a/chain-tx-enclave/tx-query/app/Cargo.toml
+++ b/chain-tx-enclave/tx-query/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-query-app"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Application server wrapper around the transaction query enclave (optional)."
 readme = "../../README.md"

--- a/chain-tx-enclave/tx-query/app/Cargo.toml
+++ b/chain-tx-enclave/tx-query/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-query-app"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Application server wrapper around the transaction query enclave (optional)."
 readme = "../../README.md"

--- a/chain-tx-enclave/tx-query/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-query/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-query-enclave"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "The transaction query enclave."
 readme = "../../README.md"

--- a/chain-tx-enclave/tx-query/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-query/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-query-enclave"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "The transaction query enclave."
 readme = "../../README.md"

--- a/chain-tx-enclave/tx-validation/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-validation-enclave"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "The transaction validation enclave."
 readme = "../../README.md"

--- a/chain-tx-enclave/tx-validation/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-validation-enclave"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "The transaction validation enclave."
 readme = "../../README.md"

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-tx-filter"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library that captures the fuctionality related to block-level public view key-based transaction filtering."
 readme = "../README.md"

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-tx-filter"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library that captures the fuctionality related to block-level public view key-based transaction filtering."
 readme = "../README.md"

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-tx-validation"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library with functions that verify, given current chain state's data, if a transaction is valid."
 readme = "../README.md"

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-tx-validation"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Library with functions that verify, given current chain state's data, if a transaction is valid."
 readme = "../README.md"

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-cli"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-cli"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-common"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-common"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-core"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 description = "This crate exposes following functionalities for interacting with Crypto.com Chain."
 edition = "2018"

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 description = "This crate exposes following functionalities for interacting with Crypto.com Chain."
 edition = "2018"
@@ -23,7 +23,7 @@ itertools = "0.8"
 base64 = "0.11"
 webpki = "0.21"
 rustls =  {version = "0.16", features = ["dangerous_configuration"]}
-yasna = { version = "0.3.0", features = ["bit-vec", "num-bigint", "chrono"] }
+yasna = { version = "0.3.1", features = ["bit-vec", "num-bigint", "chrono"] }
 bit-vec = "0.6.1"
 num-bigint = "0.2.5"
 serde_json = "1.0.48"

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-network"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-network"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-rpc"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Calvin Lau <calvin@crypto.com>"]
 edition = "2018"
 

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-rpc"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Calvin Lau <calvin@crypto.com>"]
 edition = "2018"
 

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dev-utils"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Basic CLI for development purposes (e.g. generation of genesis.json parameters)"
 edition = "2018"

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dev-utils"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Basic CLI for development purposes (e.g. generation of genesis.json parameters)"
 edition = "2018"

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-protocol"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Requests and responses exchanges over ZMQ between chain-abci app "
 readme = "../README.md"

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-protocol"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Requests and responses exchanges over ZMQ between chain-abci app "
 readme = "../README.md"

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-common"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["yihuang <yi.codeplayer@gmail.com>"]
 edition = "2018"
 

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-common"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["yihuang <yi.codeplayer@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Solution: updated changelog + bumped version numbers

--

Note this PR contains 2 commits, as the one with 0.3.1 will be cherry-picked onto release/v0.3 with the aforementioned fixes