### PR TITLE
Problem (Fix #1214): Tx validation mutate StakedState directly

### DIFF
--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -16,13 +16,12 @@ pub use self::app_init::{
     compute_accounts_root, get_validator_key, init_app_hash, ChainNodeApp, ChainNodeState,
     ValidatorState,
 };
+use crate::app::validate_tx::ResponseWithCodeAndLog;
 use crate::enclave_bridge::EnclaveProxy;
-use crate::storage::get_account;
+use crate::storage::{get_account, TxAction};
 use chain_core::common::{TendermintEventKey, TendermintEventType};
 use chain_core::state::account::PunishmentKind;
-use chain_core::state::tendermint::{BlockHeight, TendermintValidatorAddress, TendermintVotePower};
-use chain_core::tx::{TxAux, TxEnclaveAux};
-use chain_storage::account::update_staked_state;
+use chain_core::state::tendermint::{BlockHeight, TendermintValidatorAddress};
 use slash_accounts::{get_slashing_proportion, get_vote_power_in_milli};
 use std::convert::{TryFrom, TryInto};
 
@@ -57,7 +56,16 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
     fn check_tx(&mut self, _req: &RequestCheckTx) -> ResponseCheckTx {
         info!("received checktx request");
         let mut resp = ResponseCheckTx::new();
-        ChainNodeApp::validate_tx_req(self, _req, &mut resp);
+        match ChainNodeApp::validate_tx_req(self, _req) {
+            Ok(_) => {
+                resp.set_code(0);
+            }
+            Err(msg) => {
+                resp.set_code(1);
+                resp.add_log(&msg);
+                log::warn!("check tx failed: {}", msg);
+            }
+        }
         resp
     }
 
@@ -244,112 +252,55 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
     fn deliver_tx(&mut self, _req: &RequestDeliverTx) -> ResponseDeliverTx {
         info!("received delivertx request");
         let mut resp = ResponseDeliverTx::new();
-        let mtxaux = ChainNodeApp::validate_tx_req(self, _req, &mut resp);
-        if let (0, Some((txaux, fee_acc))) = (resp.code, mtxaux) {
-            let last_state = self
-                .last_state
-                .as_mut()
-                .expect("there is at least genesis state");
-            let (next_account_root, maccount) = match &txaux {
-                TxAux::EnclaveTx(TxEnclaveAux::TransferTx { inputs, .. }) => {
-                    // here the original idea was "conservative" that it "spent" utxos here
-                    // but it didn't create utxos for this TX (they are created in commit)
-                    self.storage.spend_utxos(&inputs);
-                    (self.uncommitted_account_root_hash, None)
-                }
-                TxAux::EnclaveTx(TxEnclaveAux::DepositStakeTx { tx, .. }) => {
-                    self.storage.spend_utxos(&tx.inputs);
-                    update_staked_state(
-                        fee_acc
-                            .1
-                            .expect("account returned in deposit stake verification"),
-                        &self.uncommitted_account_root_hash,
-                        &mut self.accounts,
-                    )
-                }
-                TxAux::UnbondStakeTx(_, _) => update_staked_state(
-                    fee_acc
-                        .1
-                        .expect("account returned in unbond stake verification"),
-                    &self.uncommitted_account_root_hash,
-                    &mut self.accounts,
-                ),
-                TxAux::EnclaveTx(TxEnclaveAux::WithdrawUnbondedStakeTx { .. }) => {
-                    update_staked_state(
-                        fee_acc
-                            .1
-                            .expect("account returned in withdraw unbonded stake verification"),
-                        &self.uncommitted_account_root_hash,
-                        &mut self.accounts,
-                    )
-                }
-                TxAux::UnjailTx(_, _) => update_staked_state(
-                    fee_acc.1.expect("account returned in unjail verification"),
-                    &self.uncommitted_account_root_hash,
-                    &mut self.accounts,
-                ),
-                TxAux::NodeJoinTx(_, _) => {
-                    let state = fee_acc
-                        .1
-                        .expect("staked state returned in node join verification");
-                    last_state.validators.new_valid_node_join_update(&state);
-                    update_staked_state(
-                        state,
-                        &self.uncommitted_account_root_hash,
-                        &mut self.accounts,
-                    )
-                }
+        let mtxaux = ChainNodeApp::validate_tx_req(self, _req);
+        let mut event = Event::new();
+        event.field_type = TendermintEventType::ValidTransactions.to_string();
+        let result = mtxaux.and_then(|(txaux, action)| {
+            let (fee, maccount) = match &action {
+                TxAction::Enclave(action) => self.execute_enclave_tx(&txaux.tx_id(), action),
+                TxAction::Public(fee) => self.execute_public_tx(*fee, &txaux)?,
             };
-            let mut event = Event::new();
-            event.field_type = TendermintEventType::ValidTransactions.to_string();
-            let mut kvpair_fee = KVPair::new();
-            kvpair_fee.key = TendermintEventKey::Fee.into();
-            kvpair_fee.value = Vec::from(format!("{}", fee_acc.0.to_coin()));
-            event.attributes.push(kvpair_fee);
+            Ok((txaux, fee, maccount))
+        });
+        match result {
+            Ok((txaux, fee, maccount)) => {
+                resp.set_code(0);
 
-            if let Some(ref account) = maccount {
+                // write fee into event
+                let mut kvpair_fee = KVPair::new();
+                kvpair_fee.key = TendermintEventKey::Fee.into();
+                kvpair_fee.value = Vec::from(format!("{}", fee.to_coin()));
+                event.attributes.push(kvpair_fee);
+
+                if let Some(account) = maccount {
+                    let mut kvpair = KVPair::new();
+                    kvpair.key = TendermintEventKey::Account.into();
+                    kvpair.value = Vec::from(format!("{}", &account.address));
+                    event.attributes.push(kvpair);
+                }
+
                 let mut kvpair = KVPair::new();
-                kvpair.key = TendermintEventKey::Account.into();
-                kvpair.value = Vec::from(format!("{}", &account.address));
+                kvpair.key = TendermintEventKey::TxId.into();
+                kvpair.value = Vec::from(hex::encode(txaux.tx_id()).as_bytes());
                 event.attributes.push(kvpair);
-                last_state
-                    .validators
-                    .validator_state_helper
-                    .voting_power_update(
-                        account,
-                        TendermintVotePower::from(
-                            last_state
-                                .top_level
-                                .network_params
-                                .get_required_council_node_stake(),
-                        ),
-                    );
+                resp.events.push(event);
+                self.delivered_txs.push(txaux);
+                let rewards_pool = &mut self
+                    .last_state
+                    .as_mut()
+                    .expect("deliver tx, but last state not initialized")
+                    .top_level
+                    .rewards_pool;
+                let new_remaining = (rewards_pool.period_bonus + fee.to_coin())
+                    .expect("rewards pool + fee greater than max coin?");
+                rewards_pool.period_bonus = new_remaining;
+                self.rewards_pool_updated = true;
             }
-            // as self.accounts allows querying against different tree roots
-            // the modifications done with "update_account" _should_ be safe, as the final tree root will
-            // be persisted in commit.
-            // The question is whether it really is -- e.g. if Tendermint/ABCI app crashes during DeliverTX
-            // and then it tries to replay the block on the restart, will it cause problems
-            // with the account storage (starling / MerkleBIT), because it already persisted those "future" / not-yet-committed account states?
-            // TODO: most of these intermediate uncommitted tree roots aren't useful (not exposed for querying) -- prune them / the account storage?
-            self.uncommitted_account_root_hash = next_account_root;
-            let mut kvpair = KVPair::new();
-            kvpair.key = TendermintEventKey::TxId.into();
-            kvpair.value = Vec::from(hex::encode(txaux.tx_id()).as_bytes());
-            event.attributes.push(kvpair);
-            resp.events.push(event);
-            self.delivered_txs.push(txaux);
-            let rewards_pool = &mut self
-                .last_state
-                .as_mut()
-                .expect("deliver tx, but last state not initialized")
-                .top_level
-                .rewards_pool;
-            let new_remaining = (rewards_pool.period_bonus + fee_acc.0.to_coin())
-                .expect("rewards pool + fee greater than max coin?");
-            rewards_pool.period_bonus = new_remaining;
-            self.rewards_pool_updated = true;
-            // updates in DeliverTx are not persisted -- only in-mem in self.storage
+            Err(msg) => {
+                resp.set_code(1);
+                resp.add_log(&msg);
+                log::error!("deliver tx failed: {}", msg);
+            }
         }
         resp
     }

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -1,10 +1,13 @@
 use super::ChainNodeApp;
 use crate::enclave_bridge::EnclaveProxy;
-use crate::storage::{verify_enclave_tx, verify_public_tx};
+use crate::storage::{verify_enclave_tx, verify_public_tx, TxAction, TxEnclaveAction};
 use abci::*;
 use chain_core::state::account::StakedState;
+use chain_core::state::tendermint::TendermintVotePower;
+use chain_core::tx::data::TxId;
 use chain_core::tx::fee::Fee;
 use chain_core::tx::TxAux;
+use chain_storage::account::{get_staked_state, update_staked_state, StakedStateError};
 use chain_tx_validation::{ChainInfo, Error};
 use parity_scale_codec::Decode;
 
@@ -60,12 +63,7 @@ impl ResponseWithCodeAndLog for ResponseDeliverTx {
 
 impl<T: EnclaveProxy> ChainNodeApp<T> {
     // TODO: CheckTx only against only committed states or a custom CheckTx sub-state?
-    fn handle_tx(
-        &mut self,
-        txaux: &TxAux,
-        tx_len: usize,
-        store_valid: bool,
-    ) -> Result<(Fee, Option<StakedState>), Error> {
+    fn handle_tx(&mut self, txaux: &TxAux, tx_len: usize) -> Result<TxAction, Error> {
         let state = self.last_state.as_ref().expect("the app state is expected");
         let min_fee = state
             .top_level
@@ -80,63 +78,182 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
         };
         match txaux {
             TxAux::EnclaveTx(tx) => {
-                let r = verify_enclave_tx(
+                let action = verify_enclave_tx(
                     &mut self.tx_validator,
                     &tx,
                     extra_info,
                     &self.uncommitted_account_root_hash,
                     &self.storage,
                     &self.accounts,
-                );
-                match (r, store_valid) {
-                    (Err(e), _) => Err(e),
-                    (Ok((fee, acc, _)), false) => Ok((fee, acc)),
-                    (Ok((fee, acc, None)), _) => Ok((fee, acc)),
-                    (Ok((fee, acc, Some(log))), true) => {
-                        self.storage.store_sealed_log(&txaux.tx_id(), &log);
-                        Ok((fee, acc))
-                    }
-                }
+                )?;
+                Ok(TxAction::Enclave(action))
             }
-            _ => verify_public_tx(
-                &txaux,
-                extra_info,
-                state,
-                &self.uncommitted_account_root_hash,
-                &self.accounts,
-            ),
+            _ => Ok(TxAction::Public(min_fee)),
         }
     }
 
     /// Gets CheckTx or DeliverTx requests, tries to parse its data into TxAux and validate that TxAux.
-    /// Returns Some(parsed txaux, (paid fee, updated staking account)) if OK, or None if some problems (and sets log + error code in the passed in response).
+    /// Returns Some(TxAux, TxAction) if OK, or Err(String) if some problems.
     pub fn validate_tx_req(
         &mut self,
-        _req: &dyn RequestWithTx,
-        resp: &mut dyn ResponseWithCodeAndLog,
-    ) -> Option<(TxAux, (Fee, Option<StakedState>))> {
-        let data = Vec::from(_req.tx());
-        let dtx = TxAux::decode(&mut data.as_slice());
+        req: &dyn RequestWithTx,
+    ) -> Result<(TxAux, TxAction), String> {
+        let dtx = TxAux::decode(&mut req.tx());
         match dtx {
-            Err(e) => {
-                resp.set_code(1);
-                resp.add_log(&format!("failed to deserialize tx: {}", e.what()));
-                None
-            }
+            Err(e) => Err(format!("failed to deserialize tx: {}", e.what())),
             Ok(txaux) => {
-                let fee_paid = self.handle_tx(&txaux, _req.tx().len(), _req.store_valid());
-                match fee_paid {
-                    Ok(fee) => {
-                        resp.set_code(0);
-                        Some((txaux, fee))
-                    }
-                    Err(fee_err) => {
-                        resp.set_code(1);
-                        resp.add_log(&format!("verification failed: {}", fee_err));
-                        None
-                    }
+                let result = self.handle_tx(&txaux, req.tx().len());
+                match result {
+                    Ok(action) => Ok((txaux, action)),
+                    Err(err) => Err(format!("verification failed: {}", err.to_string())),
                 }
             }
         }
+    }
+
+    pub fn execute_enclave_tx(
+        &mut self,
+        txid: &TxId,
+        action: &TxEnclaveAction,
+    ) -> (Fee, Option<StakedState>) {
+        match action {
+            TxEnclaveAction::Transfer {
+                spend_utxo,
+                sealed_log,
+                fee,
+                ..
+            } => {
+                self.storage.spend_utxos(&spend_utxo);
+                // Done in commit event
+                // self.storage.create_utxo(no_of_outputs, txid);
+                self.storage.store_sealed_log(&txid, sealed_log);
+                (*fee, None)
+            }
+            TxEnclaveAction::Deposit {
+                fee,
+                spend_utxo,
+                deposit: (address, amount),
+            } => {
+                self.storage.spend_utxos(&spend_utxo);
+                let result =
+                    get_staked_state(address, &self.uncommitted_account_root_hash, &self.accounts);
+                let mut account = match result {
+                    Ok(account) => account,
+                    Err(StakedStateError::NotFound) => StakedState::default(*address),
+                    Err(StakedStateError::IoError(err)) => {
+                        panic!("get staking state io error: {}", err)
+                    }
+                };
+                account.deposit(*amount);
+                let (new_root, maccount) = update_staked_state(
+                    account,
+                    &self.uncommitted_account_root_hash,
+                    &mut self.accounts,
+                );
+                self.uncommitted_account_root_hash = new_root;
+                self.update_account(maccount.as_ref().unwrap());
+                (*fee, maccount)
+            }
+            TxEnclaveAction::Withdraw {
+                fee,
+                withdraw: (address, amount),
+                sealed_log,
+                ..
+            } => {
+                // Done in commit event
+                // self.storage.create_utxo(no_of_outputs, txid);
+                self.storage.store_sealed_log(&txid, sealed_log);
+
+                // no panic: tx is verified, account should be exist.
+                // operations are sequential in the state machine, so no concurrent updates
+                let mut account =
+                    get_staked_state(address, &self.uncommitted_account_root_hash, &self.accounts)
+                        .unwrap();
+                assert_eq!(&account.unbonded, amount);
+                account.withdraw();
+                let (new_root, maccount) = update_staked_state(
+                    account,
+                    &self.uncommitted_account_root_hash,
+                    &mut self.accounts,
+                );
+                self.uncommitted_account_root_hash = new_root;
+                self.update_account(maccount.as_ref().unwrap());
+                (*fee, maccount)
+            }
+        }
+    }
+
+    pub fn execute_public_tx(
+        &mut self,
+        min_fee: Fee,
+        txaux: &TxAux,
+    ) -> Result<(Fee, Option<StakedState>), String> {
+        let last_state = self.last_state.as_mut().expect("the app state is expected");
+        let extra_info = ChainInfo {
+            min_fee_computed: min_fee,
+            chain_hex_id: self.chain_hex_id,
+            previous_block_time: last_state.block_time,
+            unbonding_period: last_state.top_level.network_params.get_unbonding_period(),
+        };
+        let fee_acc = verify_public_tx(
+            txaux,
+            extra_info,
+            &*last_state,
+            &self.uncommitted_account_root_hash,
+            &self.accounts,
+        )
+        .map_err(|err| format!("verification failed: {}", err.to_string()))?;
+        let (new_root, maccount) = match txaux {
+            TxAux::EnclaveTx(_) => unreachable!(),
+
+            TxAux::UnbondStakeTx(_, _) => update_staked_state(
+                fee_acc
+                    .1
+                    .clone()
+                    .expect("account returned in unbond stake verification"),
+                &self.uncommitted_account_root_hash,
+                &mut self.accounts,
+            ),
+
+            TxAux::UnjailTx(_, _) => update_staked_state(
+                fee_acc
+                    .1
+                    .clone()
+                    .expect("account returned in unjail verification"),
+                &self.uncommitted_account_root_hash,
+                &mut self.accounts,
+            ),
+            TxAux::NodeJoinTx(_, _) => {
+                let state = fee_acc
+                    .1
+                    .clone()
+                    .expect("staked state returned in node join verification");
+                last_state.validators.new_valid_node_join_update(&state);
+                update_staked_state(
+                    state,
+                    &self.uncommitted_account_root_hash,
+                    &mut self.accounts,
+                )
+            }
+        };
+        self.uncommitted_account_root_hash = new_root;
+        self.update_account(maccount.as_ref().unwrap());
+        Ok(fee_acc)
+    }
+
+    fn update_account(&mut self, account: &StakedState) {
+        let last_state = self.last_state.as_mut().unwrap();
+        last_state
+            .validators
+            .validator_state_helper
+            .voting_power_update(
+                account,
+                TendermintVotePower::from(
+                    last_state
+                        .top_level
+                        .network_params
+                        .get_required_council_node_stake(),
+                ),
+            );
     }
 }

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -273,19 +273,6 @@ pub fn to_stake_key(address: &StakedStateAddress) -> [u8; HASH_SIZE_256] {
     }
 }
 
-impl Default for StakedState {
-    fn default() -> Self {
-        StakedState::new(
-            0,
-            Coin::zero(),
-            Coin::zero(),
-            0,
-            StakedStateAddress::BasicRedeem(RedeemAddress::default()),
-            None,
-        )
-    }
-}
-
 impl StakedState {
     /// creates a new StakedState with given parameters
     pub fn new(
@@ -303,6 +290,19 @@ impl StakedState {
             unbonded_from,
             address,
             punishment,
+            council_node: None,
+        }
+    }
+
+    /// Create a default StakedState with address.
+    pub fn default(address: StakedStateAddress) -> Self {
+        StakedState {
+            nonce: 0,
+            bonded: Coin::zero(),
+            unbonded: Coin::zero(),
+            unbonded_from: 0,
+            address,
+            punishment: None,
             council_node: None,
         }
     }

--- a/chain-storage/src/account/mod.rs
+++ b/chain-storage/src/account/mod.rs
@@ -19,6 +19,7 @@ use chain_core::state::account::{to_stake_key, StakedState, StakedStateAddress};
 /// key type for looking up accounts/staked states in the merkle tree storage
 pub type StarlingFixedKey = [u8; KEY_LEN];
 
+#[derive(Debug)]
 pub enum StakedStateError {
     NotFound,
     IoError(std::io::Error),
@@ -225,7 +226,8 @@ mod test {
     #[test]
     fn test_account_insert_can_find() {
         let mut tree = AccountStorage::new(create_db(), 20).expect("account db");
-        let account = StakedState::default();
+        let account =
+            StakedState::default(StakedStateAddress::BasicRedeem(RedeemAddress::default()));
         let key = account.key();
         let wrapped = AccountWrapper(account);
         let new_root = tree
@@ -238,7 +240,8 @@ mod test {
     #[test]
     fn test_account_update_can_find() {
         let mut tree = AccountStorage::new(create_db(), 20).expect("account db");
-        let account = StakedState::default();
+        let account =
+            StakedState::default(StakedStateAddress::BasicRedeem(RedeemAddress::default()));
         let key = account.key();
         let wrapped = AccountWrapper(account);
         let old_root = tree
@@ -271,7 +274,8 @@ mod test {
     #[test]
     fn test_account_remove_cannot_find() {
         let mut tree = AccountStorage::new(create_db(), 20).expect("account db");
-        let account = StakedState::default();
+        let account =
+            StakedState::default(StakedStateAddress::BasicRedeem(RedeemAddress::default()));
         let key = account.key();
         let wrapped = AccountWrapper(account);
         let old_root = tree


### PR DESCRIPTION
Solution:
- Use `TxEnclaveAction` to seperate enclave tx validation and execution.

This is a refactoring prepared for the latter revised staking implementation.