### PR TITLE
Problem:(cro-1132) repeated db open/close and thread spawning `jsonrpc_call` C binding#1132

### DIFF
--- a/cro-clib/examples/Makefile
+++ b/cro-clib/examples/Makefile
@@ -4,3 +4,7 @@ build:
 	gcc -g test.c tx.c rpc.c -o cro -lcro_clib -lssl -lm -lcrypto -ldl -lpthread -L../../target/debug/
 run:
 	LD_LIBRARY_PATH=../../target/debug ./cro
+mac: mac_build run
+mac_build:
+	cargo build
+	gcc -g test.c tx.c rpc.c -o cro -lcro_clib  -L../../target/debug/

--- a/cro-clib/examples/rpc.c
+++ b/cro-clib/examples/rpc.c
@@ -54,11 +54,40 @@ void sync()
         printf("error: %s\n", buf);
     }
 }
+void context_sync()
+{
+    const int BUFSIZE=1000;
+    char buf[BUFSIZE];
+    char* name= getenv("CRO_NAME");
+    char* passphrase=getenv("CRO_PASSPHRASE");
+    char* enckey=getenv("CRO_ENCKEY");
+    const char* req_template = "{\"jsonrpc\": \"2.0\", \"method\": \"sync\", \"params\": [{\"name\":\"%s\", \"passphrase\":\"%s\",\"enckey\":\"%s\"}], \"id\": 1}";
+    char req[BUFSIZE];
+    sprintf(req, req_template, name, passphrase, enckey);
+
+    const char* user="i'm user";
+    const char* wallet_req = "{\"jsonrpc\": \"2.0\", \"method\": \"wallet_list\", \"params\": [], \"id\": 1}";
+
+    printf("sync with context\n");
+    CroJsonRpcPtr rpc= NULL;
+    cro_create_jsonrpc(&rpc, ".storage", "ws://localhost:26657/websocket", 0xab, &progress);
+    cro_run_jsonrpc(rpc, wallet_req, buf, sizeof(buf), user);
+    printf("response: %s\n", buf);    
+
+    cro_run_jsonrpc(rpc, req, buf, sizeof(buf),user);
+    printf("response: %s\n", buf);
+    
+    cro_destroy_jsonrpc(rpc);
+    printf("OK");
+
+}
+
 int test_rpc()
 {    
     printf("test rpc\n");
-    show_wallets();
-    sync();
+    //show_wallets();
+    //sync();
+    context_sync();
     return 0;
 }
 

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -23,8 +23,12 @@ use client_rpc::rpc::{
     wallet_rpc::{WalletRpc, WalletRpcImpl},
 };
 
+use crate::types::get_string;
 use crate::types::CroResult;
 use crate::types::ProgressCallback;
+use crate::types::{CroJsonRpc, CroJsonRpcPtr};
+use std::ptr;
+
 use client_rpc::rpc::sync_rpc::{CBindingCallback, CBindingCore};
 
 #[cfg(not(feature = "mock-enc-dec"))]
@@ -239,4 +243,124 @@ pub unsafe extern "C" fn cro_jsonrpc_call(
             CroResult::success()
         }
     }
