### PR TITLE
Problem: i64 doesn't represent the semantic of BlockHeight

### DIFF
--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -116,7 +116,7 @@ impl ChainNodeState {
         validators: ValidatorState,
     ) -> Self {
         ChainNodeState {
-            last_block_height: 0,
+            last_block_height: BlockHeight::genesis(),
             last_apphash: genesis_apphash,
             block_time: genesis_time,
             validators,

--- a/chain-abci/src/app/end_block.rs
+++ b/chain-abci/src/app/end_block.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::app::app_init::ChainNodeApp;
 use crate::enclave_bridge::EnclaveProxy;
 use abci::{Event, KVPair, RequestEndBlock, ResponseEndBlock};
@@ -39,7 +41,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             state.block_time + (state.top_level.network_params.get_unbonding_period() as u64)) {
             resp.set_validator_updates(RepeatedField::from(validators));
         }
-        state.last_block_height = _req.height;
+        state.last_block_height = _req.height.try_into().unwrap();
         }).expect("executing end block, but no app state stored (i.e. no initchain or recovery was executed)");
         resp
     }

--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -4,6 +4,8 @@ use super::*;
 use abci::{RequestQuery, ResponseQuery};
 use chain_core::state::account::DepositBondTx;
 #[cfg(feature = "mock-enc-dec")]
+use chain_core::state::tendermint::BlockHeight;
+#[cfg(feature = "mock-enc-dec")]
 use chain_core::tx::data::input::TxoIndex;
 use chain_core::tx::PlainTxAux;
 #[cfg(feature = "mock-enc-dec")]
