### PR TITLE
Problem(fix #914) Unable to restore wallet with the same mnemonic words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * *chain-abci* [1100](https://github.com/crypto-com/chain/pull/1100): account nonce increased after reward distribution
 * *chain-core* [1162](https://github.com/crypto-com/chain/pull/1162): transaction witness contains BIP-340-compatible Schnorr signatures (instead of the previous WIP scheme)
 * *client* [1158](https://github.com/crypto-com/chain/pull/1158): "deposit-amount" is the default flow for client-cli when doing deposit
+* *client* [1185](https://github.com/crypto-com/chain/pull/1185): public and private key pairs stored in wallet, use public_key + wallet_name as key to store the multi_sig_address
 
 ### Features
 * *client* [1072](https://github.com/crypto-com/chain/pull/1072): airgap-friendly workflow for client

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -161,8 +161,16 @@ pub trait WalletClient: Send + Sync {
         address: &ExtendedAddr,
     ) -> Result<Option<H256>>;
 
+    /// Retrieves private key corresponding to given wallet name
+    fn wallet_private_key(&self, name: &str, enckey: &SecKey) -> Result<Option<PrivateKey>>;
+
     /// Retrieves private key corresponding to given public key
-    fn private_key(&self, enckey: &SecKey, public_key: &PublicKey) -> Result<Option<PrivateKey>>;
+    fn private_key(
+        &self,
+        name: &str,
+        enckey: &SecKey,
+        public_key: &PublicKey,
+    ) -> Result<Option<PrivateKey>>;
 
     /// Generates a new public key for given wallet
     fn new_public_key(

--- a/client-core/src/wallet/syncer.rs
+++ b/client-core/src/wallet/syncer.rs
@@ -164,12 +164,8 @@ where
 }
 
 fn load_view_key<S: SecureStorage>(storage: &S, name: &str, enckey: &SecKey) -> Result<PrivateKey> {
-    let wallet = service::load_wallet(storage, name, enckey)?
-        .err_kind(ErrorKind::InvalidInput, || {
-            format!("wallet not found: {}", name)
-        })?;
     KeyService::new(storage.clone())
-        .private_key(&wallet.view_key, enckey)?
+        .wallet_private_key(name, enckey)?
         .err_kind(ErrorKind::InvalidInput, || {
             format!("wallet private view key not found: {}", name)
         })

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -249,7 +249,7 @@ where
         };
         let private_key = self
             .wallet_client
-            .private_key(enckey, &public_key)?
+            .private_key(name, enckey, &public_key)?
             .chain(|| {
                 (
                     ErrorKind::InvalidInput,
@@ -316,7 +316,7 @@ where
         };
         let private_key = self
             .wallet_client
-            .private_key(enckey, &public_key)?
+            .private_key(name, enckey, &public_key)?
             .chain(|| {
                 (
                     ErrorKind::InvalidInput,
@@ -384,7 +384,7 @@ where
         };
         let private_key = self
             .wallet_client
-            .private_key(enckey, &public_key)?
+            .private_key(name, enckey, &public_key)?
             .chain(|| {
                 (
                     ErrorKind::InvalidInput,
@@ -484,7 +484,7 @@ where
         };
         let private_key = self
             .wallet_client
-            .private_key(enckey, &public_key)?
+            .private_key(name, enckey, &public_key)?
             .chain(|| {
                 (
                     ErrorKind::InvalidInput,

--- a/client-rpc/src/rpc/multisig_rpc.rs
+++ b/client-rpc/src/rpc/multisig_rpc.rs
@@ -131,7 +131,7 @@ where
         let self_public_key = parse_public_key(self_public_key).map_err(to_rpc_error)?;
         // Check if self public key belongs to current wallet
         self.client
-            .private_key(&request.enckey, &self_public_key)
+            .private_key(&request.name, &request.enckey, &self_public_key)
             .chain(|| {
                 (
                     ErrorKind::InvalidInput,


### PR DESCRIPTION
solution:
* store the (wallet_name, wallet's private_key) in `KeySerivce`
* move the (public_key, private_key) pair (used for transfer add and staking address) in `Wallet`
* extend the `root_hash` with the `wallet_name` as  storage_key to store the `multi_sig_address`
* add unit test