### PR TITLE
Problem: Persistence unit tests cannot run twice successfully (fixes #1169)

### DIFF
--- a/chain-storage/src/lib.rs
+++ b/chain-storage/src/lib.rs
@@ -342,6 +342,7 @@ mod test {
             "buffered write should not persist",
             TEST_DB_1,
         );
+        let _ = std::fs::remove_dir_all(TEST_DB_1);
     }
 
     #[test]
@@ -375,5 +376,6 @@ mod test {
             "persist write should commit data",
             TEST_DB_2,
         );
+        let _ = std::fs::remove_dir_all(TEST_DB_2);
     }
 }


### PR DESCRIPTION
Solution: added explicit cleanups after successful (not failing) test execution
