### PR TITLE
Problem: cryptographic library code diverged from "planned" upstream (fixes #1143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@
 ### Breaking changes
 * *chain-abci* [1090](https://github.com/crypto-com/chain/pull/1090): upper bounds of reward parameters changed
 * *chain-abci* [1100](https://github.com/crypto-com/chain/pull/1100): account nonce increased after reward distribution
+* *chain-core* [1162](https://github.com/crypto-com/chain/pull/1162): transaction witness contains BIP-340-compatible Schnorr signatures (instead of the previous WIP scheme)
+* *client* [1158](https://github.com/crypto-com/chain/pull/1158): "deposit-amount" is the default flow for client-cli when doing deposit
 
 ### Features
 * *client* [1072](https://github.com/crypto-com/chain/pull/1072): airgap-friendly workflow for client
+* *client* [1136](https://github.com/crypto-com/chain/pull/1136): logo and version number with git commit in client
+* *client* [1106](https://github.com/crypto-com/chain/pull/1106): import/export of non-HD keys
 
 ### Improvements
 * *client* [1099](https://github.com/crypto-com/chain/pull/1099): client-cli asks to confirm the value
 * *client* [1074](https://github.com/crypto-com/chain/pull/1074): watch-only mode can be used in client-cli
+* *client* [1131](https://github.com/crypto-com/chain/pull/1131): checking of generated transactions in client
 
 ### Bug Fixes
 * *chain-abci* [1092](https://github.com/crypto-com/chain/pull/1092): rewards may be recorded for inactive validators

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "cro-clib"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "cbindgen",
  "chain-core",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-t-common"
-version = "0.1.1"
+version = "0.4.0"
 dependencies = [
  "chain-core",
  "parity-scale-codec",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "secp256k1zkp"
 version = "0.13.0"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=0125097a7bf6f939db0ce52e49803c5e0312bf5e#0125097a7bf6f939db0ce52e49803c5e0312bf5e"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=d50d5998a11064591d86583b297130d6d9636aa5#d50d5998a11064591d86583b297130d6d9636aa5"
 dependencies = [
  "cc",
  "rand 0.7.3",

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -35,7 +35,7 @@ hex = "0.4"
 protobuf = "2.7.0"
 integer-encoding = "1.1.3"
 structopt = "0.3"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism"] }
 blake2 = "0.8"
 parity-scale-codec = { features = ["derive"], version = "1.1" }
 

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -16,7 +16,7 @@ digest = { version = "0.8", default-features = false}
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 sha2 = { version = "0.8", default-features = false }
 hex = { version = "0.4", optional = true }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = { version = "0.8", default-features = false }
 parity-scale-codec = { features = ["derive"], default-features = false, version = "1.1" }

--- a/chain-core/src/tx/witness/mod.rs
+++ b/chain-core/src/tx/witness/mod.rs
@@ -8,7 +8,7 @@ use std::prelude::v1::Vec;
 use secp256k1::{self, recovery::RecoverableSignature, schnorrsig::SchnorrSignature};
 
 use crate::common::Proof;
-use crate::tx::witness::tree::{RawPubkey, RawSignature};
+use crate::tx::witness::tree::{RawSignature, RawXOnlyPubkey};
 
 pub type EcdsaSignature = RecoverableSignature;
 
@@ -80,7 +80,7 @@ impl ::std::ops::DerefMut for TxWitness {
 // normally should be some structure: e.g. indicate a type of signature
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TxInWitness {
-    TreeSig(SchnorrSignature, Proof<RawPubkey>),
+    TreeSig(SchnorrSignature, Proof<RawXOnlyPubkey>),
 }
 
 impl fmt::Display for TxInWitness {

--- a/chain-core/src/tx/witness/tree.rs
+++ b/chain-core/src/tx/witness/tree.rs
@@ -1,101 +1,31 @@
-use std::cmp::Ordering;
-use std::fmt;
-
+use crate::common::{H256, H512};
 use parity_scale_codec::{Decode, Encode};
-
-use crate::common::{H264, H512};
-
-// there was no [T; 33] / [u8; 33] impl in parity-codec :/
-// TODO: Do we remove `RawPubKey` and directly use [u8; 33] as `Encode` and `Decode` impls are now available?
-#[derive(Clone, Encode, Decode)]
-pub struct RawPubkey(H264);
-
 #[cfg(not(feature = "mesalock_sgx"))]
-impl ::serde::Serialize for RawPubkey {
-    fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_bytes(&self.0)
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Encode, Decode, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(not(feature = "mesalock_sgx"), serde(transparent))]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
+pub struct RawXOnlyPubkey(H256);
+
+impl RawXOnlyPubkey {
+    /// Extracts a byte slice containing the entire public key.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 }
 
-#[cfg(not(feature = "mesalock_sgx"))]
-impl<'de> ::serde::Deserialize<'de> for RawPubkey {
-    fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<RawPubkey, D::Error> {
-        use serde::de::Error;
-
-        let sl: &[u8] = ::serde::Deserialize::deserialize(d)?;
-        if sl.len() == 33 {
-            let mut out: H264 = [0u8; 33];
-            out.copy_from_slice(sl);
-            Ok(RawPubkey(out))
-        } else {
-            Err(D::Error::custom("incorrect public key length"))
-        }
-    }
-}
-
-impl From<H264> for RawPubkey {
-    fn from(h: H264) -> Self {
-        RawPubkey(h)
-    }
-}
-
-impl AsRef<[u8]> for RawPubkey {
+impl AsRef<[u8]> for RawXOnlyPubkey {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl PartialEq for RawPubkey {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.as_bytes() == other.as_bytes()
-    }
-}
-
-impl Eq for RawPubkey {}
-
-impl PartialOrd for RawPubkey {
-    #[inline]
-    fn partial_cmp(&self, other: &RawPubkey) -> Option<Ordering> {
-        PartialOrd::partial_cmp(&&self.0[..], &&other.0[..])
-    }
-    #[inline]
-    fn lt(&self, other: &RawPubkey) -> bool {
-        PartialOrd::lt(&&self.0[..], &&other.0[..])
-    }
-    #[inline]
-    fn le(&self, other: &RawPubkey) -> bool {
-        PartialOrd::le(&&self.0[..], &&other.0[..])
-    }
-    #[inline]
-    fn ge(&self, other: &RawPubkey) -> bool {
-        PartialOrd::ge(&&self.0[..], &&other.0[..])
-    }
-    #[inline]
-    fn gt(&self, other: &RawPubkey) -> bool {
-        PartialOrd::gt(&&self.0[..], &&other.0[..])
-    }
-}
-
-impl Ord for RawPubkey {
-    #[inline]
-    fn cmp(&self, other: &RawPubkey) -> Ordering {
-        Ord::cmp(&&self.0[..], &&other.0[..])
-    }
-}
-
-impl fmt::Debug for RawPubkey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&&self.0[..], f)
-    }
-}
-
-impl RawPubkey {
-    /// Extracts a byte slice containing the entire public key.
-    #[inline]
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
+impl From<H256> for RawXOnlyPubkey {
+    fn from(h: H256) -> Self {
+        RawXOnlyPubkey(h)
     }
 }
 

--- a/chain-tx-enclave/enclave-t-common/Cargo.toml
+++ b/chain-tx-enclave/enclave-t-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-t-common"
-version = "0.1.1"
+version = "0.4.0"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Trusted enclave-related code."
 readme = "../../README.md"
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 sgx_tstd    = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 chain-core   = { path = "../../chain-core", default-features = false, features = ["mesalock_sgx"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism", "sgx"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism", "sgx"] }
 zeroize = { version = "1.0", default-features = false }
 sgx_tseal     = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 parity-scale-codec = { default-features = false, version = "1.0" }

--- a/chain-tx-enclave/tx-query/app/Cargo.toml
+++ b/chain-tx-enclave/tx-query/app/Cargo.toml
@@ -18,7 +18,7 @@ sgx_urts = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.g
 parity-scale-codec = { features = ["derive"], version = "1.0" }
 chain-core   = { path = "../../../chain-core" }
 enclave-protocol   = { path = "../../../enclave-protocol" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism"] }
 zmq = "0.9"
 
 [build-dependencies]

--- a/chain-tx-enclave/tx-query/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-query/enclave/Cargo.toml
@@ -23,7 +23,7 @@ parity-scale-codec = { default-features = false, features = ["derive"], version 
 chain-core   = { path = "../../../chain-core", default-features = false, features = ["mesalock_sgx"] }
 enclave-protocol  = {  path = "../../../enclave-protocol", default-features = false, features = ["mesalock_sgx"] }
 enclave-t-common = { path = "../../enclave-t-common" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism", "sgx"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism", "sgx"] }
 
 [dependencies]
 chrono      = { git = "https://github.com/mesalock-linux/chrono-sgx" }

--- a/chain-tx-enclave/tx-validation/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/enclave/Cargo.toml
@@ -24,7 +24,7 @@ sgx_tcrypto   = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-
 enclave-macro = { path = "../../enclave-macro" }
 chain-tx-validation   = {  path = "../../../chain-tx-validation", default-features = false, features = ["mesalock_sgx"] }
 chain-core   = {  path = "../../../chain-core", default-features = false, features = ["mesalock_sgx"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism", "sgx"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism", "sgx"] }
 parity-scale-codec = { default-features = false, version = "1.0" }
 enclave-protocol   = { path = "../../../enclave-protocol", default-features = false, features = ["mesalock_sgx"] }
 chain-tx-filter   = { path = "../../../chain-tx-filter", default-features = false, features = ["mesalock_sgx"] }

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -13,7 +13,7 @@ mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx"]
 [dependencies]
 chain-core = { default-features = false, path = "../chain-core" }
 parity-scale-codec = { default-features = false, version = "1.1" }
-secp256k1zkp = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["endomorphism"] }
+secp256k1zkp = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["endomorphism"] }
 bit-vec = { default-features = false, version = "0.6" }
 sgx_tstd = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -12,6 +12,6 @@ mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx"]
 
 [dependencies]
 chain-core = { path = "../chain-core", default-features = false }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], default-features = false, version = "1.1" }
 sgx_tstd = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/chain-tx-validation/src/witness.rs
+++ b/chain-tx-validation/src/witness.rs
@@ -3,7 +3,7 @@ use chain_core::state::account::{StakedStateAddress, StakedStateOpWitness};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::TxId;
 use chain_core::tx::witness::TxInWitness;
-use secp256k1::{schnorrsig::schnorr_verify, Message, PublicKey, Secp256k1};
+use secp256k1::{key::XOnlyPublicKey, schnorrsig::schnorr_verify, Message, Secp256k1};
 
 /// verify a given extended address is associated to the witness
 /// and the signature against the given transaction `Tx`
@@ -26,7 +26,7 @@ pub fn verify_tx_address(
                     &secp,
                     &message,
                     &sig,
-                    &PublicKey::from_slice(proof.value().as_bytes())?,
+                    &XOnlyPublicKey::from_slice(proof.value().as_bytes())?,
                 )
             }
         }
@@ -56,11 +56,11 @@ pub mod tests {
     use super::*;
 
     use secp256k1::schnorrsig::schnorr_sign;
-    use secp256k1::SecretKey;
+    use secp256k1::{PublicKey, SecretKey};
 
     use chain_core::common::MerkleTree;
     use chain_core::tx::data::Tx;
-    use chain_core::tx::witness::tree::RawPubkey;
+    use chain_core::tx::witness::tree::RawXOnlyPubkey;
     use chain_core::tx::TransactionId;
 
     #[test]
@@ -70,9 +70,9 @@ pub mod tests {
         let secp = Secp256k1::new();
 
         let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
-        let public_key = PublicKey::from_secret_key(&secp, &secret_key);
+        let public_key = XOnlyPublicKey::from_secret_key(&secp, &secret_key);
 
-        let merkle_tree = MerkleTree::new(vec![RawPubkey::from(public_key.serialize())]);
+        let merkle_tree = MerkleTree::new(vec![RawXOnlyPubkey::from(public_key.serialize())]);
         let address = ExtendedAddr::OrTree(merkle_tree.root_hash());
 
         let witness = TxInWitness::TreeSig(
@@ -80,10 +80,9 @@ pub mod tests {
                 &secp,
                 &Message::from_slice(&transation.id()).unwrap(),
                 &secret_key,
-            )
-            .0,
+            ),
             merkle_tree
-                .generate_proof(RawPubkey::from(public_key.serialize()))
+                .generate_proof(RawXOnlyPubkey::from(public_key.serialize()))
                 .unwrap(),
         );
 
@@ -101,13 +100,13 @@ pub mod tests {
             SecretKey::from_slice(&[0xde; 32]).expect("Unable to create secret key"),
         ];
         let public_keys = [
-            PublicKey::from_secret_key(&secp, &secret_keys[0]),
-            PublicKey::from_secret_key(&secp, &secret_keys[1]),
+            XOnlyPublicKey::from_secret_key(&secp, &secret_keys[0]),
+            XOnlyPublicKey::from_secret_key(&secp, &secret_keys[1]),
         ];
 
         let merkle_tree = MerkleTree::new(vec![
-            RawPubkey::from(public_keys[0].serialize()),
-            RawPubkey::from(public_keys[1].serialize()),
+            RawXOnlyPubkey::from(public_keys[0].serialize()),
+            RawXOnlyPubkey::from(public_keys[1].serialize()),
         ]);
         let address = ExtendedAddr::OrTree(merkle_tree.root_hash());
 
@@ -116,10 +115,9 @@ pub mod tests {
                 &secp,
                 &Message::from_slice(&transation.id()).unwrap(),
                 &secret_keys[0],
-            )
-            .0,
+            ),
             merkle_tree
-                .generate_proof(RawPubkey::from(public_keys[0].serialize()))
+                .generate_proof(RawXOnlyPubkey::from(public_keys[0].serialize()))
                 .unwrap(),
         );
 
@@ -137,13 +135,13 @@ pub mod tests {
             SecretKey::from_slice(&[0xde; 32]).expect("Unable to create secret key"),
         ];
         let public_keys = [
-            PublicKey::from_secret_key(&secp, &secret_keys[0]),
-            PublicKey::from_secret_key(&secp, &secret_keys[1]),
+            XOnlyPublicKey::from_secret_key(&secp, &secret_keys[0]),
+            XOnlyPublicKey::from_secret_key(&secp, &secret_keys[1]),
         ];
 
         let merkle_tree = MerkleTree::new(vec![
-            RawPubkey::from(public_keys[0].serialize()),
-            RawPubkey::from(public_keys[1].serialize()),
+            RawXOnlyPubkey::from(public_keys[0].serialize()),
+            RawXOnlyPubkey::from(public_keys[1].serialize()),
         ]);
         let address = ExtendedAddr::OrTree(merkle_tree.root_hash());
 
@@ -152,10 +150,9 @@ pub mod tests {
                 &secp,
                 &Message::from_slice(&transation.id()).unwrap(),
                 &secret_keys[0],
-            )
-            .0,
+            ),
             merkle_tree
-                .generate_proof(RawPubkey::from(public_keys[1].serialize()))
+                .generate_proof(RawXOnlyPubkey::from(public_keys[1].serialize()))
                 .unwrap(),
         );
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 chain-tx-filter = { path = "../chain-tx-filter" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 rand = "0.7"
 log = "0.4.8"
 aes-gcm-siv = "0.3"

--- a/client-common/src/key/private_key.rs
+++ b/client-common/src/key/private_key.rs
@@ -56,7 +56,7 @@ impl PrivateKey {
                 "Unable to deserialize message to sign",
             )
         })?;
-        let signature = SECP.with(|secp| schnorr_sign(&secp, &message, &self.0).0);
+        let signature = SECP.with(|secp| schnorr_sign(&secp, &message, &self.0));
         Ok(signature)
     }
 }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -11,7 +11,7 @@ client-common = { path = "../client-common" }
 chain-tx-filter = { path = "../chain-tx-filter" }
 enclave-protocol = { path = "../enclave-protocol" }
 chain-tx-validation = { path = "../chain-tx-validation" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 parity-scale-codec = { features = ["derive"], version = "1.1" }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.7"

--- a/client-core/src/multi_sig/builder.rs
+++ b/client-core/src/multi_sig/builder.rs
@@ -78,7 +78,7 @@ impl MultiSigBuilder {
     ///
     /// This function will fail if nonce commitments from all co-signers are
     /// not received.
-    pub fn nonce(&mut self) -> Result<PublicKey> {
+    pub fn nonce(&mut self) -> Result<H256> {
         let nonce = self.session.nonce()?;
 
         let public_key = &self.session.public_key.clone();
@@ -90,7 +90,7 @@ impl MultiSigBuilder {
     }
 
     /// Adds a nonce from a public key to session.
-    pub fn add_nonce(&mut self, public_key: &PublicKey, nonce: &PublicKey) -> Result<()> {
+    pub fn add_nonce(&mut self, public_key: &PublicKey, nonce: &H256) -> Result<()> {
         self.session.add_nonce(public_key, nonce.clone())?;
 
         Ok(())
@@ -167,7 +167,7 @@ impl MultiSigBuilder {
     /// Restoring from such a source can result in complete lost of your funds.
     /// If you are in doubt, always create a new session builder and restart
     /// the whole process from scratch.
-    pub fn from_incomplete(bytes: Vec<u8>) -> Result<Self> {
+    pub fn from_incomplete_insecure(bytes: Vec<u8>) -> Result<Self> {
         let session = MultiSigSession::decode(&mut bytes.as_slice()).chain(|| {
             (
                 ErrorKind::DeserializationError,
@@ -267,7 +267,7 @@ mod multi_sig_builder_tests {
 
         let encoded = session_1.to_incomplete();
 
-        let restored_session_1 = MultiSigBuilder::from_incomplete(encoded)
+        let restored_session_1 = MultiSigBuilder::from_incomplete_insecure(encoded)
             .expect("Should be able to restore from encoded incompleted bytes");
 
         let signature_1 = session_1.signature().unwrap();

--- a/client-core/src/multi_sig/signer.rs
+++ b/client-core/src/multi_sig/signer.rs
@@ -11,7 +11,7 @@ pub struct Signer {
     /// Nonce commitment of signer (when available)
     pub nonce_commitment: Option<H256>,
     /// Nonce of signer (when available)
-    pub nonce: Option<PublicKey>,
+    pub nonce: Option<H256>,
     /// Partial signature of signer (when available)
     pub partial_signature: Option<H256>,
 }
@@ -31,7 +31,7 @@ impl Signer {
     }
 
     /// Adds nonce to current signer if not already added.
-    pub fn add_nonce(&mut self, nonce: PublicKey) -> Result<()> {
+    pub fn add_nonce(&mut self, nonce: H256) -> Result<()> {
         if self.nonce.is_some() {
             return Err(Error::new(
                 ErrorKind::InvalidInput,

--- a/client-core/src/service/hd_key_service.rs
+++ b/client-core/src/service/hd_key_service.rs
@@ -276,12 +276,13 @@ mod tests {
             .restore_wallet(&name, &passphrase, &mnemonic)
             .expect("restore wallet");
 
+        // NOTE: addresses changed here in 0.4 due to migration to x-only pubkeys used in BIP-340
         for addr in &[
-            "dcro1vjjulckel0jthl8d5vgvjkt9l9jncvgvpnpcwu9680qws44g5ymq5fprcu",
-            "dcro13z2xw689qhpmv7ge9xg428ljg4848rtu5dcpdmxy3m6njdsjtd3sl30d8n",
-            "dcro1fnjq70pf9hvd2tkd3rj7pash6ph7p42qakqt2k39sjqp4m4p25kqclslnt",
-            "dcro1ee3exuxyv5pauameswxureamlvmptjm8tsg4lcwqpx2nclshc6eqt8fanm",
-            "dcro1kl06wz2ytp02zlneqzsmtaecxvqdelkgrp693xk55tj7zs5vns7sjheun0",
+            "dcro13jycspqf67hp3ejjjlyt5y23umwrutv3gxfynk4s5lqh50pgsp5skktpj6",
+            "dcro1qlavhgsvpv4q5pm3qg93jmrskzhwww2td4e8cl40vuej7yww97hs2dqms9",
+            "dcro17pfjfshdgmh0e7ea59fd4vuk8jpuqhnht296gy2jzmr5g7h2449qu7ndd7",
+            "dcro1vgg3rdajp9awxrz9smvwn9yhvr3l28yfjueul7wr0fmxwxq85yvs6j2lfz",
+            "dcro1tjt8l64wpuqp80hf94cceututwhc5t76hwty7guty5rm7svg9xjs2zm6q8",
         ] {
             assert_eq!(
                 wallet

--- a/client-core/src/service/multi_sig_session_service.rs
+++ b/client-core/src/service/multi_sig_session_service.rs
@@ -80,7 +80,8 @@ where
                         format!("Session with ID ({}) not found", hex::encode(session_id)),
                     )
                 })?;
-                let mut session = MultiSigBuilder::from_incomplete(session_bytes.to_vec())?;
+                let mut session =
+                    MultiSigBuilder::from_incomplete_insecure(session_bytes.to_vec())?;
                 session.add_nonce_commitment(public_key, nonce_commitment)?;
 
                 Ok(Some(session.to_incomplete()))
@@ -89,7 +90,7 @@ where
     }
 
     /// Returns nonce of self. This function will fail if nonce commitments from all co-signers are not received.
-    pub fn nonce(&self, session_id: &H256, enckey: &SecKey) -> Result<PublicKey> {
+    pub fn nonce(&self, session_id: &H256, enckey: &SecKey) -> Result<H256> {
         let mut session = self.get_session(session_id, enckey)?;
         let nonce = session.nonce()?;
 
@@ -101,7 +102,7 @@ where
     pub fn add_nonce(
         &self,
         session_id: &H256,
-        nonce: &PublicKey,
+        nonce: &H256,
         public_key: &PublicKey,
         enckey: &SecKey,
     ) -> Result<()> {
@@ -113,7 +114,8 @@ where
                         format!("Session with ID ({}) not found", hex::encode(session_id)),
                     )
                 })?;
-                let mut session = MultiSigBuilder::from_incomplete(session_bytes.to_vec())?;
+                let mut session =
+                    MultiSigBuilder::from_incomplete_insecure(session_bytes.to_vec())?;
                 session.add_nonce(public_key, nonce)?;
 
                 Ok(Some(session.to_incomplete()))
@@ -146,7 +148,8 @@ where
                         format!("Session with ID ({}) not found", hex::encode(session_id)),
                     )
                 })?;
-                let mut session = MultiSigBuilder::from_incomplete(session_bytes.to_vec())?;
+                let mut session =
+                    MultiSigBuilder::from_incomplete_insecure(session_bytes.to_vec())?;
                 session.add_partial_signature(public_key, partial_signature)?;
 
                 Ok(Some(session.to_incomplete()))
@@ -177,7 +180,7 @@ where
                     format!("Session with ID ({}) not found", hex::encode(session_id)),
                 )
             })?;
-        MultiSigBuilder::from_incomplete(session_bytes)
+        MultiSigBuilder::from_incomplete_insecure(session_bytes)
     }
 
     /// Persists a session in storage

--- a/client-core/src/service/root_hash_service.rs
+++ b/client-core/src/service/root_hash_service.rs
@@ -1,7 +1,7 @@
 use parity_scale_codec::{Decode, Encode};
 
 use chain_core::common::{Proof, H256};
-use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use client_common::MultiSigAddress;
 use client_common::{ErrorKind, PublicKey, Result, ResultExt, SecKey, SecureStorage, Storage};
 
@@ -54,7 +54,7 @@ where
         root_hash: &H256,
         public_keys: Vec<PublicKey>,
         enckey: &SecKey,
-    ) -> Result<Proof<RawPubkey>> {
+    ) -> Result<Proof<RawXOnlyPubkey>> {
         let address = self.get_multi_sig_address_from_root_hash(root_hash, enckey)?;
 
         address
@@ -109,8 +109,6 @@ where
 mod tests {
     use super::*;
     use secstr::SecUtf8;
-
-    use secp256k1::PublicKey as SecpPublicKey;
 
     use client_common::storage::MemoryStorage;
     use client_common::{seckey::derive_enckey, PrivateKey};
@@ -229,9 +227,7 @@ mod tests {
         let mut signers = vec![public_keys[0].clone(), public_keys[1].clone()];
         signers.sort();
 
-        let signer = RawPubkey::from(
-            SecpPublicKey::from(PublicKey::combine(&signers).unwrap().0).serialize(),
-        );
+        let signer = RawXOnlyPubkey::from(PublicKey::combine(&signers).unwrap().0.serialize());
 
         assert_eq!(proof.value(), &signer);
     }

--- a/client-core/src/signer/dummy_signer.rs
+++ b/client-core/src/signer/dummy_signer.rs
@@ -1,5 +1,5 @@
 use chain_core::common::MerkleTree;
-use chain_core::common::H264;
+use chain_core::common::H256;
 use chain_core::init::address::RedeemAddress;
 use chain_core::state::account::{
     DepositBondTx, StakedStateAddress, StakedStateOpAttributes, StakedStateOpWitness,
@@ -7,7 +7,7 @@ use chain_core::state::account::{
 };
 use chain_core::tx::data::input::{TxoIndex, TxoPointer};
 use chain_core::tx::data::{Tx, TxId};
-use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::witness::{TxInWitness, TxWitness};
 use chain_core::tx::{PlainTxAux, TransactionId, TxAux, TxEnclaveAux, TxObfuscated};
 use client_common::Result;
@@ -29,16 +29,16 @@ impl DummySigner {
     /// Creates a mock merkletree
     fn mock_merkletree(
         &self,
-        raw_pubkey: RawPubkey,
+        raw_pubkey: RawXOnlyPubkey,
         tree_length: usize,
-    ) -> Result<MerkleTree<RawPubkey>> {
+    ) -> Result<MerkleTree<RawXOnlyPubkey>> {
         let tree = vec![raw_pubkey; tree_length];
         Ok(MerkleTree::new(tree))
     }
 
     /// Signs transaction with the mock key pair
     fn sign_tx(&self, total_pubkeys_len: usize) -> Result<TxInWitness> {
-        let raw_pk = RawPubkey::from([0_u8; 33] as H264);
+        let raw_pk = RawXOnlyPubkey::from([0_u8; 32] as H256);
         let merkle_tree = self.mock_merkletree(raw_pk.clone(), total_pubkeys_len)?;
         let proof = merkle_tree
             .generate_proof(raw_pk)

--- a/client-core/src/signer/key_pair_signer.rs
+++ b/client-core/src/signer/key_pair_signer.rs
@@ -1,7 +1,7 @@
 //! A signer that sign message using the provided key pair
 use chain_core::common::Proof;
 use chain_core::tx::data::address::ExtendedAddr;
-use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::witness::{TxInWitness, TxWitness};
 use client_common::{Error, ErrorKind, MultiSigAddress, PrivateKey, PublicKey, Result, ResultExt};
 
@@ -10,7 +10,7 @@ use crate::{SelectedUnspentTransactions, SignCondition, Signer};
 /// Signer using key pair
 pub struct KeyPairSigner {
     extended_addr: ExtendedAddr,
-    proof: Proof<RawPubkey>,
+    proof: Proof<RawXOnlyPubkey>,
     private_key: PrivateKey,
 }
 
@@ -29,7 +29,7 @@ impl KeyPairSigner {
 
 fn generate_extended_addr_and_proof(
     public_key: PublicKey,
-) -> Result<(ExtendedAddr, Proof<RawPubkey>)> {
+) -> Result<(ExtendedAddr, Proof<RawXOnlyPubkey>)> {
     let require_signers = 1;
     let multi_sig_address = MultiSigAddress::new(
         vec![public_key.clone()],

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -532,12 +532,12 @@ mod raw_transfer_transaction_builder_tests {
     use secp256k1::schnorrsig::SchnorrSignature;
 
     use chain_core::common::MerkleTree;
-    use chain_core::common::H264;
+    use chain_core::common::H256;
     use chain_core::init::MAX_COIN;
     use chain_core::tx::data::address::ExtendedAddr;
     use chain_core::tx::data::input::TxoIndex;
     use chain_core::tx::fee::{LinearFee, Milli};
-    use chain_core::tx::witness::tree::RawPubkey;
+    use chain_core::tx::witness::tree::RawXOnlyPubkey;
     use chain_core::tx::{TxEnclaveAux, TxObfuscated};
     use client_common::{MultiSigAddress, PrivateKey, PublicKey, Transaction};
 
@@ -1195,7 +1195,7 @@ mod raw_transfer_transaction_builder_tests {
     }
 
     fn create_dummy_witness() -> TxInWitness {
-        let raw_pubkey = RawPubkey::from([0_u8; 33] as H264);
+        let raw_pubkey = RawXOnlyPubkey::from([0_u8; 32] as H256);
         let total_pubkeys_len = 2;
         let tree = vec![raw_pubkey.clone(); total_pubkeys_len];
         let merkle_tree = MerkleTree::new(tree);

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -19,7 +19,7 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::{Tx, TxId};
-use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::TxAux;
 use client_common::tendermint::types::BroadcastTxResponse;
 use client_common::{PrivateKey, PublicKey, Result, SecKey, Transaction, TransactionInfo};
@@ -219,7 +219,7 @@ pub trait WalletClient: Send + Sync {
         enckey: &SecKey,
         address: &ExtendedAddr,
         public_keys: Vec<PublicKey>,
-    ) -> Result<Proof<RawPubkey>>;
+    ) -> Result<Proof<RawXOnlyPubkey>>;
 
     /// Returns number of cosigners required to sign the transaction
     fn required_cosigners(&self, name: &str, enckey: &SecKey, root_hash: &H256) -> Result<usize>;
@@ -393,14 +393,14 @@ pub trait MultiSigWalletClient: WalletClient {
 
     /// Returns nonce of current signer. This function will fail if nonce commitments from all co-signers are not
     /// received.
-    fn nonce(&self, session_id: &H256, enckey: &SecKey) -> Result<PublicKey>;
+    fn nonce(&self, session_id: &H256, enckey: &SecKey) -> Result<H256>;
 
     /// Adds a nonce from a public key to session with given id
     fn add_nonce(
         &self,
         session_id: &H256,
         enckey: &SecKey,
-        nonce: &PublicKey,
+        nonce: &H256,
         public_key: &PublicKey,
     ) -> Result<()>;
 

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -27,7 +27,7 @@ use chain_core::tx::data::input::{str2txid, TxoPointer};
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::data::{Tx, TxId};
 use chain_core::tx::fee::Fee;
-use chain_core::tx::witness::tree::RawPubkey;
+use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::witness::{TxInWitness, TxWitness};
 use chain_core::tx::{TransactionId, TxAux, TxEnclaveAux, TxObfuscated};
 use client_common::tendermint::types::Time;
@@ -583,7 +583,7 @@ where
         enckey: &SecKey,
         address: &ExtendedAddr,
         public_keys: Vec<PublicKey>,
-    ) -> Result<Proof<RawPubkey>> {
+    ) -> Result<Proof<RawXOnlyPubkey>> {
         // To verify if the enckey is correct or not
         self.wallet_service.view_key(name, enckey)?;
 
@@ -996,7 +996,7 @@ where
         )
     }
 
-    fn nonce(&self, session_id: &H256, enckey: &SecKey) -> Result<PublicKey> {
+    fn nonce(&self, session_id: &H256, enckey: &SecKey) -> Result<H256> {
         self.multi_sig_session_service.nonce(session_id, enckey)
     }
 
@@ -1004,7 +1004,7 @@ where
         &self,
         session_id: &H256,
         enckey: &SecKey,
-        nonce: &PublicKey,
+        nonce: &H256,
         public_key: &PublicKey,
     ) -> Result<()> {
         self.multi_sig_session_service

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -16,8 +16,8 @@ base64 = "0.11"
 chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.1" }
 hex = "0.4.2"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery"] }
 tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "2aa9dcece9d5abf5b8f108fec61baaa5c83d5884" }
 
 [dev-dependencies]
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -210,7 +210,7 @@ where
 
         self.client
             .nonce(&session_id, &enckey)
-            .map(serialize_public_key)
+            .map(serialize_hash_256)
             .map_err(to_rpc_error)
     }
 
@@ -222,7 +222,7 @@ where
         public_key: String,
     ) -> Result<()> {
         let session_id = parse_hash_256(session_id).map_err(to_rpc_error)?;
-        let nonce = parse_public_key(nonce).map_err(to_rpc_error)?;
+        let nonce = parse_hash_256(nonce).map_err(to_rpc_error)?;
         let public_key = parse_public_key(public_key).map_err(to_rpc_error)?;
 
         self.client
@@ -312,10 +312,6 @@ fn parse_hash_256(hash: String) -> CommonResult<H256> {
     new_hash.copy_from_slice(&array);
 
     Ok(new_hash)
-}
-
-fn serialize_public_key(public_key: PublicKey) -> String {
-    encode(&public_key.serialize())
 }
 
 fn parse_public_keys(public_keys: Vec<String>) -> CommonResult<Vec<PublicKey>> {

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -935,10 +935,11 @@ pub mod tests {
             )
             .unwrap();
 
+        // NOTE: this changed in 0.4 due to a migration to x-only pubkeys, as specified by BIP-340
         let expect_addrs = [
-            "dcro13z2xw689qhpmv7ge9xg428ljg4848rtu5dcpdmxy3m6njdsjtd3sl30d8n",
-            "dcro1fnjq70pf9hvd2tkd3rj7pash6ph7p42qakqt2k39sjqp4m4p25kqclslnt",
-            "dcro1ee3exuxyv5pauameswxureamlvmptjm8tsg4lcwqpx2nclshc6eqt8fanm",
+            "dcro1qlavhgsvpv4q5pm3qg93jmrskzhwww2td4e8cl40vuej7yww97hs2dqms9",
+            "dcro17pfjfshdgmh0e7ea59fd4vuk8jpuqhnht296gy2jzmr5g7h2449qu7ndd7",
+            "dcro1vgg3rdajp9awxrz9smvwn9yhvr3l28yfjueul7wr0fmxwxq85yvs6j2lfz",
         ];
         let addrs = expect_addrs
             .iter()

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cro-clib"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["jongwhan lee <jonghwan@crypto.com>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ client-core = { path = "../client-core" }
 client-network = { path = "../client-network" }
 client-rpc = { path = "../client-rpc" }
 secstr = { version = "0.4.0", features = ["serde"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism"] }
 jsonrpc-core = "14.0"
 libc = "0.2.67"
 

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -14,5 +14,5 @@ mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx", "chai
 chain-core = { path = "../chain-core", default-features = false }
 chain-tx-validation = { path = "../chain-tx-validation", default-features = false }
 parity-scale-codec = { version = "1.1", default-features = false, features = ["derive"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e" }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "d50d5998a11064591d86583b297130d6d9636aa5" }
 sgx_tstd = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/integration-tests/address-state.json
+++ b/integration-tests/address-state.json
@@ -1,7 +1,7 @@
 {
   "staking": "0x33502ed39d0c4e2044fb37fdcd5161493f5900c3",
   "transfer": [
-    "dcro1mq6d4n9nmp90lmxkvpgznc0l6kkru8u63qqu2ysmz8lalqf3c4ms8zxrup",
-    "dcro1qf26s0auk6p68snflspan44hm4f8gvjw56yh8ju95yh49edrjzxq2swuys"
+    "dcro1l0jcmwq4ppjc24h83eled8ed00twfvmeeam2f7k88e9sszxlfkuswc8x3h",
+    "dcro1jtv9cgwrk3kvvyxr7v6xw7jftw78wpxer2jl00vm0deqvm92n60s4kjynx"
   ]
 }

--- a/integration-tests/pytests/test_wallet_offline.py
+++ b/integration-tests/pytests/test_wallet_offline.py
@@ -16,7 +16,7 @@ rpc = RPC()
 # ./client-cli wallet auth-token -n ${wallet_name}
 enckey_offline = "678207f07853b6f2c361989cb3eb31fd15ed0d30da7e01d1e8b50a1f38eb63dd"
 # ./client-cli address new -n ${wallet_name} -t transfer
-transfer_address_offline = "dcro1ayhu0665wprxf86letqlv8x4ssppeu6awf7m60qlwds9268vltwsk6ehwa"
+transfer_address_offline = "dcro1ne3l2yxmneg6mfce096424w3dawjmpr6yfjp2tffwd6tn42pp7fst75jua"
 # ./client-cli address list-pub-key -n ${wallet_name} -t transfer
 transfer_pubkey_offline = "02a732fb6c34812ea5a46547344d63a360e22d0c4815c837af82a09de7b7fd9797"
 view_key_offline = "02b4dabfc862b9cb9f86b8d49520023aa0cccb2ad89446577dd0fee7bc946a79a1"

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -17,7 +17,7 @@ signature = "1.0.0-pre.1"
 abci = "0.6"
 kvdb-memorydb = "0.4"
 protobuf = "2.7.0"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "0125097a7bf6f939db0ce52e49803c5e0312bf5e", features = ["recovery", "endomorphism"] }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "d50d5998a11064591d86583b297130d6d9636aa5", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], version = "1.1" }
 base64 = "0.11"
 hex = "0.4"


### PR DESCRIPTION
Solution:
- cherry-picked changes from the planned upstream changes to the *temporary* custom secp256k1 fork
- adapted the *temporary* Rust library fork to it
- changed chain-core witness structure to use the BIP-340 encoding of public keys
- adapted client and tests to it

NOTE:
the schnorrsig proposal was stabilized as https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
the code wasn't yet merged to upstream, so it's possible that underlying cryptographic API
may change (and the corresponding Rust), but the transaction (binary/serialized) payloads
will be the same.