+}
+
+/// create json-rpc context
+/// rpc_out: null pointer which will be written
+/// example c-code)
+///  CroJsonRpcPtr rpc= NULL;
+///  cro_create_jsonrpc(&rpc, ".storage", "ws://localhost:26657/websocket", 0xab, &progress);
+/// storage_dir: ".storage"
+/// websocket_url:  "ws://localhost:26657/websocket"
+/// network: network-id  ex) 0xab
+/// progress_callback: callback function which user codes
+/// example c-code)
+/// int32_t  progress(float rate)
+/// {
+///    printf("progress %f\n", rate);
+/// }
+/// you can give this callback like below
+/// CroResult retcode = cro_jsonrpc_call("./.storage", "ws://localhost:26657/websocket", 0xab, req, buf, sizeof(buf), &progress);
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn cro_create_jsonrpc(
+    rpc_out: *mut CroJsonRpcPtr,
+    storage_dir_user: *const c_char,
+    websocket_url_user: *const c_char,
+    network_id: u8,
+    progress_callback: ProgressCallback,
+) -> CroResult {
+    let storage_dir = get_string(storage_dir_user);
+    let websocket_url = get_string(websocket_url_user);
+
+    let mut io = IoHandler::new();
+    let storage = SledStorage::new(&storage_dir).unwrap();
+    let tendermint_client = WebsocketRpcClient::new(&websocket_url).unwrap();
+    let wallet_client = make_wallet_client(storage.clone(), tendermint_client.clone()).unwrap();
+    let ops_client = make_ops_client(storage.clone(), tendermint_client.clone()).unwrap();
+    let syncer_config = make_syncer_config(storage, tendermint_client).unwrap();
+
+    let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
+    let transaction_rpc = TransactionRpcImpl::new(network_id);
+    let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
+
+    let cbindingcallback = CBindingCore {
+        data: Arc::new(Mutex::new(CBindingData {
+            progress_callback,
+            user_data: 0 as u64,
+        })),
+    };
+
+    let sync_rpc = SyncRpcImpl::new(syncer_config, Some(cbindingcallback.clone()));
+    let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
+
+    io.extend_with(multisig_rpc.to_delegate());
+    io.extend_with(transaction_rpc.to_delegate());
+    io.extend_with(staking_rpc.to_delegate());
+    io.extend_with(sync_rpc.to_delegate());
+    io.extend_with(wallet_rpc.to_delegate());
+
+    let rpc = CroJsonRpc {
+        handler: io,
+        binding: cbindingcallback,
+    };
+    let rpc_box = Box::new(rpc);
+    ptr::write(rpc_out, Box::into_raw(rpc_box));
+
+    CroResult::success()
+}
+
+/// request: json rpc request
+/// example c code) const char* req = "{\"jsonrpc\": \"2.0\", \"method\": \"wallet_list\", \"params\": [], \"id\": 1}";
+/// buf: minimum 500 bytes
+/// buf_size: size of buf in bytes
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn cro_run_jsonrpc(
+    rpc_ptr: CroJsonRpcPtr,
+    request: *const c_char,
+    buf: *mut c_char,
+    buf_size: usize,
+    user_data: *const std::ffi::c_void,
+) -> CroResult {
+    if rpc_ptr.is_null() {
+        return CroResult::fail();
+    }
+    let rpc = rpc_ptr.as_mut().expect("get wallet");
+    let json_request = get_string(request);
+
+    {
+        let mut user = (*rpc).binding.data.lock().expect("get cbinding callback");
+        user.set_user(user_data as u64);
+    }
+
+    let io = &rpc.handler;
+    let res = io
+        .handle_request_sync(&json_request)
+        .err_kind(ErrorKind::InvalidInput, || {
+            "stateful command execute failed"
+        });
+    match res {
+        Err(e) => {
+            libc::strncpy(
+                buf,
+                CString::new(e.to_string()).unwrap().into_raw(),
+                buf_size,
+            );
+            CroResult::fail()
+        }
+        Ok(s) => {
+            libc::strncpy(buf, CString::new(s).unwrap().into_raw(), buf_size);
+            CroResult::success()
+        }
+    }
+}
+
+/// destroy json-rpc context
+/// rpc: containing pointer to free
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn cro_destroy_jsonrpc(rpc: CroJsonRpcPtr) -> CroResult {
+    Box::from_raw(rpc);
+    CroResult::success()
 }

--- a/cro-clib/src/types.rs
+++ b/cro-clib/src/types.rs
@@ -4,9 +4,16 @@ use chain_core::tx::fee::{LinearFee, Milli};
 use client_common::{PrivateKey, PublicKey};
 use client_core::transaction_builder::WitnessedUTxO;
 use client_core::HDSeed;
+use client_rpc::rpc::sync_rpc::CBindingCore;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
+
+use jsonrpc_core::IoHandler;
+
+#[cfg(feature = "mock-enc-dec")]
+use client_core::cipher::MockAbciTransactionObfuscation;
+
 pub type CroHDWalletPtr = *mut CroHDWallet;
 pub type CroAddressPtr = *mut CroAddress;
 pub type CroTxPtr = *mut CroTx;
@@ -17,6 +24,7 @@ pub const SUCCESS: i32 = 0;
 pub const FAIL: i32 = -1;
 
 pub type CroString = [u8; 200];
+
 /// account types
 #[repr(C)]
 pub enum CroAccount {
@@ -99,3 +107,10 @@ impl Default for CroFee {
 /// current, start, end, userdata
 /// return: 1: continue, 0: stop
 pub type ProgressCallback = extern "C" fn(u64, u64, u64, *const std::ffi::c_void) -> i32;
+
+#[derive(Clone)]
+pub struct CroJsonRpc {
+    pub handler: IoHandler,
+    pub binding: CBindingCore,
+}
+pub type CroJsonRpcPtr = *mut CroJsonRpc;


### PR DESCRIPTION
## Solution ##
1.  add context
2. for different request, you can give different user_data as void*
```
actual code is  called in-directly via `handle_request_sync`, so, callback is stored at trait,
and called afterwards

this is for simplicity of reusing rpc-server.
also json run code is all synchronous.
```
## flow ##
rpc call1 end
rpc call2 end

## to do ##
for autosync, call is sync,
but actual syncing is endless. 
so, other thread checking via polling  
it's will be added soon.


