### PR TITLE
Problem (Fix #1282): chain-abci may crash with unititialized mempool storage

### DIFF
--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -506,6 +506,7 @@ impl<T: EnclaveProxy> ChainNodeApp<T> {
             flush_storage(&mut self.storage, mem::take(&mut self.kv_buffer))
                 .expect("storage io error");
             self.last_state = Some(genesis_state);
+            self.mempool_state = self.last_state.clone();
 
             ResponseInitChain::new()
         } else {


### PR DESCRIPTION
Solution:
- Initialize mempool_state in init chain event.