### PR TITLE
Problem: Makefile is trying to compile tx-validation-ap #1128

### DIFF
--- a/ci-scripts/run_chain_abci.sh
+++ b/ci-scripts/run_chain_abci.sh
@@ -8,10 +8,17 @@ if [ x"${SGX_MODE}" == "xHW" ]; then
   LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service &
 
   echo "[aesm_service] Running in background ..."
-  # Wait for aesm_service to initialize
-  sleep 4
 fi
 
+PID=$!
 trap 'kill -TERM $PID' TERM INT
-echo "[Config] start enclave on port ${APP_PORT_VALIDATION}"
-RUST_LOG=${RUST_LOG} ./tx-validation-app tcp://0.0.0.0:${APP_PORT_VALIDATION}
+
+echo "[Config] start chain abci on port 26658"
+chain-abci \
+    --chain_id ${CHAIN_ID} \
+    --data /crypto-chain/chain-storage \
+    --enclave_server ${TX_VALIDATION_CONN} \
+    --genesis_app_hash ${APP_HASH} \
+    --host 0.0.0.0 \
+    --port 26658 \
+    --tx_query ${PREFIX}sgx-query:26651

--- a/ci-scripts/run_tx_query.sh
+++ b/ci-scripts/run_tx_query.sh
@@ -11,5 +11,6 @@ echo "[aesm_service] Running in background ..."
 sleep 4
 
 # assumes SPID + IAS_API_KEY are set
+PID=$!
 trap 'kill -TERM $PID' TERM INT
 RUST_LOG=${RUST_LOG} ./tx-query-app 0.0.0.0:${APP_PORT_QUERY} ${TX_VALIDATION_CONN} ${TX_QUERY_TIMEOUT}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
 From ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \
-     make \
-     libzmq3-dev \
-     libssl1.1 \
-     curl \
-     libprotobuf-dev \
-     libssl-dev && \
-     rm -rf /var/lib/apt/lists/*
+    make \
+    libzmq3-dev \
+    libssl1.1 \
+    curl \
+    libprotobuf-dev \
+    libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 arg BUILD_MODE
 
@@ -19,15 +19,18 @@ COPY ./target/${BUILD_MODE}/dev-utils /usr/local/bin/
 # copy sgx binary file
 COPY ./target/${BUILD_MODE}/tx-query-app /usr/local/bin
 COPY ./target/${BUILD_MODE}/tx_query_enclave.signed.so /usr/local/bin
-COPY ./target/${BUILD_MODE}/tx-validation-app /usr/local/bin
 COPY ./target/${BUILD_MODE}/tx_validation_enclave.signed.so /usr/local/bin
 # copy scripts
 COPY ./docker/wait-for-it.sh /usr/local/bin
 COPY ci-scripts/run_tx_query.sh /usr/local/bin
-COPY ci-scripts/run_tx_validation.sh /usr/local/bin
+COPY ci-scripts/run_chain_abci.sh /usr/local/bin
 
 # install sgx enclave pws
 ARG SGX_ENCLAVE=https://download.01.org/intel-sgx/sgx-linux/2.7.1/distro/ubuntu18.04-server/libsgx-enclave-common_2.7.101.3-bionic1_amd64.deb
+# TODO
+# update PSW to 2.8
+# ARG SGX_ENCLAVE=https://download.01.org/intel-sgx/sgx-linux/2.8/distro/ubuntu18.04-server/debian_pkgs/libs/libsgx-enclave-common/libsgx-enclave-common_2.8.100.3-bionic1_amd64.deb
+
 RUN mkdir -p /opt/intel && \
     cd /opt/intel && \
     set -eux; \


### PR DESCRIPTION
Solution: remove tx-validation-app component from makefile and dockerfile
fix  enclave.socket issue for run-abci and run-sgx-query to share same unix domain socket
replace run_tx_validation.sh with ci-scripts/run_chain_abci.sh to make sure abci can replace the deprecated tx-validation-app 
fix other minor issue like setting $PID in shell script