### PR TITLE
Problem: EDP unseal doesn't work/compile (fixes #1274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ version = "0.4.0"
 dependencies = [
  "aead",
  "aes-gcm",
+ "rand 0.7.3",
  "sgx-isa",
  "zeroize 1.1.0",
 ]

--- a/chain-tx-enclave/enclave-utils/Cargo.toml
+++ b/chain-tx-enclave/enclave-utils/Cargo.toml
@@ -11,6 +11,7 @@ sgx-isa = "0.3"
 aes-gcm = "0.5.0"
 aead = "0.2"
 zeroize = "1.1"
+rand = "0.7"
 
 [features]
 sgxstd = ["sgx-isa/sgxstd"]


### PR DESCRIPTION
Solution: temporarily put attributes from tx validation + added temporary seal
when this WIP is finished, `cargo test --target x86_64-fortanix-unknown-sgx`
could perhaps but put into a CI pipeline