### PR TITLE
Problem: (cro-1133) no way to get progress from sync in `jsonrpc_call…

### DIFF
--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -5,9 +5,23 @@ use crate::server::to_rpc_error;
 use client_common::tendermint::Client;
 use client_common::Storage;
 use client_core::synchronizer::PollingSynchronizer;
+use client_core::wallet::syncer::ProgressReport;
 use client_core::wallet::syncer::{ObfuscationSyncerConfig, WalletSyncer};
 use client_core::wallet::WalletRequest;
 use client_core::TransactionObfuscation;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+pub trait CBindingCallback: Send + Sync {
+    fn progress(&self, current: u64, start: u64, end: u64) -> i32;
+    fn set_user(&mut self, user: u64);
+    fn get_user(&self) -> u64;
+}
+
+#[derive(Clone)]
+pub struct CBindingCore {
+    pub data: Arc<Mutex<dyn CBindingCallback>>,
+}
 
 #[rpc]
 pub trait SyncRpc: Send + Sync {
@@ -32,6 +46,7 @@ where
 {
     config: ObfuscationSyncerConfig<S, C, O>,
     polling_synchronizer: PollingSynchronizer,
+    progress_callback: Option<CBindingCore>,
 }
 
 impl<S, C, O> SyncRpc for SyncRpcImpl<S, C, O>
@@ -70,13 +85,17 @@ where
     C: Client + 'static,
     O: TransactionObfuscation + 'static,
 {
-    pub fn new(config: ObfuscationSyncerConfig<S, C, O>) -> Self {
+    pub fn new(
+        config: ObfuscationSyncerConfig<S, C, O>,
+        progress_callback: Option<CBindingCore>,
+    ) -> Self {
         let mut polling_synchronizer = PollingSynchronizer::default();
         polling_synchronizer.spawn(config.clone());
 
         SyncRpcImpl {
             config,
             polling_synchronizer,
+            progress_callback,
         }
     }
 
@@ -90,7 +109,54 @@ where
         if reset {
             syncer.reset_state().map_err(to_rpc_error)?;
         }
-        syncer.sync(|_| true).map_err(to_rpc_error)
+
+        if self.progress_callback.is_none() {
+            return syncer.sync(|_| true).map_err(to_rpc_error);
+        }
+
+        let mut init_block_height = 0;
+        let mut final_block_height = 0;
+        syncer
+            .sync(|report: ProgressReport| -> bool {
+                match report {
+                    ProgressReport::Init {
+                        start_block_height,
+                        finish_block_height,
+                        ..
+                    } => {
+                        init_block_height = start_block_height;
+                        final_block_height = finish_block_height;
+                        if let Some(delegator) = &self.progress_callback {
+                            {
+                                let user_callback =
+                                    delegator.data.lock().expect("get cbinding callback");
+                                user_callback.progress(0, init_block_height, final_block_height);
+                                return true;
+                            }
+                        }
+                        true
+                    }
+                    ProgressReport::Update {
+                        current_block_height,
+                        ..
+                    } => {
+                        if let Some(delegator) = &self.progress_callback {
+                            {
+                                let user_callback =
+                                    delegator.data.lock().expect("get cbinding callback");
+                                return 1
+                                    == user_callback.progress(
+                                        current_block_height,
+                                        init_block_height,
+                                        final_block_height,
+                                    );
+                            }
+                        }
+                        true
+                    }
+                }
+            })
+            .map_err(to_rpc_error)
     }
 }
 

--- a/client-rpc/src/server.rs
+++ b/client-rpc/src/server.rs
@@ -163,7 +163,7 @@ impl Server {
 
         let syncer_config = self.make_syncer_config(storage.clone(), tendermint_client.clone())?;
 
-        let sync_rpc = SyncRpcImpl::new(syncer_config);
+        let sync_rpc = SyncRpcImpl::new(syncer_config, None);
 
         let wallet_rpc_wallet_client = self.make_wallet_client(storage, tendermint_client)?;
         let wallet_rpc = WalletRpcImpl::new(wallet_rpc_wallet_client, self.network_id);

--- a/cro-clib/chain.h
+++ b/cro-clib/chain.h
@@ -42,6 +42,12 @@ typedef struct CroStakedState {
 } CroStakedState;
 
 /**
+ * current, start, end, userdata
+ * return: 1: continue, 0: stop
+ */
+typedef int32_t (*ProgressCallback)(uint64_t, uint64_t, uint64_t, const void*);
+
+/**
  * create staking address
  * # Safety
  */
@@ -293,7 +299,9 @@ CroResult cro_jsonrpc_call(const char *storage_dir,
                            uint8_t network_id,
                            const char *request,
                            char *buf,
-                           uintptr_t buf_size);
+                           uintptr_t buf_size,
+                           ProgressCallback progress_callback,
+                           const void *user_data);
 
 /**
  * # Safety

--- a/cro-clib/examples/Makefile
+++ b/cro-clib/examples/Makefile
@@ -1,4 +1,6 @@
-all:
+all: build run
+build:
 	cargo build
-	gcc -g test.c tx.c -o cro -lcro_clib -lssl -lm -lcrypto -ldl -lpthread -L../../target/debug/
+	gcc -g test.c tx.c rpc.c -o cro -lcro_clib -lssl -lm -lcrypto -ldl -lpthread -L../../target/debug/
+run:
 	LD_LIBRARY_PATH=../../target/debug ./cro

--- a/cro-clib/examples/rpc.c
+++ b/cro-clib/examples/rpc.c
@@ -1,0 +1,64 @@
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include <assert.h>
+#include "../chain-core.h"
+#include "../chain.h"
+
+//ret 1: continue, 0: stop
+int32_t progress(uint64_t current, uint64_t start, uint64_t end, const void*  user_data)
+{
+    double gap= 0;
+    double rate=0;
+    if (end>start) {
+        gap= end- start;
+        rate= (current-start)/ gap*100.0;
+    }
+    char* user= (char*)user_data;
+    printf("%8.2lf  progress current=%lu  start= %lu ~ end=%lu   user= %s\n",rate, current,start, end, user);
+    return 1;
+}
+
+void show_wallets()
+{
+    const int BUFSIZE=1000;
+    char buf[BUFSIZE];
+     const char* req = "{\"jsonrpc\": \"2.0\", \"method\": \"wallet_list\", \"params\": [], \"id\": 1}";
+    CroResult retcode = cro_jsonrpc_call("./.storage", "ws://localhost:26657/websocket", 0xab, req, buf, sizeof(buf), &progress,NULL);
+    if (retcode.result == 0) {
+        printf("response: %s\n", buf);
+    } else {
+        printf("error: %s\n", buf);
+    }
+}
+
+void sync()
+{
+    const int BUFSIZE=1000;
+    char buf[BUFSIZE];
+    char* name= getenv("CRO_NAME");
+    char* passphrase=getenv("CRO_PASSPHRASE");
+    char* enckey=getenv("CRO_ENCKEY");
+    const char* req_template = "{\"jsonrpc\": \"2.0\", \"method\": \"sync\", \"params\": [{\"name\":\"%s\", \"passphrase\":\"%s\",\"enckey\":\"%s\"}], \"id\": 1}";
+    char req[BUFSIZE];
+    sprintf(req, req_template, name, passphrase, enckey);
+    char* user_data="i'm user";
+
+    CroResult retcode = cro_jsonrpc_call("./.storage", "ws://localhost:26657/websocket", 0xab, req, buf, sizeof(buf), &progress, user_data);
+    if (retcode.result == 0) {
+        printf("response: %s\n", buf);
+    } else {
+        printf("error: %s\n", buf);
+    }
+}
+int test_rpc()
+{    
+    printf("test rpc\n");
+    show_wallets();
+    sync();
+    return 0;
+}
+

--- a/cro-clib/examples/test.c
+++ b/cro-clib/examples/test.c
@@ -7,6 +7,7 @@
 #include "../chain.h"
 
 int test_tx();
+int test_rpc();
 
 void print_address(CroAddressPtr a)
 {
@@ -154,6 +155,7 @@ int main()
     //test_hdwallet_create();
     //test_hdwallet_mnemonics();
     //test_normal_wallet_create();
-    test_tx();
+    //test_tx();
+    test_rpc();
     return 0;
 }

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -24,6 +24,8 @@ use client_rpc::rpc::{
 };
 
 use crate::types::CroResult;
+use crate::types::ProgressCallback;
+use client_rpc::rpc::sync_rpc::{CBindingCallback, CBindingCore};
 
 #[cfg(not(feature = "mock-enc-dec"))]
 type AppTransactionCipher = DefaultTransactionObfuscation;
@@ -108,11 +110,45 @@ fn make_syncer_config(
     ))
 }
 
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Clone)]
+struct CBindingData {
+    progress_callback: ProgressCallback,
+    // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
+    user_data: u64,
+}
+
+impl CBindingCallback for CBindingData {
+    // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
+    fn set_user(&mut self, user: u64) {
+        self.user_data = user;
+    }
+    // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
+    fn get_user(&self) -> u64 {
+        self.user_data
+    }
+
+    fn progress(&self, current: u64, start: u64, end: u64) -> i32 {
+        let back = &self.progress_callback;
+        (back)(
+            current,
+            start,
+            end,
+            // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
+            self.user_data as *const std::ffi::c_void,
+        )
+    }
+}
+
 fn do_jsonrpc_call(
     storage_dir: &str,
     websocket_url: &str,
     network_id: u8,
     json_request: &str,
+    progress_callback: ProgressCallback,
+    user_data: *const std::ffi::c_void,
 ) -> Result<String> {
     let mut io = IoHandler::new();
     let storage = SledStorage::new(storage_dir)?;
@@ -124,7 +160,14 @@ fn do_jsonrpc_call(
     let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
     let transaction_rpc = TransactionRpcImpl::new(network_id);
     let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
-    let sync_rpc = SyncRpcImpl::new(syncer_config);
+    let cbindingcallback = CBindingCore {
+        data: Arc::new(Mutex::new(CBindingData {
+            progress_callback,
+            // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
+            user_data: user_data as u64,
+        })),
+    };
+    let sync_rpc = SyncRpcImpl::new(syncer_config, Some(cbindingcallback));
     let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
 
     io.extend_with(multisig_rpc.to_delegate());
@@ -164,6 +207,8 @@ pub unsafe extern "C" fn cro_jsonrpc_call(
     request: *const c_char,
     buf: *mut c_char,
     buf_size: usize,
+    progress_callback: ProgressCallback,
+    user_data: *const std::ffi::c_void,
 ) -> CroResult {
     let res = do_jsonrpc_call(
         CStr::from_ptr(storage_dir)
@@ -176,6 +221,9 @@ pub unsafe extern "C" fn cro_jsonrpc_call(
         CStr::from_ptr(request)
             .to_str()
             .expect("storage_dir should be utf-8"),
+        progress_callback,
+        // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
+        user_data,
     );
     match res {
         Err(e) => {

--- a/cro-clib/src/types.rs
+++ b/cro-clib/src/types.rs
@@ -95,3 +95,7 @@ impl Default for CroFee {
         CroFee { fee }
     }
 }
+
+/// current, start, end, userdata
+/// return: 1: continue, 0: stop
+pub type ProgressCallback = extern "C" fn(u64, u64, u64, *const std::ffi::c_void) -> i32;


### PR DESCRIPTION
## Solution: add get progress callback
1. u64: for handle of json rpc context , * const c_void is not allowed in rust
    using handle as integer is recommended rather than putting pointer directly
2. callback in same thread, so can use ui in callback thread 
3. used Arc, Mutex for thread safety in calling c-callbacks 
## sync example 
```
   95.04  progress current=89117  start= 89002 ~ end=89123   user= 2020
   95.87  progress current=89118  start= 89002 ~ end=89123   user= 2020
   96.69  progress current=89119  start= 89002 ~ end=89123   user= 2020
   97.52  progress current=89120  start= 89002 ~ end=89123   user= 2020
   98.35  progress current=89121  start= 89002 ~ end=89123   user= 2020
   99.17  progress current=89122  start= 89002 ~ end=89123   user= 2020
  100.00  progress current=89123  start= 89002 ~ end=89123   user= 2020
  100.00  progress current=89123  start= 89002 ~ end=89123   user= 2020
response: {"jsonrpc":"2.0","result":null,"id":1}
```