@@ -58,7 +60,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                             inputs: tx.inputs.clone(),
                             no_of_outputs: tx.outputs.len() as TxoIndex,
                             payload: TxObfuscated {
-                                key_from: 0,
+                                key_from: BlockHeight::genesis(),
                                 txid: tx.id(),
                                 init_vector: [0u8; 12],
                                 txpayload: pad_payload(&plain.encode()),
@@ -73,7 +75,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                         resp: Ok(TxEnclaveAux::DepositStakeTx {
                             tx: maintx.clone(),
                             payload: TxObfuscated {
-                                key_from: 0,
+                                key_from: BlockHeight::genesis(),
                                 txid: maintx.id(),
                                 init_vector: [0u8; 12],
                                 txpayload: pad_payload(&plain.encode()),
@@ -89,7 +91,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                             no_of_outputs: tx.outputs.len() as TxoIndex,
                             witness,
                             payload: TxObfuscated {
-                                key_from: 0,
+                                key_from: BlockHeight::genesis(),
                                 txid: tx.id(),
                                 init_vector: [0u8; 12],
                                 txpayload: pad_payload(&plain.encode()),

--- a/chain-abci/src/liveness.rs
+++ b/chain-abci/src/liveness.rs
@@ -29,8 +29,8 @@ impl LivenessTracker {
     /// Updates liveness tracker with new block data
     pub fn update(&mut self, block_height: BlockHeight, signed: bool) {
         let block_signing_window = self.liveness.len();
-        let update_index = (block_height as usize - 1) % block_signing_window; // Because `block_height` starts from 1
-        self.liveness.set(update_index, signed)
+        let update_index = block_height.value() as usize % block_signing_window;
+        self.liveness.set(update_index, signed);
     }
 
     /// Checks if validator is live or not
@@ -72,8 +72,8 @@ mod tests {
     #[test]
     fn check_liveness_tracker_encode_decode() {
         let mut initial = LivenessTracker::new(50);
-        initial.update(1, true);
-        initial.update(2, false);
+        initial.update(1.into(), true);
+        initial.update(2.into(), false);
 
         let encoded = initial.encode();
         let decoded = LivenessTracker::decode(&mut encoded.as_ref()).unwrap();
@@ -84,11 +84,11 @@ mod tests {
     #[test]
     fn check_liveness_tracker() {
         let mut tracker = LivenessTracker::new(5);
-        tracker.update(1, true);
-        tracker.update(2, false);
-        tracker.update(3, true);
-        tracker.update(4, false);
-        tracker.update(5, true);
+        tracker.update(1.into(), true);
+        tracker.update(2.into(), false);
+        tracker.update(3.into(), true);
+        tracker.update(4.into(), false);
+        tracker.update(5.into(), true);
 
         assert!(tracker.is_live(3));
         assert!(!tracker.is_live(2));

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -13,6 +13,7 @@ use chain_core::state::account::{
     DepositBondTx, Punishment, PunishmentKind, StakedStateOpWitness, UnbondTx, UnjailTx,
     WithdrawUnbondedTx,
 };
+use chain_core::state::tendermint::BlockHeight;
 use chain_core::state::tendermint::{
     TendermintValidatorAddress, TendermintValidatorPubKey, TendermintVotePower,
 };
@@ -233,7 +234,7 @@ fn prepare_app_valid_transfer_tx(
         no_of_outputs: tx.outputs.len() as TxoIndex,
         payload: TxObfuscated {
             txid: tx.id(),
-            key_from: 0,
+            key_from: BlockHeight::genesis(),
             init_vector: [0; 12],
             txpayload: plain_txaux.encode(),
         },
@@ -417,7 +418,7 @@ fn prepare_app_valid_withdraw_tx(
         witness: witness.clone(),
         payload: TxObfuscated {
             txid: tx.id(),
-            key_from: 0,
+            key_from: BlockHeight::genesis(),
             init_vector: [0; 12],
             txpayload: PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()).encode(),
         },
@@ -670,7 +671,7 @@ fn prepare_app_valid_deposit_tx(
         tx: tx.clone(),
         payload: TxObfuscated {
             txid: tx.id(),
-            key_from: 0,
+            key_from: BlockHeight::genesis(),
             init_vector: [0u8; 12],
             txpayload: PlainTxAux::DepositStakeTx(witness.clone().into()).encode(),
         },
@@ -1385,7 +1386,7 @@ fn prepare_withdraw_transaction(secret_key: &SecretKey) -> TxEnclaveAux {
         witness: witness.clone(),
         payload: TxObfuscated {
             txid: tx.id(),
-            key_from: 0,
+            key_from: BlockHeight::genesis(),
             init_vector: [0; 12],
             txpayload: PlainTxAux::WithdrawUnbondedStakeTx(tx.clone()).encode(),
         },
@@ -1411,7 +1412,7 @@ fn prepare_deposit_transaction(
         tx: tx.clone(),
         payload: TxObfuscated {
             txid: tx.id(),
-            key_from: 0,
+            key_from: BlockHeight::genesis(),
             init_vector: [0u8; 12],
             txpayload: PlainTxAux::DepositStakeTx(witness.into()).encode(),
         },

--- a/chain-core/src/state/mod.rs
+++ b/chain-core/src/state/mod.rs
@@ -65,7 +65,7 @@ impl RewardsPoolState {
     pub fn new(genesis_time: Timespec, tau: u64) -> Self {
         RewardsPoolState {
             period_bonus: Coin::zero(),
-            last_block_height: 0,
+            last_block_height: 0.into(),
             last_distribution_time: genesis_time,
             minted: Coin::zero(),
             tau,

--- a/chain-core/src/state/tendermint.rs
+++ b/chain-core/src/state/tendermint.rs
@@ -14,8 +14,60 @@ use std::prelude::v1::{String, ToString, Vec};
 use thiserror::Error;
 
 /// Tendermint block height
-/// TODO: u64?
-pub type BlockHeight = i64;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+#[cfg_attr(not(feature = "mesalock_sgx"), derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "mesalock_sgx"), serde(transparent))]
+pub struct BlockHeight(u64);
+
+impl std::fmt::Display for BlockHeight {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl BlockHeight {
+    #[inline]
+    pub fn new(n: u64) -> BlockHeight {
+        BlockHeight(n)
+    }
+    #[inline]
+    pub fn genesis() -> BlockHeight {
+        BlockHeight(0)
+    }
+    #[inline]
+    pub fn value(self) -> u64 {
+        self.0
+    }
+    #[inline]
+    pub fn checked_sub(self, n: u64) -> Option<BlockHeight> {
+        self.0.checked_sub(n).map(BlockHeight)
+    }
+    #[inline]
+    pub fn checked_add(self, n: u64) -> Option<BlockHeight> {
+        self.0.checked_add(n).map(BlockHeight)
+    }
+    #[inline]
+    pub fn saturating_sub(self, n: u64) -> BlockHeight {
+        BlockHeight(self.0.saturating_sub(n))
+    }
+    #[inline]
+    pub fn saturating_add(self, n: u64) -> BlockHeight {
+        BlockHeight(self.0.saturating_add(n))
+    }
+}
+
+impl From<u64> for BlockHeight {
+    fn from(n: u64) -> BlockHeight {
+        BlockHeight(n)
+    }
+}
+
+impl TryFrom<i64> for BlockHeight {
+    type Error = <u64 as TryFrom<i64>>::Error;
+    fn try_from(n: i64) -> Result<BlockHeight, Self::Error> {
+        u64::try_from(n).map(BlockHeight)
+    }
+}
 
 /// ed25519 public key size
 pub const PUBLIC_KEY_SIZE: usize = 32;

--- a/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/obfuscate.rs
@@ -1,6 +1,7 @@
 use crate::validate::write_back_response;
 use aead::{generic_array::GenericArray, Aead, NewAead};
 use aes_gcm_siv::Aes128GcmSiv;
+use chain_core::state::tendermint::BlockHeight;
 use chain_core::tx::TransactionId;
 use chain_core::tx::{PlainTxAux, TxObfuscated, TxToObfuscate};
 use chain_tx_validation::{
@@ -31,7 +32,7 @@ pub(crate) fn encrypt(tx: TxToObfuscate) -> TxObfuscated {
     let nonce = GenericArray::from_slice(&init_vector);
     let ciphertext = aead.encrypt(nonce, &tx).expect("encryption failure!");
     TxObfuscated {
-        key_from: -1,
+        key_from: BlockHeight::genesis(),
         init_vector,
         txpayload: ciphertext,
         txid: tx.txid,

--- a/client-core/src/cipher/mock_abci_transaction_obfuscation.rs
+++ b/client-core/src/cipher/mock_abci_transaction_obfuscation.rs
@@ -125,6 +125,7 @@ mod tests {
 
     use base64::encode;
 
+    use chain_core::state::tendermint::BlockHeight;
     use chain_core::state::ChainState;
     use chain_core::tx::data::Tx;
     use chain_core::tx::witness::TxWitness;
@@ -138,7 +139,7 @@ mod tests {
             no_of_outputs: 2,
             payload: TxObfuscated {
                 txid: [0; 32],
-                key_from: 0,
+                key_from: BlockHeight::genesis(),
                 init_vector: [0; 12],
                 txpayload: Vec::new(),
             },

--- a/client-core/src/signer/dummy_signer.rs
+++ b/client-core/src/signer/dummy_signer.rs
@@ -5,6 +5,7 @@ use chain_core::state::account::{
     DepositBondTx, StakedStateAddress, StakedStateOpAttributes, StakedStateOpWitness,
     WithdrawUnbondedTx,
 };
+use chain_core::state::tendermint::BlockHeight;
 use chain_core::tx::data::input::{TxoIndex, TxoPointer};
 use chain_core::tx::data::{Tx, TxId};
 use chain_core::tx::witness::tree::RawXOnlyPubkey;
@@ -71,7 +72,7 @@ impl DummySigner {
             no_of_outputs: tx.outputs.len() as TxoIndex,
             payload: TxObfuscated {
                 txid: [0; 32],
-                key_from: 0,
+                key_from: BlockHeight::genesis(),
                 init_vector: [0u8; 12],
                 txpayload: padded_payload,
             },
@@ -95,7 +96,7 @@ impl DummySigner {
         };
         let payload = TxObfuscated {
             txid: TxId::default(),
-            key_from: 0,
+            key_from: BlockHeight::genesis(),
             init_vector: [0u8; 12],
             txpayload: padded_payload,
         };
@@ -120,7 +121,7 @@ impl DummySigner {
             witness,
             payload: TxObfuscated {
                 txid,
-                key_from: 0,
+                key_from: BlockHeight::genesis(),
                 init_vector: [0u8; 12],
                 txpayload: padded_plain,
             },

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -193,6 +193,7 @@ mod default_wallet_transaction_builder_tests {
     use secstr::SecUtf8;
 
     use super::*;
+    use chain_core::state::tendermint::BlockHeight;
     use chain_core::tx::data::input::{TxoIndex, TxoPointer};
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::{LinearFee, Milli};
@@ -228,7 +229,7 @@ mod default_wallet_transaction_builder_tests {
                         no_of_outputs: tx.outputs.len() as TxoIndex,
                         payload: TxObfuscated {
                             txid: [0; 32],
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload,
                         },

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -534,6 +534,7 @@ mod raw_transfer_transaction_builder_tests {
     use chain_core::common::MerkleTree;
     use chain_core::common::H256;
     use chain_core::init::MAX_COIN;
+    use chain_core::state::tendermint::BlockHeight;
     use chain_core::tx::data::address::ExtendedAddr;
     use chain_core::tx::data::input::TxoIndex;
     use chain_core::tx::fee::{LinearFee, Milli};
@@ -1231,7 +1232,7 @@ mod raw_transfer_transaction_builder_tests {
                         no_of_outputs: tx.outputs.len() as TxoIndex,
                         payload: TxObfuscated {
                             txid: [0; 32],
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload,
                         },

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -517,6 +517,7 @@ mod tests {
     use chain_core::state::account::{
         Punishment, PunishmentKind, StakedState, StakedStateOpAttributes,
     };
+    use chain_core::state::tendermint::BlockHeight;
     use chain_core::state::tendermint::TendermintValidatorPubKey;
     use chain_core::state::ChainState;
     use chain_core::tx::data::input::TxoIndex;
@@ -554,7 +555,7 @@ mod tests {
                         tx: tx.clone(),
                         payload: TxObfuscated {
                             txid: tx.id(),
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload: plain.encode(),
                         },
@@ -567,7 +568,7 @@ mod tests {
                         witness,
                         payload: TxObfuscated {
                             txid: tx.id(),
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload: plain.encode(),
                         },

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -435,6 +435,7 @@ pub mod tests {
     use parity_scale_codec::Encode;
 
     use chain_core::init::coin::CoinError;
+    use chain_core::state::tendermint::BlockHeight;
     use chain_core::state::ChainState;
     use chain_core::tx::data::input::TxoIndex;
     use chain_core::tx::data::TxId;
@@ -489,7 +490,7 @@ pub mod tests {
                         no_of_outputs: tx.outputs.len() as TxoIndex,
                         payload: TxObfuscated {
                             txid: tx.id(),
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload,
                         },
@@ -501,7 +502,7 @@ pub mod tests {
                         tx: tx.clone(),
                         payload: TxObfuscated {
                             txid: tx.id(),
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload: plain.encode(),
                         },
@@ -514,7 +515,7 @@ pub mod tests {
                         witness,
                         payload: TxObfuscated {
                             txid: tx.id(),
-                            key_from: 0,
+                            key_from: BlockHeight::genesis(),
                             init_vector: [0u8; 12],
                             txpayload: plain.encode(),
                         },


### PR DESCRIPTION
Solution:
- Change `BlockHeight` to a newtype over u64
- Only support safe operations like `checked_sub/add`, `saturating_sub/add`.