### PR TITLE
Problem: infeasible to create a large chunk of transfer addresses in …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "1cfb90d266d6ca61cea4d155dd5033c9516495f4f74f82faf1ca5c4feeb82577"
 dependencies = [
  "byteorder",
  "bytes",
- "env_logger 0.7.1",
+ "env_logger",
  "futures 0.3.4",
  "integer-encoding",
  "log 0.4.8",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
 ]
@@ -122,12 +122,6 @@ checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
  "winapi 0.3.8",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 
 [[package]]
 name = "arrayref"
@@ -166,9 +160,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.43"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f80256bc78f67e7df7e36d77366f636ed976895d91fe2ab9efa3973e8fe8c4f"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -178,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.32"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 dependencies = [
  "cc",
  "libc",
@@ -233,23 +227,24 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
 name = "bindgen"
-version = "0.49.4"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c07087f3d5731bf3fb375a81841b99597e25dc11bd3bc72d16d43adf6624a6e"
+checksum = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
 dependencies = [
  "bitflags",
  "cexpr",
  "cfg-if",
  "clang-sys",
  "clap",
- "env_logger 0.6.2",
- "fxhash",
+ "env_logger",
  "lazy_static",
+ "lazycell",
  "log 0.4.8",
  "peeking_take_while",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
  "regex",
+ "rustc-hash",
  "shlex",
  "which",
 ]
@@ -355,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 dependencies = [
  "memchr",
 ]
@@ -404,15 +399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cbindgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,11 +406,11 @@ checksum = "2db2df1ebc842c41fd2c4ae5b5a577faf63bd5151b953db752fc686812bee318"
 dependencies = [
  "clap",
  "log 0.4.8",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
  "serde",
  "serde_json",
- "syn 1.0.14",
+ "syn 1.0.17",
  "tempfile",
  "toml 0.5.6",
 ]
