### PR TITLE
Problem: fuzzer crashes with invalid initchain (fixes #1178)

### DIFF
--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -10,6 +10,8 @@ mod validate_tx;
 use abci::*;
 use log::info;
 
+#[cfg(fuzzing)]
+pub use self::app_init::check_validators;
 pub use self::app_init::{
     compute_accounts_root, get_validator_key, init_app_hash, ChainNodeApp, ChainNodeState,
     ValidatorState,


### PR DESCRIPTION
Solution: refactored validators<->council nodes check
and added that as an extra filter to the fuzzer

Note: we'll see how it goes with this raw byte stream fuzzing;
we may possibly restrict it with:
https://rust-fuzz.github.io/book/cargo-fuzz/structure-aware-fuzzing.html