@@ -440,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -470,7 +456,7 @@ dependencies = [
  "digest 0.8.1",
  "enclave-protocol",
  "enclave-u-common",
- "env_logger 0.7.1",
+ "env_logger",
  "hex 0.4.2",
  "integer-encoding",
  "kvdb",
@@ -570,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer 0.1.42",
  "num-traits 0.2.11",
@@ -582,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+checksum = "f92986241798376849e1a007827041fed9bb36195822c2049d18e174420e0534"
 dependencies = [
  "glob",
  "libc",
@@ -643,13 +629,13 @@ version = "0.4.0"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "cli-table",
  "client-common",
  "client-core",
  "client-network",
  "console",
- "env_logger 0.7.1",
+ "env_logger",
  "hex 0.4.2",
  "log 0.4.8",
  "once_cell",
@@ -675,7 +661,7 @@ dependencies = [
  "blake2",
  "chain-core",
  "chain-tx-filter",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "hex 0.4.2",
  "hmac",
  "indexmap",
@@ -708,7 +694,7 @@ dependencies = [
  "chain-core",
  "chain-tx-filter",
  "chain-tx-validation",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "client-common",
  "enclave-protocol",
  "hex 0.4.2",
@@ -749,7 +735,7 @@ dependencies = [
  "base64 0.11.0",
  "chain-core",
  "chain-tx-validation",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "client-common",
  "client-core",
  "hex 0.4.2",
@@ -766,12 +752,12 @@ dependencies = [
  "base64 0.11.0",
  "chain-core",
  "chain-tx-filter",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "client-common",
  "client-core",
  "client-network",
  "dirs",
- "env_logger 0.7.1",
+ "env_logger",
  "hex 0.4.2",
  "indexmap",
  "jsonrpc-core",
@@ -821,9 +807,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -831,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crc32fast"
@@ -890,24 +876,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -924,11 +912,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
 ]
@@ -980,10 +968,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
  "strsim 0.9.3",
- "syn 1.0.14",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -993,8 +981,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1005,9 +993,9 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1017,9 +1005,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1028,7 +1016,7 @@ version = "0.4.0"
 dependencies = [
  "chain-abci",
  "chain-core",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "client-common",
  "client-core",
  "client-network",
@@ -1201,7 +1189,7 @@ dependencies = [
 name = "enclave-u-common"
 version = "0.1.1"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "hex 0.3.2",
  "log 0.4.8",
  "sgx_types",
@@ -1224,19 +1212,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "env_logger"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-dependencies = [
- "atty",
- "humantime",
- "log 0.4.8",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "env_logger"
@@ -1272,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -1282,13 +1257,13 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "synstructure",
 ]
 
@@ -1300,9 +1275,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fancy-regex"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0626a241d18e88e899f9f17e55825c7136c509b8ff7315b8e2aff28d4d98a3"
+checksum = "b0e2de1b89ad299d536b7cefc5d177f5c005957fa2266ce58eca4d189e74bff5"
 dependencies = [
  "bit-set",
  "regex",
@@ -1471,9 +1446,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1564,9 +1539,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1604,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
@@ -1761,9 +1736,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1840,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1904,9 +1879,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -2033,6 +2008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+
+[[package]]
 name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.2.4"
+version = "6.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0785e816e1e11e7599388a492c61ef80ddc2afc91e313e61662cce537809be"
+checksum = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
 dependencies = [
  "bindgen",
  "cc",
@@ -2116,17 +2097,17 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
- "rustc_version",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2193,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2248,12 +2229,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 dependencies = [
  "memchr",
- "version_check 0.1.5",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -2388,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "owning_ref"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -2433,9 +2414,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -2458,8 +2439,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.8",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "syn 1.0.17",
  "synstructure",
 ]
 
@@ -2586,46 +2567,41 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875077759af22fa20b610ad4471d8155b321c89c3f2785526c9839b099be4e0a"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "rustversion",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
+ "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5717d9fa2664351a01ed73ba5ef6df09c01a521cb42cb65a061432a826f3c7a"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "rustversion",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.11"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
-]
+checksum = "fcfdefadc3d57ca21cf17990a28ef4c0f7c61383a28cb7604cf4a18e6ede1420"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
+checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
@@ -2638,9 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -2741,7 +2717,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log 0.4.8",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -2758,11 +2734,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
 ]
 
 [[package]]
@@ -2792,7 +2768,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
 ]
@@ -2809,11 +2785,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core 0.5.1",
 ]
 
@@ -2949,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2961,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "remove_dir_all"
@@ -3013,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a44d5ae8afcb238af8b75640907edc6c931efcfab2c854e81ed35fa080f84cd"
+checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
 dependencies = [
  "rustc-hex",
 ]
@@ -3119,21 +3095,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "safemem"
@@ -3143,9 +3108,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
+checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
@@ -3153,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
@@ -3201,23 +3166,24 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
+checksum = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
 dependencies = [
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+checksum = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
 dependencies = [
  "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3250,9 +3216,9 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -3568,12 +3534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
-name = "sourcefile"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,9 +3597,9 @@ checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -3696,12 +3656,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
 
@@ -3711,9 +3671,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -3722,9 +3682,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "unicode-xid 0.2.0",
 ]
 
@@ -3734,7 +3694,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4014289c3d2b8168880ae86633247e73712fcc579969aff0ca7c5dcd17456b82"
 dependencies = [
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
 ]
 
 [[package]]
@@ -3757,7 +3717,7 @@ version = "0.10.0"
 source = "git+https://github.com/crypto-com/tendermint-rs.git?rev=2aa9dcece9d5abf5b8f108fec61baaa5c83d5884#2aa9dcece9d5abf5b8f108fec61baaa5c83d5884"
 dependencies = [
  "bytes",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "failure",
  "hyper 0.10.16",
  "prost-amino",
@@ -3858,9 +3818,9 @@ version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -4147,7 +4107,7 @@ dependencies = [
  "chain-core",
  "enclave-protocol",
  "enclave-u-common",
- "env_logger 0.7.1",
+ "env_logger",
  "log 0.4.8",
  "parity-scale-codec",
  "secp256k1zkp",
@@ -4164,7 +4124,7 @@ dependencies = [
  "bit-vec 0.6.1",
  "cc",
  "chain-core",
- "chrono 0.4.10 (git+https://github.com/mesalock-linux/chrono-sgx)",
+ "chrono 0.4.10",
  "enclave-protocol",
  "enclave-t-common",
  "httparse",
@@ -4193,7 +4153,7 @@ dependencies = [
  "aesm-client",
  "enclave-protocol",
  "enclave-runner",
- "env_logger 0.7.1",
+ "env_logger",
  "futures 0.3.4",
  "log 0.4.8",
  "sgxs-loaders",
@@ -4377,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
 dependencies = [
  "bitflags",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
 ]
 
 [[package]]
@@ -4417,9 +4377,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4427,75 +4387,56 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
 dependencies = [
- "quote 1.0.2",
+ "quote 1.0.3",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
-
-[[package]]
-name = "wasm-bindgen-webidl"
-version = "0.2.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
-dependencies = [
- "anyhow",
- "heck",
- "log 0.4.8",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
- "wasm-bindgen-backend",
- "weedle",
-]
+checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
 
 [[package]]
 name = "web-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
 dependencies = [
- "anyhow",
  "js-sys",
- "sourcefile",
  "wasm-bindgen",
- "wasm-bindgen-webidl",
 ]
 
 [[package]]
@@ -4569,21 +4510,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "weedle"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "which"
-version = "2.0.1"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "failure",
  "libc",
 ]
 
@@ -4655,7 +4586,7 @@ version = "0.3.1"
 source = "git+https://github.com/mesalock-linux/yasna.rs-sgx#a7b9bf193c7335be62151c714eb3ca9cf91ab269"
 dependencies = [
  "bit-vec 0.6.1",
- "chrono 0.4.10 (git+https://github.com/mesalock-linux/chrono-sgx)",
+ "chrono 0.4.10",
  "num-bigint 0.2.5",
  "sgx_tstd",
 ]
@@ -4667,7 +4598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a563d10ead87e2d798e357d44f40f495ad70bcee4d5c0d3f77a5b1b7376645d9"
 dependencies = [
  "bit-vec 0.6.1",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "num-bigint 0.2.6",
 ]
 
@@ -4692,9 +4623,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "synstructure",
 ]
 
@@ -4726,7 +4657,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b69cd8a6484379ef04457ba1c00aaadad166c693b1b6a625b01bcc694b212b"
 dependencies = [
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11",
  "derive_builder",
  "fancy-regex",
  "itertools 0.8.2",

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -289,11 +289,7 @@ impl TransactionCommand {
                 to_file,
             } => {
                 let enckey = ask_seckey(None)?;
-                let mut from_file =
-                    File::open(from_file).chain(|| (ErrorKind::IoError, "Unable to open file"))?;
-                let mut tx_unsigned = String::new();
-                from_file
-                    .read_to_string(&mut tx_unsigned)
+                let tx_unsigned = std::fs::read_to_string(from_file)
                     .chain(|| (ErrorKind::IoError, "Unable to read from file"))?;
                 let unsigned = UnsignedTransferTransaction::from_str(&tx_unsigned)?;
                 let signed = wallet_client.sign_raw_transfer_tx(name, &enckey, unsigned)?;
@@ -311,10 +307,7 @@ impl TransactionCommand {
             }
             TransactionCommand::Broadcast { name, file } => {
                 let enckey = ask_seckey(None)?;
-                let mut file =
-                    File::open(file).chain(|| (ErrorKind::IoError, "Unable to open file"))?;
-                let mut tx_signed = String::new();
-                file.read_to_string(&mut tx_signed)
+                let tx_signed = std::fs::read_to_string(file)
                     .chain(|| (ErrorKind::IoError, "Unable to read from file"))?;
                 let signed = SignedTransferTransaction::from_str(&tx_signed)?;
                 let tx_id = wallet_client.broadcast_signed_transfer_tx(name, &enckey, signed)?;

--- a/client-cli/src/command/wallet_command.rs
+++ b/client-cli/src/command/wallet_command.rs
@@ -10,7 +10,7 @@ use crate::{ask_passphrase, ask_seckey};
 use client_core::service::WalletInfo;
 use client_core::wallet::WalletRequest;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 const WALLET_KIND_VARIANTS: [&str; 3] = ["basic", "hd", "hw"];
@@ -199,10 +199,7 @@ impl WalletCommand {
                 }
             }
             (None, Some(from_file)) => {
-                let mut file =
-                    File::open(from_file).chain(|| (ErrorKind::IoError, "Unable to open file"))?;
-                let mut settings: String = String::new();
-                file.read_to_string(&mut settings)
+                let settings = std::fs::read_to_string(from_file)
                     .chain(|| (ErrorKind::IoError, "Unable to read from file"))?;
                 let wallet_requests: Vec<WalletRequest> = serde_json::from_str(&settings)
                     .chain(|| (ErrorKind::InvalidInput, "Invalid wallet info"))?;
@@ -256,10 +253,9 @@ impl WalletCommand {
     }
 
     fn import<T: WalletClient>(wallet_client: T, file: &PathBuf) -> Result<()> {
-        let mut file = File::open(file).chain(|| (ErrorKind::IoError, "Unable to open file"))?;
-        let mut wallet_info_str = String::new();
-        file.read_to_string(&mut wallet_info_str)
+        let wallet_info_str = std::fs::read_to_string(file)
             .chain(|| (ErrorKind::IoError, "Unable to read from file"))?;
+
         let wallet_info_list: Vec<WalletInfo> = serde_json::from_str(&wallet_info_str)
             .chain(|| (ErrorKind::InvalidInput, "Invalid wallet info list"))?;
         for wallet_info in wallet_info_list {

--- a/client-core/src/service.rs
+++ b/client-core/src/service.rs
@@ -23,7 +23,7 @@ pub use self::root_hash_service::RootHashService;
 pub use self::sync_state_service::{
     delete_sync_state, load_sync_state, save_sync_state, SyncState, SyncStateService,
 };
-pub use self::wallet_service::{load_wallet, save_wallet, Wallet, WalletInfo, WalletService};
+pub use self::wallet_service::{load_wallet, Wallet, WalletInfo, WalletService};
 pub use self::wallet_state_service::{
     delete_wallet_state, load_wallet_state, modify_wallet_state, save_wallet_state, WalletState,
     WalletStateService,

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -2,6 +2,7 @@ use indexmap::IndexSet;
 use parity_scale_codec::{Decode, Encode, Input, Output};
 
 use crate::service::{load_wallet_state, WalletState};
+use crate::types::WalletKind;
 use chain_core::common::H256;
 use chain_core::init::address::RedeemAddress;
 use chain_core::state::account::StakedStateAddress;
@@ -9,17 +10,50 @@ use chain_core::tx::data::address::ExtendedAddr;
 use client_common::{
     Error, ErrorKind, PrivateKey, PublicKey, Result, ResultExt, SecKey, SecureStorage, Storage,
 };
-use std::fmt;
-//use serde::ser::{Serialize, SerializeStruct, Serializer};
-use crate::types::WalletKind;
-use parity_scale_codec::alloc::collections::BTreeMap;
 use secstr::SecUtf8;
 use serde::de::{self, Visitor};
 use serde::export::PhantomData;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
+use std::fmt;
+use std::str;
 /// Key space of wallet
 const KEYSPACE: &str = "core_wallet";
+
+fn get_public_keyspace(name: &str) -> String {
+    format!("{}_{}_publickey", KEYSPACE, name)
+}
+
+fn get_stakingkey_keyspace(name: &str) -> String {
+    format!("{}_{}_stakingkey", KEYSPACE, name)
+}
+
+fn get_stakingkeyset_keyspace(name: &str) -> String {
+    format!("{}_{}_stakingkeyset", KEYSPACE, name)
+}
+
+fn get_private_keyspace(name: &str) -> String {
+    format!("{}_{}_privatekey", KEYSPACE, name)
+}
+
+fn get_roothash_keyspace(name: &str) -> String {
+    format!("{}_{}_roothash", KEYSPACE, name)
+}
+
+fn get_roothashset_keyspace(name: &str) -> String {
+    format!("{}_{}_roothashset", KEYSPACE, name)
+}
+
+pub fn get_multisig_keyspace(name: &str) -> String {
+    format!("{}_{}_multisigaddress", KEYSPACE, name)
+}
+
+fn get_info_keyspace(name: &str) -> String {
+    format!("{}_{}_info", KEYSPACE, name)
+}
+
+fn get_wallet_keyspace() -> String {
+    format!("{}_walletname", KEYSPACE)
+}
 
 fn serde_to_str<T, S>(value: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
@@ -75,17 +109,14 @@ pub struct WalletInfo {
 }
 
 /// Wallet meta data
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Wallet {
     /// view key to decrypt enclave transactions
     pub view_key: PublicKey,
-    /// public key and private key pair
-    pub key_pairs: BTreeMap<PublicKey, PrivateKey>,
-    /// public keys to construct transfer addresses
-    pub public_keys: IndexSet<PublicKey>,
     /// public keys of staking addresses
     pub staking_keys: IndexSet<PublicKey>,
     /// root hashes of multi-sig transfer addresses
+    // this is transfer address
     pub root_hashes: IndexSet<H256>,
     /// wallet type
     pub wallet_kind: WalletKind,
@@ -94,63 +125,20 @@ pub struct Wallet {
 impl Encode for Wallet {
     fn encode_to<W: Output>(&self, dest: &mut W) {
         self.view_key.encode_to(dest);
-        (self.key_pairs.len() as u64).encode_to(dest);
-        for (key, value) in self.key_pairs.iter() {
-            key.encode_to(dest);
-            value.encode_to(dest);
-        }
-        (self.public_keys.len() as u64).encode_to(dest);
-        for key in self.public_keys.iter() {
-            key.encode_to(dest);
-        }
-        (self.staking_keys.len() as u64).encode_to(dest);
-        for key in self.staking_keys.iter() {
-            key.encode_to(dest);
-        }
-        (self.root_hashes.len() as u64).encode_to(dest);
-        for hash in self.root_hashes.iter() {
-            hash.encode_to(dest);
-        }
-        self.wallet_kind.encode_to(dest);
     }
 }
 
 impl Decode for Wallet {
     fn decode<I: Input>(input: &mut I) -> std::result::Result<Self, parity_scale_codec::Error> {
         let view_key = PublicKey::decode(input)?;
-        let mut key_pairs = BTreeMap::new();
-        let len = u64::decode(input)?;
-        for _ in 0..len {
-            let key = PublicKey::decode(input)?;
-            let value = PrivateKey::decode(input)?;
-            key_pairs.insert(key, value);
-        }
-        let len = u64::decode(input)?;
-        let mut public_keys = IndexSet::with_capacity(len as usize);
-        for _ in 0..len {
-            public_keys.insert(PublicKey::decode(input)?);
-        }
-
-        let len = u64::decode(input)?;
-        let mut staking_keys = IndexSet::with_capacity(len as usize);
-        for _ in 0..len {
-            staking_keys.insert(PublicKey::decode(input)?);
-        }
-
-        let len = u64::decode(input)?;
-        let mut root_hashes = IndexSet::with_capacity(len as usize);
-        for _ in 0..len {
-            root_hashes.insert(H256::decode(input)?);
-        }
-        let wallet_kind = WalletKind::decode(input)?;
+        let staking_keys = IndexSet::new();
+        let root_hashes = IndexSet::new();
 
         Ok(Wallet {
             view_key,
-            key_pairs,
-            public_keys,
             staking_keys,
             root_hashes,
-            wallet_kind,
+            wallet_kind: WalletKind::HD,
         })
     }
 }
@@ -160,8 +148,6 @@ impl Wallet {
     pub fn new(view_key: PublicKey, wallet_kind: WalletKind) -> Self {
         Self {
             view_key,
-            key_pairs: Default::default(),
-            public_keys: Default::default(),
             staking_keys: Default::default(),
             root_hashes: Default::default(),
             wallet_kind,
@@ -184,33 +170,100 @@ impl Wallet {
             .map(ExtendedAddr::OrTree)
             .collect()
     }
+}
 
-    /// find staking key
-    pub fn find_staking_key(&self, redeem_address: &RedeemAddress) -> Option<&PublicKey> {
-        self.staking_keys
-            .iter()
-            .find(|staking_key| &RedeemAddress::from(*staking_key) == redeem_address)
+fn read_pubkey<S: SecureStorage>(storage: &S, keyspace: &str, key: &str) -> Result<PublicKey> {
+    let value = storage.get(keyspace, key)?;
+    if let Some(raw_value) = value {
+        let pubkey = PublicKey::deserialize_from(&raw_value)?;
+        Ok(pubkey)
+    } else {
+        Err(Error::new(ErrorKind::InvalidInput, "read pubkey error"))
+    }
+}
+
+fn write_pubkey<S: SecureStorage>(
+    storage: &S,
+    keyspace: &str,
+    key: &str,
+    value: &PublicKey,
+) -> Result<()> {
+    storage.set(keyspace, key, value.serialize())?;
+    Ok(())
+}
+
+fn read_pubkey_enc<S: SecureStorage>(
+    storage: &S,
+    keyspace: &str,
+    key: &str,
+    enckey: &SecKey,
+) -> Result<PublicKey> {
+    let value = storage.get_secure(keyspace, key, enckey)?;
+    if let Some(raw_value) = value {
+        let pubkey = PublicKey::deserialize_from(&raw_value)?;
+        Ok(pubkey)
+    } else {
+        Err(Error::new(ErrorKind::InvalidInput, "read pubkey error"))
+    }
+}
+
+fn write_pubkey_enc<S: SecureStorage>(
+    storage: &S,
+    keyspace: &str,
+    key: &str,
+    value: &PublicKey,
+    enckey: &SecKey,
+) -> Result<()> {
+    storage.set_secure(keyspace, key, value.serialize(), enckey)?;
+    Ok(())
+}
+
+fn read_string<S: SecureStorage>(storage: &S, keyspace: &str, key: &str) -> Result<String> {
+    let value = storage.get(keyspace, key.as_bytes())?;
+    if let Some(raw_value) = value {
+        let ret = str::from_utf8(&raw_value).chain(|| {
+            (
+                ErrorKind::InvalidInput,
+                "Unable to read string in wallet_service",
+            )
+        })?;
+        Ok(ret.to_string())
+    } else {
+        Err(Error::new(ErrorKind::InvalidInput, "read string error"))
+    }
+}
+
+fn read_number<S: SecureStorage>(
+    storage: &S,
+    keyspace: &str,
+    key: &str,
+    defaut_value: Option<u64>,
+) -> Result<u64> {
+    let value = storage.get(keyspace, key.as_bytes())?;
+    if let Some(raw_value) = value {
+        let mut v: [u8; 8] = [0; 8];
+        v.copy_from_slice(&raw_value);
+        let index_value: u64 = u64::from_le_bytes(v);
+        return Ok(index_value);
     }
 
-    /// find private key
-    pub fn find_private_key(&self, public_key: &PublicKey) -> Option<&PrivateKey> {
-        self.key_pairs.get(public_key)
+    if let Some(value) = defaut_value {
+        Ok(value)
+    } else {
+        Err(Error::new(ErrorKind::InvalidInput, "read number error"))
     }
+}
 
-    /// add key pair
-    pub fn add_key_pair(&mut self, public_key: &PublicKey, private_key: &PrivateKey) {
-        self.key_pairs
-            .insert(public_key.clone(), private_key.clone());
-    }
-
-    /// find root hash
-    pub fn find_root_hash(&self, address: &ExtendedAddr) -> Option<&H256> {
-        match address {
-            ExtendedAddr::OrTree(ref root_hash) => {
-                self.root_hashes.iter().find(|hash| hash == &root_hash)
-            }
-        }
-    }
+fn write_number<S: SecureStorage>(
+    storage: &S,
+    keyspace: &str,
+    key: &str,
+    value: u64,
+) -> Result<()> {
+    storage
+        .set(keyspace, key.as_bytes(), value.to_le_bytes().to_vec())
+        .expect("write storage");
+    Ok(())
 }
 
 /// Load wallet from storage
@@ -219,17 +272,43 @@ pub fn load_wallet<S: SecureStorage>(
     name: &str,
     enckey: &SecKey,
 ) -> Result<Option<Wallet>> {
-    storage.load_secure(KEYSPACE, name, enckey)
-}
+    let wallet: Option<Wallet> = storage.load_secure(KEYSPACE, name, enckey)?;
 
-/// Save wallet to storage
-pub fn save_wallet<S: SecureStorage>(
-    storage: &S,
-    name: &str,
-    enckey: &SecKey,
-    wallet: &Wallet,
-) -> Result<()> {
-    storage.save_secure(KEYSPACE, name, enckey, wallet)
+    if let Some(value) = wallet {
+        let mut new_wallet = value;
+        // storage -> wallet
+        let info_keyspace = get_info_keyspace(name);
+        new_wallet.view_key = read_pubkey_enc(storage, &info_keyspace, "viewkey", enckey)?;
+        // pubkey
+        let info_keyspace = format!("{}_{}_info", KEYSPACE, name);
+        let staking_keyspace = get_stakingkey_keyspace(name);
+        let stakingkey_count: u64 =
+            read_number(storage, &info_keyspace, "stakingkeyindex", Some(0))?;
+        for i in 0..stakingkey_count {
+            let stakingkey = read_pubkey(storage, &staking_keyspace, &format!("{}", i))?;
+            new_wallet.staking_keys.insert(stakingkey);
+        }
+
+        // roothash
+        let roothash_keyspace = get_roothash_keyspace(name);
+        let roothash_count: u64 = read_number(storage, &info_keyspace, "roothashindex", Some(0))?;
+        for i in 0..roothash_count {
+            let value = storage.get(&roothash_keyspace, format!("{}", i))?;
+            if let Some(raw_value) = value {
+                let mut roothash_found: H256 = H256::default();
+                roothash_found.copy_from_slice(&raw_value);
+                new_wallet.root_hashes.insert(roothash_found);
+            }
+        }
+
+        // load walletkind
+        let walletkind: u64 = read_number(storage, &info_keyspace, "walletkind", Some(0))?;
+        new_wallet.wallet_kind = walletkind.into();
+
+        return Ok(Some(new_wallet));
+    }
+
+    Ok(None)
 }
 /// Maintains mapping `wallet-name -> wallet-details`
 #[derive(Debug, Default, Clone)]
@@ -254,28 +333,74 @@ where
     }
 
     /// Get the wallet state from storage
+    // storage -> wallet
     pub fn get_wallet_state(&self, name: &str, enckey: &SecKey) -> Result<WalletState> {
         load_wallet_state(&self.storage, name, enckey)?.err_kind(ErrorKind::InvalidInput, || {
             format!("WalletState with name ({}) not found", name)
         })
     }
 
+    /// Save wallet to storage
+    pub fn save_wallet(&self, name: &str, enckey: &SecKey, wallet: &Wallet) -> Result<()> {
+        self.storage.save_secure(KEYSPACE, name, enckey, wallet)?;
+
+        let info_keyspace = get_info_keyspace(name);
+        // write viewkey
+        write_pubkey_enc(
+            &self.storage,
+            &info_keyspace,
+            "viewkey",
+            &wallet.view_key,
+            enckey,
+        )?;
+
+        // stakingkey
+        write_number(
+            &self.storage,
+            &info_keyspace,
+            "walletkind",
+            wallet.wallet_kind as u64,
+        )?;
+        write_number(&self.storage, &info_keyspace, "publicindex", 0)?;
+        write_number(&self.storage, &info_keyspace, "stakingkeyindex", 0)?;
+        for public_key in wallet.staking_keys.iter() {
+            self.add_staking_key(name, enckey, public_key)?;
+        }
+
+        // root hash
+        write_number(&self.storage, &info_keyspace, "roothashindex", 0)?;
+        for root_hash in wallet.root_hashes.iter() {
+            self.add_root_hash(name, enckey, root_hash.clone())?;
+        }
+
+        Ok(())
+    }
+
     /// Store the wallet to storage
+    // wallet -> storage
     pub fn set_wallet(&self, name: &str, enckey: &SecKey, wallet: Wallet) -> Result<()> {
-        save_wallet(&self.storage, name, enckey, &wallet)
+        self.save_wallet(name, enckey, &wallet)
     }
 
     /// Finds staking key corresponding to given redeem address
+    // TODO: change api not to use _enckey
     pub fn find_staking_key(
         &self,
         name: &str,
-        enckey: &SecKey,
+        _enckey: &SecKey,
         redeem_address: &RedeemAddress,
     ) -> Result<Option<PublicKey>> {
-        Ok(self
-            .get_wallet(name, enckey)?
-            .find_staking_key(redeem_address)
-            .cloned())
+        let stakingkey_keyspace = get_stakingkeyset_keyspace(name);
+
+        if let Ok(value) = read_pubkey(
+            &self.storage,
+            &stakingkey_keyspace,
+            &redeem_address.to_string(),
+        ) {
+            Ok(Some(value))
+        } else {
+            Err(Error::new(ErrorKind::InvalidInput, "finding staking"))
+        }
     }
 
     /// Finds private_key corresponding to given public_key
@@ -285,22 +410,48 @@ where
         enckey: &SecKey,
         public_key: &PublicKey,
     ) -> Result<Option<PrivateKey>> {
-        let wallet = self.get_wallet(name, enckey)?;
-        let private_key = wallet.find_private_key(public_key).cloned();
-        Ok(private_key)
+        let private_keyspace = get_private_keyspace(name);
+
+        // key: public_key
+        // value: private_key
+        let value = self
+            .storage
+            .get_secure(private_keyspace, public_key.serialize(), enckey)?;
+        if let Some(raw_value) = value {
+            let privatekey = PrivateKey::deserialize_from(&raw_value)?;
+            Ok(Some(privatekey))
+        } else {
+            Err(Error::new(ErrorKind::InvalidInput, "private_key not found"))
+        }
     }
 
     /// Checks if root hash exists in current wallet and returns root hash if exists
+    // TODO: change api not to use _enckey
     pub fn find_root_hash(
         &self,
         name: &str,
-        enckey: &SecKey,
+        _enckey: &SecKey,
         address: &ExtendedAddr,
     ) -> Result<Option<H256>> {
-        Ok(self
-            .get_wallet(name, enckey)?
-            .find_root_hash(address)
-            .copied())
+        match address {
+            ExtendedAddr::OrTree(ref root_hash) => {
+                // roothashset
+                let roothash_keyspace = get_roothashset_keyspace(name);
+
+                let value = self
+                    .storage
+                    .get(roothash_keyspace, hex::encode(&root_hash))?;
+
+                if let Some(raw_value) = value {
+                    let mut roothash_found: H256 = H256::default();
+                    roothash_found.copy_from_slice(&raw_value);
+
+                    return Ok(Some(roothash_found));
+                }
+            }
+        }
+
+        Err(Error::new(ErrorKind::InvalidInput, "private_key not found"))
     }
 
     /// Creates a new wallet and returns wallet ID
@@ -318,31 +469,72 @@ where
             ));
         }
 
-        self.set_wallet(name, enckey, Wallet::new(view_key, wallet_kind))
+        self.set_wallet(name, enckey, Wallet::new(view_key.clone(), wallet_kind))?;
+
+        let info_keyspace = get_info_keyspace(name);
+        // key: "viewkey"
+        // value: view-key
+        write_pubkey_enc(&self.storage, &info_keyspace, "viewkey", &view_key, enckey)?;
+
+        // key: index
+        // value: walletname
+        let wallet_keyspace = get_wallet_keyspace();
+        self.storage
+            .set(wallet_keyspace, name, name.as_bytes().to_vec())?;
+
+        Ok(())
     }
 
     /// Returns view key of wallet
     pub fn view_key(&self, name: &str, enckey: &SecKey) -> Result<PublicKey> {
-        let wallet = self.get_wallet(name, enckey)?;
-        Ok(wallet.view_key)
+        let _wallet_found = self.get_wallet(name, enckey)?;
+        let info_keyspace = get_info_keyspace(name);
+        read_pubkey_enc(&self.storage, &info_keyspace, "viewkey", enckey)
     }
 
     /// Returns all public keys stored in a wallet
     pub fn public_keys(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<PublicKey>> {
-        let wallet = self.get_wallet(name, enckey)?;
-        Ok(wallet.public_keys)
+        if !self.storage.contains_key(KEYSPACE, name)? {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Wallet with name ({}) not found", name),
+            ));
+        }
+
+        let _wallet_found = self.get_wallet(name, enckey)?;
+
+        let public_keyspace = get_public_keyspace(name);
+
+        let mut ret: IndexSet<PublicKey> = IndexSet::<PublicKey>::new();
+        let info_keyspace = get_info_keyspace(name);
+        let publickey_count: u64 = read_number(&self.storage, &info_keyspace, "publicindex", None)?;
+
+        for i in 0..publickey_count {
+            let pubkey = read_pubkey(&self.storage, &public_keyspace, &format!("{}", i))?;
+            ret.insert(pubkey);
+        }
+        Ok(ret)
     }
 
     /// Returns all public keys corresponding to staking addresses stored in a wallet
     pub fn staking_keys(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<PublicKey>> {
-        let wallet = self.get_wallet(name, enckey)?;
-        Ok(wallet.staking_keys)
-    }
-
-    /// Returns all multi-sig addresses stored in a wallet
-    pub fn root_hashes(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<H256>> {
-        let wallet = self.get_wallet(name, enckey)?;
-        Ok(wallet.root_hashes)
+        if !self.storage.contains_key(KEYSPACE, name)? {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Wallet with name ({}) not found", name),
+            ));
+        }
+        let _wallet_found = self.get_wallet(name, enckey)?;
+        let stakingkey_keyspace = get_stakingkey_keyspace(name);
+        let mut ret: IndexSet<PublicKey> = IndexSet::<PublicKey>::new();
+        let info_keyspace = get_info_keyspace(name);
+        let staking_count: u64 =
+            read_number(&self.storage, &info_keyspace, "stakingkeyindex", None)?;
+        for i in 0..staking_count {
+            let pubkey = read_pubkey(&self.storage, &stakingkey_keyspace, &format!("{}", i))?;
+            ret.insert(pubkey);
+        }
+        Ok(ret)
     }
 
     /// Returns all staking addresses stored in a wallet
@@ -351,7 +543,38 @@ where
         name: &str,
         enckey: &SecKey,
     ) -> Result<IndexSet<StakedStateAddress>> {
-        Ok(self.get_wallet(name, enckey)?.staking_addresses())
+        let pubkeys: IndexSet<PublicKey> = self.staking_keys(name, enckey)?;
+        let mut ret: IndexSet<StakedStateAddress> = IndexSet::<StakedStateAddress>::new();
+        for pubkey in &pubkeys {
+            let staked = StakedStateAddress::BasicRedeem(RedeemAddress::from(pubkey));
+            ret.insert(staked);
+        }
+        Ok(ret)
+    }
+
+    /// Returns all multi-sig addresses stored in a wallet
+    pub fn root_hashes(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<H256>> {
+        if !self.storage.contains_key(KEYSPACE, name)? {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Wallet with name ({}) not found", name),
+            ));
+        }
+        let _wallet_found = self.get_wallet(name, enckey)?;
+        let roothash_keyspace = get_roothash_keyspace(name);
+        let mut ret: IndexSet<H256> = IndexSet::<H256>::new();
+        let info_keyspace = get_info_keyspace(name);
+        let roothash_count: u64 =
+            read_number(&self.storage, &info_keyspace, "roothashindex", None)?;
+        for i in 0..roothash_count {
+            let value = self.storage.get(&roothash_keyspace, format!("{}", i))?;
+            if let Some(raw_value) = value {
+                let mut roothash_found: H256 = H256::default();
+                roothash_found.copy_from_slice(&raw_value);
+                ret.insert(roothash_found);
+            }
+        }
+        Ok(ret)
     }
 
     /// Returns all tree addresses stored in a wallet
@@ -360,7 +583,13 @@ where
         name: &str,
         enckey: &SecKey,
     ) -> Result<IndexSet<ExtendedAddr>> {
-        Ok(self.get_wallet(name, enckey)?.transfer_addresses())
+        let roothashes: IndexSet<H256> = self.root_hashes(name, enckey)?;
+        let mut ret: IndexSet<ExtendedAddr> = IndexSet::<ExtendedAddr>::new();
+        for roothash_found in &roothashes {
+            let extended_addr = ExtendedAddr::OrTree(*roothash_found);
+            ret.insert(extended_addr);
+        }
+        Ok(ret)
     }
 
     /// Adds a (public_key, private_key) pair to given wallet
@@ -371,94 +600,196 @@ where
         public_key: &PublicKey,
         private_key: &PrivateKey,
     ) -> Result<()> {
-        self.modify_wallet(name, enckey, move |wallet| {
-            wallet
-                .key_pairs
-                .insert(public_key.clone(), private_key.clone());
-        })
+        let private_keyspace = get_private_keyspace(name);
+
+        // key: public_key
+        // value: private_key
+        self.storage.set_secure(
+            private_keyspace,
+            public_key.serialize(),
+            private_key.serialize(),
+            enckey,
+        )?;
+        Ok(())
     }
 
     /// Adds a public key to given wallet
+    // TODO: change api not to use _enckey
     pub fn add_public_key(
         &self,
         name: &str,
-        enckey: &SecKey,
+        _enckey: &SecKey,
         public_key: &PublicKey,
     ) -> Result<()> {
-        self.modify_wallet(name, enckey, move |wallet| {
-            wallet.public_keys.insert(public_key.clone());
-        })
+        let public_keyspace = get_public_keyspace(name);
+        let info_keyspace = get_info_keyspace(name);
+
+        let mut index_value: u64 =
+            read_number(&self.storage, &info_keyspace, "publicindex", Some(0))?;
+
+        // key: index
+        // value: publickey
+        write_pubkey(
+            &self.storage,
+            &public_keyspace,
+            &format!("{}", index_value),
+            &public_key,
+        )?;
+
+        index_value += 1;
+        write_number(&self.storage, &info_keyspace, "publicindex", index_value)?;
+
+        Ok(())
     }
 
     /// Adds a public key corresponding to a staking address to given wallet
+    // TODO: change api not to use _enckey
     pub fn add_staking_key(
         &self,
         name: &str,
-        enckey: &SecKey,
+        _enckey: &SecKey,
         staking_key: &PublicKey,
     ) -> Result<()> {
-        self.modify_wallet(name, enckey, move |wallet| {
-            wallet.staking_keys.insert(staking_key.clone());
-        })
-    }
+        // stakingkey set
+        // key: redeem address (20 bytes)
+        // value: staking key (<-publickey)
+        let redeemaddress = RedeemAddress::from(staking_key).to_string();
+        let stakingkey_keyspace = get_stakingkey_keyspace(name);
+        let stakingkeyset_keyspace = get_stakingkeyset_keyspace(name);
+        let info_keyspace = get_info_keyspace(name);
 
-    fn modify_wallet<F>(&self, name: &str, enckey: &SecKey, f: F) -> Result<()>
-    where
-        F: Fn(&mut Wallet),
-    {
-        self.storage
-            .fetch_and_update_secure(KEYSPACE, name, enckey, move |value| {
-                let mut wallet_bytes = value.chain(|| {
-                    (
-                        ErrorKind::InvalidInput,
-                        format!("Wallet with name ({}) not found", name),
-                    )
-                })?;
-                let mut wallet = Wallet::decode(&mut wallet_bytes).chain(|| {
-                    (
-                        ErrorKind::DeserializationError,
-                        format!("Unable to deserialize wallet with name {}", name),
-                    )
-                })?;
-                f(&mut wallet);
-                Ok(Some(wallet.encode()))
-            })
-            .map(|_| ())
+        let mut index_value: u64 =
+            read_number(&self.storage, &info_keyspace, "stakingkeyindex", Some(0))?;
+
+        write_pubkey(
+            &self.storage,
+            &stakingkeyset_keyspace,
+            &redeemaddress,
+            &staking_key,
+        )?;
+
+        write_pubkey(
+            &self.storage,
+            &stakingkey_keyspace,
+            &format!("{}", index_value),
+            &staking_key,
+        )?;
+
+        // increase
+        index_value += 1;
+        write_number(
+            &self.storage,
+            &info_keyspace,
+            "stakingkeyindex",
+            index_value,
+        )?;
+
+        Ok(())
     }
 
     /// Adds a multi-sig address to given wallet
-    pub fn add_root_hash(&self, name: &str, enckey: &SecKey, root_hash: H256) -> Result<()> {
-        self.modify_wallet(name, enckey, move |wallet| {
-            wallet.root_hashes.insert(root_hash);
-        })
+    // TODO: change api not to use _enckey
+    pub fn add_root_hash(&self, name: &str, _enckey: &SecKey, root_hash: H256) -> Result<()> {
+        // roothashset
+        let roothash_keyspace = get_roothash_keyspace(name);
+        let roothashset_keyspace = get_roothashset_keyspace(name);
+        let info_keyspace = get_info_keyspace(name);
+
+        let mut index_value: u64 =
+            read_number(&self.storage, &info_keyspace, "roothashindex", Some(0))?;
+
+        // key: index
+        // value: roothash
+        self.storage.set(
+            &roothash_keyspace,
+            format!("{}", index_value),
+            root_hash.to_vec(),
+        )?;
+
+        // roothashset
+        self.storage.set(
+            &roothashset_keyspace,
+            hex::encode(&root_hash),
+            root_hash.to_vec(),
+        )?;
+
+        // increase
+        index_value += 1;
+        write_number(&self.storage, &info_keyspace, "roothashindex", index_value)?;
+
+        Ok(())
     }
 
     /// Retrieves names of all the stored wallets
     pub fn names(&self) -> Result<Vec<String>> {
-        let keys = self.storage.keys(KEYSPACE)?;
-
-        keys.into_iter()
-            .map(|bytes| {
-                String::from_utf8(bytes).chain(|| {
-                    (
-                        ErrorKind::DeserializationError,
-                        "Unable to deserialize wallet names in storage",
-                    )
-                })
-            })
-            .collect()
+        let wallet_keyspace = get_wallet_keyspace();
+        let keys = self.storage.keys(&wallet_keyspace)?;
+        let mut names: Vec<String> = vec![];
+        for key in keys {
+            let string_key = String::from_utf8(key).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to deserialize wallet names in storage",
+                )
+            })?;
+            let name_found = read_string(&self.storage, &wallet_keyspace, &string_key)?;
+            names.push(name_found);
+        }
+        Ok(names)
     }
 
     /// Clears all storage
     pub fn clear(&self) -> Result<()> {
-        self.storage.clear(KEYSPACE)
+        let wallet_keyspace = get_wallet_keyspace();
+        let keys = self.storage.keys(&wallet_keyspace)?;
+        for key in keys {
+            let string_key = String::from_utf8(key).chain(|| {
+                (
+                    ErrorKind::DeserializationError,
+                    "Unable to deserialize wallet names in storage",
+                )
+            })?;
+            let name_found = read_string(&self.storage, &wallet_keyspace, &string_key)?;
+
+            self.delete_wallet_keyspace(&name_found)?;
+        }
+        self.storage.clear(wallet_keyspace)?;
+        self.storage.clear(KEYSPACE)?;
+
+        Ok(())
     }
 
-    /// Delete the key
-    pub fn delete(&self, name: &str, enckey: &SecKey) -> Result<Wallet> {
-        let wallet = self.get_wallet(name, enckey)?;
+    fn delete_wallet_keyspace(&self, name: &str) -> Result<()> {
         self.storage.delete(KEYSPACE, name)?;
-        Ok(wallet)
+        assert!(self.storage.get(KEYSPACE, name)?.is_none());
+        let info_keyspace = get_info_keyspace(name);
+
+        let stakingkey_keyspace = get_stakingkey_keyspace(name);
+        let stakingkeyset_keyspace = get_stakingkeyset_keyspace(name);
+        let public_keyspace = get_public_keyspace(name);
+        let private_keyspace = get_private_keyspace(name);
+        let roothash_keyspace = get_roothash_keyspace(name);
+        let roothashset_keyspace = get_roothashset_keyspace(name);
+        let multisigaddress_keyspace = get_multisig_keyspace(name);
+        let wallet_keyspace = get_wallet_keyspace();
+        self.storage.delete(wallet_keyspace, name)?;
+        self.storage.clear(info_keyspace)?;
+        self.storage.clear(roothash_keyspace)?;
+        self.storage.clear(roothashset_keyspace)?;
+        self.storage.clear(stakingkey_keyspace)?;
+        self.storage.clear(stakingkeyset_keyspace)?;
+        self.storage.clear(public_keyspace)?;
+        self.storage.clear(private_keyspace)?;
+        self.storage.clear(multisigaddress_keyspace)?;
+        Ok(())
+    }
+    /// Delete the key
+    // TODO: change api not to use _enckey
+    pub fn delete(&self, name: &str, enckey: &SecKey) -> Result<Wallet> {
+        let wallet_found = self.get_wallet(name, enckey)?;
+        self.storage.delete(KEYSPACE, name)?;
+        self.delete_wallet_keyspace(name)?;
+        Ok(wallet_found)
     }
 }
 

--- a/client-core/src/types/wallet_type.rs
+++ b/client-core/src/types/wallet_type.rs
@@ -11,11 +11,21 @@ use client_common::{Error, ErrorKind, Result};
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub enum WalletKind {
     /// Basic Wallet
-    Basic,
+    Basic = 0,
     /// HD Wallet
     HD,
     /// HW Wallet
     HW,
+}
+
+impl From<u64> for WalletKind {
+    fn from(code: u64) -> Self {
+        match code {
+            0 => WalletKind::Basic,
+            1 => WalletKind::HD,
+            _ => WalletKind::HW,
+        }
+    }
 }
 
 impl FromStr for WalletKind {

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -388,12 +388,13 @@ where
 
     fn delete_wallet(&self, name: &str, passphrase: &SecUtf8) -> Result<()> {
         // remove from wallet/sync_state/wallet_state/key_service
+
         let enckey = derive_enckey(passphrase, name).err_kind(ErrorKind::InvalidInput, || {
             "unable to derive encryption key from passphrase"
         })?;
 
         // the passphrase is verified here.
-        let wallet = self.wallet_service.delete(name, &enckey)?;
+        self.wallet_service.delete(name, &enckey)?;
         self.sync_state_service.delete_global_state(name)?;
         self.wallet_state_service
             .delete_wallet_state(name, &enckey)?;
@@ -402,10 +403,6 @@ where
         }
         self.key_service.delete_wallet_private_key(name, &enckey)?;
 
-        for root_hash in wallet.root_hashes.iter() {
-            self.root_hash_service
-                .delete_root_hash(name, root_hash, &enckey)?;
-        }
         Ok(())
     }
 

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -40,6 +40,9 @@ pub trait WalletRpc: Send + Sync {
     #[rpc(name = "wallet_createStakingAddress")]
     fn create_staking_address(&self, request: WalletRequest) -> Result<String>;
 
+    #[rpc(name = "wallet_createStakingAddressBatch")]
+    fn create_staking_address_batch(&self, request: WalletRequest, count: u32) -> Result<u32>;
+
     #[rpc(name = "wallet_createWatchStakingAddress")]
     fn create_watch_staking_address(
         &self,
@@ -49,6 +52,9 @@ pub trait WalletRpc: Send + Sync {
 
     #[rpc(name = "wallet_createTransferAddress")]
     fn create_transfer_address(&self, request: WalletRequest) -> Result<String>;
+
+    #[rpc(name = "wallet_createTransferAddressBatch")]
+    fn create_transfer_address_batch(&self, request: WalletRequest, count: u32) -> Result<u32>;
 
     #[rpc(name = "wallet_createWatchTransferAddress")]
     fn create_watch_transfer_address(
@@ -222,6 +228,15 @@ where
             .map(|staked_state_addr| staked_state_addr.to_string())
             .map_err(to_rpc_error)
     }
+    fn create_staking_address_batch(&self, request: WalletRequest, count: u32) -> Result<u32> {
+        for _i in 0..count {
+            self.client
+                .new_staking_address(&request.name, &request.enckey)
+                .map(|staked_state_addr| staked_state_addr.to_string())
+                .map_err(to_rpc_error)?;
+        }
+        Ok(count)
+    }
 
     fn create_watch_staking_address(
         &self,
@@ -241,6 +256,15 @@ where
             .map_err(to_rpc_error)?;
 
         Ok(extended_address.to_string())
+    }
+
+    fn create_transfer_address_batch(&self, request: WalletRequest, count: u32) -> Result<u32> {
+        for _i in 0..count {
+            self.client
+                .new_transfer_address(&request.name, &request.enckey)
+                .map_err(to_rpc_error)?;
+        }
+        Ok(count)
     }
 
     fn create_watch_transfer_address(

--- a/integration-tests/multinode/multitx_test.py
+++ b/integration-tests/multinode/multitx_test.py
@@ -29,11 +29,14 @@ wait_for_validators(rpc, 2)
 os.environ['ENCKEY'] = rpc.wallet.enckey()
 
 print('Prepare node0 transfer addresses')
+
+enckey = rpc.wallet.enckey()
 unbonded = rpc.address.list()[1]
 transfer1 = rpc.address.list(type='transfer')[0]
 
+
 time.sleep(3)  # wait for at least one block, FIXME remove after #828 fixed
-txid = rpc.staking.withdraw_all_unbonded(unbonded, transfer1)
+txid = rpc.staking.withdraw_all_unbonded(unbonded, transfer1, enckey=enckey)
 wait_for_tx(rpc, txid)
 rpc.wallet.sync()
 


### PR DESCRIPTION
Solution: make wallet to use storage directly
1. Root cause of the problem:
wallet is encoded, decoded, to one key, value.
a few address are ok, but addresses are about 1,000,000,

also if wallet is very big, it's also encoded, decoded, that time linearly increases with address increases.

it's O(n) , became very slow
now it's O(log(n))

also, for finding roothash, publickey,
it was O(n), now, it utilize keyvalue get ,
became, O(log(n))

2.What solutions did you consider to solve the root cause?
now, it's O(log(n)), and wallet is written to db directly.

3. What is the chosen solution?
publickey, stakingkey, roothases are flattened to key,value with different keyspace.

4.New benchmarks for generaton 1,0000,000 utxo addresses
999994
999995
999996
999997
999998
999999
1000000

real	82m2.542s
user	51m53.714s
sys	1m47.806s

key generation and write to db time is constant)
time = 334.744µs
time = 323.544µs
time = 321.788µs
costs are from http restful api processing cost,
so, i'll add batch generation,too.
if then, time can be done with 10 minutes for generating 1,000,000 utxo addresses

with batch) for generation 1,000,000 addresses by 50000 batch,
as original issue stated , batch made even faster for generating addresses

result 750000 50000
result 800000 50000
result 850000 50000
result 900000 50000
result 950000 50000
result 1000000 50000

real	3m43.747s
user	0m0.172s
sys	0m0.01

size benchmark) for 1,000,000 addresses
about 30 GB -> 1.9 GB for .storage