### PR TITLE
Problem:(cro-1223) TxoIndex is misused to refer to output size #1223

### DIFF
--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -5,7 +5,7 @@ use crate::enclave_bridge::EnclaveProxy;
 use abci::*;
 use chain_core::common::MerkleTree;
 use chain_core::compute_app_hash;
-use chain_core::tx::data::input::{TxoIndex, TxoPointer};
+use chain_core::tx::data::input::{TxoPointer, TxoSize};
 use chain_core::tx::data::TxId;
 use chain_core::tx::{TxAux, TxEnclaveAux, TxPublicAux};
 use chain_storage::buffer::{flush_staking_storage, flush_storage, StoreKV};
@@ -15,7 +15,7 @@ use parity_scale_codec::Encode;
 /// in the TX_META storage and it will create a new entry for TX in TX_META with all outputs marked as unspent.
 fn update_utxos_commit(
     inputs: &[TxoPointer],
-    no_of_outputs: TxoIndex,
+    no_of_outputs: TxoSize,
     txid: TxId,
     db: &mut impl StoreKV,
 ) {

--- a/chain-abci/src/enclave_bridge/mock.rs
+++ b/chain-abci/src/enclave_bridge/mock.rs
@@ -6,7 +6,7 @@ use chain_core::state::account::DepositBondTx;
 #[cfg(feature = "mock-enc-dec")]
 use chain_core::state::tendermint::BlockHeight;
 #[cfg(feature = "mock-enc-dec")]
-use chain_core::tx::data::input::TxoIndex;
+use chain_core::tx::data::input::TxoSize;
 use chain_core::tx::PlainTxAux;
 #[cfg(feature = "mock-enc-dec")]
 use chain_core::tx::TransactionId;
@@ -58,7 +58,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                     let mock = EncryptionResponse {
                         resp: Ok(TxEnclaveAux::TransferTx {
                             inputs: tx.inputs.clone(),
-                            no_of_outputs: tx.outputs.len() as TxoIndex,
+                            no_of_outputs: tx.outputs.len() as TxoSize,
                             payload: TxObfuscated {
                                 key_from: BlockHeight::genesis(),
                                 txid: tx.id(),
@@ -88,7 +88,7 @@ pub fn handle_enc_dec(_req: &RequestQuery, resp: &mut ResponseQuery, storage: &S
                     let plain = PlainTxAux::WithdrawUnbondedStakeTx(tx.clone());
                     let mock = EncryptionResponse {
                         resp: Ok(TxEnclaveAux::WithdrawUnbondedStakeTx {
-                            no_of_outputs: tx.outputs.len() as TxoIndex,
+                            no_of_outputs: tx.outputs.len() as TxoSize,
                             witness,
                             payload: TxObfuscated {
                                 key_from: BlockHeight::genesis(),

--- a/chain-abci/src/enclave_bridge/real/test/seal.rs
+++ b/chain-abci/src/enclave_bridge/real/test/seal.rs
@@ -16,7 +16,7 @@ use chain_core::tx::{
         access::{TxAccess, TxAccessPolicy},
         address::ExtendedAddr,
         attribute::TxAttributes,
-        input::{TxoIndex, TxoPointer},
+        input::{TxoPointer, TxoSize},
         output::TxOut,
         Tx, TxId,
     },
@@ -144,7 +144,7 @@ pub fn test_sealing() {
     let witness0 = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &txid, &secret_key));
     let account = get_account(&addr);
     let withdrawtx = TxEnclaveAux::WithdrawUnbondedStakeTx {
-        no_of_outputs: tx0.outputs.len() as TxoIndex,
+        no_of_outputs: tx0.outputs.len() as TxoSize,
         witness: witness0.clone(),
         payload: encrypt(
             enclave.geteid(),
@@ -202,7 +202,7 @@ pub fn test_sealing() {
     .into();
     let transfertx = TxEnclaveAux::TransferTx {
         inputs: tx1.inputs.clone(),
-        no_of_outputs: tx1.outputs.len() as TxoIndex,
+        no_of_outputs: tx1.outputs.len() as TxoSize,
         payload: encrypt(
             enclave.geteid(),
             EncryptionRequest::TransferTx(tx1, witness1),
@@ -235,7 +235,7 @@ pub fn test_sealing() {
     .into();
     let transfertx2 = TxEnclaveAux::TransferTx {
         inputs: tx2.inputs.clone(),
-        no_of_outputs: tx2.outputs.len() as TxoIndex,
+        no_of_outputs: tx2.outputs.len() as TxoSize,
         payload: encrypt(
             enclave.geteid(),
             EncryptionRequest::TransferTx(tx2, witness2),

--- a/chain-abci/src/storage/mod.rs
+++ b/chain-abci/src/storage/mod.rs
@@ -1,7 +1,7 @@
 use crate::enclave_bridge::EnclaveProxy;
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{StakedState, StakedStateAddress};
-use chain_core::tx::data::input::{TxoIndex, TxoPointer};
+use chain_core::tx::data::input::{TxoPointer, TxoSize};
 use chain_core::tx::fee::Fee;
 use chain_core::tx::{TransactionId, TxEnclaveAux, TxObfuscated, TxPublicAux};
 use chain_storage::account::{
@@ -24,7 +24,7 @@ pub enum TxEnclaveAction {
     Transfer {
         fee: Fee,
         spend_utxo: Vec<TxoPointer>,
-        create_utxo: TxoIndex,
+        create_utxo: TxoSize,
         sealed_log: SealedLog,
     },
     Deposit {
@@ -35,7 +35,7 @@ pub enum TxEnclaveAction {
     Withdraw {
         fee: Fee,
         withdraw: (StakedStateAddress, Coin),
-        create_utxo: TxoIndex,
+        create_utxo: TxoSize,
         sealed_log: SealedLog,
     },
 }
@@ -44,7 +44,7 @@ impl TxEnclaveAction {
     fn transfer(
         fee: Fee,
         spend_utxo: Vec<TxoPointer>,
-        create_utxo: TxoIndex,
+        create_utxo: TxoSize,
         sealed_log: SealedLog,
     ) -> Self {
         Self::Transfer {
@@ -63,7 +63,7 @@ impl TxEnclaveAction {
     }
     fn withdraw(
         fee: Fee,
-        create_utxo: TxoIndex,
+        create_utxo: TxoSize,
         sealed_log: SealedLog,
         withdraw: (StakedStateAddress, Coin),
     ) -> Self {

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -33,7 +33,7 @@ use chain_core::tx::{
         access::{TxAccess, TxAccessPolicy},
         address::ExtendedAddr,
         attribute::TxAttributes,
-        input::{TxoIndex, TxoPointer},
+        input::{TxoPointer, TxoSize},
         output::TxOut,
         txid_hash, Tx, TxId,
     },
@@ -445,7 +445,7 @@ fn prepare_app_valid_tx() -> (ChainNodeApp<MockClient>, TxAux, WithdrawUnbondedT
     let witness = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &tx.id(), &secret_key));
     // TODO: mock enc
     let txaux = TxAux::EnclaveTx(TxEnclaveAux::WithdrawUnbondedStakeTx {
-        no_of_outputs: tx.outputs.len() as TxoIndex,
+        no_of_outputs: tx.outputs.len() as TxoSize,
         witness: witness.clone(),
         payload: TxObfuscated {
             txid: tx.id(),
@@ -820,7 +820,7 @@ fn all_valid_tx_types_should_commit() {
     let txid = &tx0.id();
     let witness0 = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &txid, &secret_key));
     let withdrawtx = TxAux::EnclaveTx(TxEnclaveAux::WithdrawUnbondedStakeTx {
-        no_of_outputs: tx0.outputs.len() as TxoIndex,
+        no_of_outputs: tx0.outputs.len() as TxoSize,
         witness: witness0,
         payload: TxObfuscated {
             txid: tx0.id(),
@@ -859,7 +859,7 @@ fn all_valid_tx_types_should_commit() {
     let plain_txaux = PlainTxAux::TransferTx(tx1.clone(), witness1);
     let transfertx = TxAux::EnclaveTx(TxEnclaveAux::TransferTx {
         inputs: tx1.inputs.clone(),
-        no_of_outputs: tx1.outputs.len() as TxoIndex,
+        no_of_outputs: tx1.outputs.len() as TxoSize,
         payload: TxObfuscated {
             txid: tx1.id(),
             key_from: BlockHeight::genesis(),

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -21,7 +21,7 @@ use chain_core::state::validator::NodeJoinRequestTx;
 use chain_core::tx::data::{
     address::ExtendedAddr,
     attribute::TxAttributes,
-    input::{TxoIndex, TxoPointer},
+    input::{TxoPointer, TxoSize},
     output::TxOut,
 };
 use chain_core::tx::data::{Tx, TxId};
@@ -236,7 +236,7 @@ fn prepare_app_valid_transfer_tx(
     // TODO: mock enc
     let txaux = TxEnclaveAux::TransferTx {
         inputs: tx.inputs.clone(),
-        no_of_outputs: tx.outputs.len() as TxoIndex,
+        no_of_outputs: tx.outputs.len() as TxoSize,
         payload: TxObfuscated {
             txid: tx.id(),
             key_from: BlockHeight::genesis(),
@@ -435,7 +435,7 @@ fn prepare_app_valid_withdraw_tx(
     let witness = get_account_op_witness(secp, &tx.id(), &secret_key);
     // TODO: mock enc
     let txaux = TxEnclaveAux::WithdrawUnbondedStakeTx {
-        no_of_outputs: tx.outputs.len() as TxoIndex,
+        no_of_outputs: tx.outputs.len() as TxoSize,
         witness: witness.clone(),
         payload: TxObfuscated {
             txid: tx.id(),
@@ -1006,7 +1006,7 @@ fn replace_tx_payload(
             PlainTxAux::TransferTx(tx, _),
         ) => TxEnclaveAux::TransferTx {
             inputs: tx.inputs.clone(),
-            no_of_outputs: tx.outputs.len() as TxoIndex,
+            no_of_outputs: tx.outputs.len() as TxoSize,
             payload: TxObfuscated {
                 txid: tx.id(),
                 key_from,
@@ -1047,7 +1047,7 @@ fn replace_tx_payload(
             },
             PlainTxAux::WithdrawUnbondedStakeTx(tx),
         ) => TxEnclaveAux::WithdrawUnbondedStakeTx {
-            no_of_outputs: tx.outputs.len() as TxoIndex,
+            no_of_outputs: tx.outputs.len() as TxoSize,
             witness: if let Some(w) = mwitness { w } else { witness },
             payload: TxObfuscated {
                 txid: tx.id(),
@@ -1439,7 +1439,7 @@ fn prepare_withdraw_transaction(secret_key: &SecretKey) -> TxEnclaveAux {
     let witness = get_account_op_witness(secp, &tx.id(), secret_key);
 
     TxEnclaveAux::WithdrawUnbondedStakeTx {
-        no_of_outputs: tx.outputs.len() as TxoIndex,
+        no_of_outputs: tx.outputs.len() as TxoSize,
         witness: witness.clone(),
         payload: TxObfuscated {
             txid: tx.id(),

--- a/chain-core/src/tx/data/input.rs
+++ b/chain-core/src/tx/data/input.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::tx::data::TxId;
 
 // TODO: u16 and Vec size check in Decode implementation
-pub type TxoIndex = u16;
+pub type TxoSize = u16;
 
 /// Structure used for addressing a specific output of a transaction
 /// built from a TxId (hash of the tx) and the offset in the outputs of this
@@ -31,7 +31,7 @@ pub struct TxoPointer {
     )]
     pub id: TxId,
     // TODO: u16 and Vec size check in Decode implementation
-    pub index: TxoIndex,
+    pub index: TxoSize,
 }
 
 #[cfg(not(feature = "mesalock_sgx"))]
@@ -94,7 +94,7 @@ impl TxoPointer {
     pub fn new(id: TxId, index: usize) -> Self {
         TxoPointer {
             id,
-            index: index as TxoIndex,
+            index: index as TxoSize,
         }
     }
 }

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -22,7 +22,7 @@ use crate::state::tendermint::BlockHeight;
 use crate::state::validator::NodeJoinRequestTx;
 use crate::tx::data::{txid_hash, TxId};
 use aead::Payload;
-use data::input::{TxoIndex, TxoPointer};
+use data::input::{TxoPointer, TxoSize};
 use data::output::TxOut;
 
 const TX_AUX_SIZE: usize = 1024 * 60; // 60 KB
@@ -153,7 +153,7 @@ pub enum TxEnclaveAux {
     /// normal value transfer Tx with the vector of witnesses
     TransferTx {
         inputs: Vec<TxoPointer>,
-        no_of_outputs: TxoIndex,
+        no_of_outputs: TxoSize,
         payload: TxObfuscated,
     },
     /// Tx "spends" utxos to be deposited as bonded stake in an account (witnesses as in transfer)
@@ -163,7 +163,7 @@ pub enum TxEnclaveAux {
     },
     /// Tx that "creates" utxos out of account state; withdraws unbonded stake (witness for account)
     WithdrawUnbondedStakeTx {
-        no_of_outputs: TxoIndex,
+        no_of_outputs: TxoSize,
         witness: StakedStateOpWitness,
         payload: TxObfuscated,
     },

--- a/chain-storage/src/api.rs
+++ b/chain-storage/src/api.rs
@@ -6,7 +6,7 @@ use parity_scale_codec::Encode;
 use chain_core::common::H256;
 use chain_core::state::tendermint::BlockHeight;
 use chain_core::tx::data::{
-    input::{TxoIndex, TxoPointer},
+    input::{TxoPointer, TxoSize},
     TxId,
 };
 
@@ -130,7 +130,7 @@ pub fn spend_utxos(db: &mut impl StoreKV, txins: &[TxoPointer]) {
     }
 }
 
-pub fn create_utxo(db: &mut impl StoreKV, no_of_outputs: TxoIndex, txid: &TxId) {
+pub fn create_utxo(db: &mut impl StoreKV, no_of_outputs: TxoSize, txid: &TxId) {
     insert_item(
         db,
         LookupItem::TxMetaSpent,

--- a/chain-tx-enclave/tx-query/enclave/src/lib.rs
+++ b/chain-tx-enclave/tx-query/enclave/src/lib.rs
@@ -12,7 +12,7 @@ use sgx_rand::*;
 use sgx_types::*;
 
 use chain_core::tx::{
-    data::{input::TxoIndex, TxId},
+    data::{input::TxoSize, TxId},
     TransactionId, TxEnclaveAux,
 };
 use enclave_protocol::{
@@ -222,7 +222,7 @@ fn handle_encryption_request(
                             let tx = match req {
                                 EncryptionRequest::TransferTx(tx, _) => {
                                     let inputs = tx.inputs;
-                                    let no_of_outputs = tx.outputs.len() as TxoIndex;
+                                    let no_of_outputs = tx.outputs.len() as TxoSize;
                                     TxEnclaveAux::TransferTx {
                                         inputs,
                                         no_of_outputs,
@@ -233,7 +233,7 @@ fn handle_encryption_request(
                                     TxEnclaveAux::DepositStakeTx { tx, payload }
                                 }
                                 EncryptionRequest::WithdrawStake(tx, _, witness) => {
-                                    let no_of_outputs = tx.outputs.len() as TxoIndex;
+                                    let no_of_outputs = tx.outputs.len() as TxoSize;
                                     TxEnclaveAux::WithdrawUnbondedStakeTx {
                                         no_of_outputs,
                                         witness,

--- a/chain-tx-enclave/tx-validation/enclave/src/validate.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/validate.rs
@@ -2,7 +2,7 @@ use chain_core::init::coin::Coin;
 use chain_core::tx::data::TxId;
 use chain_core::tx::fee::Fee;
 use chain_core::tx::TransactionId;
-use chain_core::tx::{data::input::TxoIndex, PlainTxAux, TxEnclaveAux, TxObfuscated};
+use chain_core::tx::{data::input::TxoSize, PlainTxAux, TxEnclaveAux, TxObfuscated};
 use chain_tx_filter::BlockFilter;
 use chain_tx_validation::witness::verify_tx_recover_address;
 use chain_tx_validation::{
@@ -171,7 +171,7 @@ pub(crate) fn handle_validate_tx(
                 check_unseal(None, false, inputs.iter().map(|x| x.id), sealed_inputs);
             match (plaintx, unsealed_inputs) {
                 (Ok(PlainTxAux::TransferTx(tx, witness)), Some(inputs)) => {
-                    if tx.id() != payload.txid || tx.outputs.len() as TxoIndex != no_of_outputs {
+                    if tx.id() != payload.txid || tx.outputs.len() as TxoSize != no_of_outputs {
                         log::error!("input invalid txid or outputs index not match!");
                         return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
                     }
@@ -221,7 +221,7 @@ pub(crate) fn handle_validate_tx(
             match (plaintx, request.account) {
                 (Ok(PlainTxAux::WithdrawUnbondedStakeTx(tx)), Some(account)) => {
                     if tx.id() != payload.txid
-                        || no_of_outputs != tx.outputs.len() as TxoIndex
+                        || no_of_outputs != tx.outputs.len() as TxoSize
                         || account.address != address.unwrap()
                     {
                         return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;

--- a/client-core/src/signer/dummy_signer.rs
+++ b/client-core/src/signer/dummy_signer.rs
@@ -6,7 +6,7 @@ use chain_core::state::account::{
     WithdrawUnbondedTx,
 };
 use chain_core::state::tendermint::BlockHeight;
-use chain_core::tx::data::input::{TxoIndex, TxoPointer};
+use chain_core::tx::data::input::{TxoPointer, TxoSize};
 use chain_core::tx::data::{Tx, TxId};
 use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::witness::{TxInWitness, TxWitness};
@@ -69,7 +69,7 @@ impl DummySigner {
         // mock the enclave encrypted result
         let tx_enclave_aux = TxEnclaveAux::TransferTx {
             inputs: tx.inputs.clone(),
-            no_of_outputs: tx.outputs.len() as TxoIndex,
+            no_of_outputs: tx.outputs.len() as TxoSize,
             payload: TxObfuscated {
                 txid: [0; 32],
                 key_from: BlockHeight::genesis(),
@@ -89,7 +89,7 @@ impl DummySigner {
         let deposit_bond_tx = DepositBondTx {
             inputs: vec![TxoPointer {
                 id: TxId::default(),
-                index: TxoIndex::default(),
+                index: TxoSize::default(),
             }],
             to_staked_account: StakedStateAddress::BasicRedeem(RedeemAddress::default()),
             attributes: StakedStateOpAttributes::default(),
@@ -112,7 +112,7 @@ impl DummySigner {
         let ecdsa_signature =
             RecoverableSignature::from_compact(&[0; 64], RecoveryId::from_i32(1).unwrap()).unwrap();
         let witness = StakedStateOpWitness::new(ecdsa_signature);
-        let no_of_outputs = tx.outputs.len() as TxoIndex;
+        let no_of_outputs = tx.outputs.len() as TxoSize;
         let txid = tx.id();
         let plain = PlainTxAux::WithdrawUnbondedStakeTx(tx);
         let padded_plain = self.pad_payload(plain);

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -194,7 +194,7 @@ mod default_wallet_transaction_builder_tests {
 
     use super::*;
     use chain_core::state::tendermint::BlockHeight;
-    use chain_core::tx::data::input::{TxoIndex, TxoPointer};
+    use chain_core::tx::data::input::{TxoPointer, TxoSize};
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::{LinearFee, Milli};
     use chain_core::tx::{PlainTxAux, TransactionId, TxAux, TxEnclaveAux, TxObfuscated};
@@ -226,7 +226,7 @@ mod default_wallet_transaction_builder_tests {
                 SignedTransaction::TransferTransaction(tx, _) => {
                     Ok(TxAux::EnclaveTx(TxEnclaveAux::TransferTx {
                         inputs: tx.inputs.clone(),
-                        no_of_outputs: tx.outputs.len() as TxoIndex,
+                        no_of_outputs: tx.outputs.len() as TxoSize,
                         payload: TxObfuscated {
                             txid: [0; 32],
                             key_from: BlockHeight::genesis(),

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -536,7 +536,7 @@ mod raw_transfer_transaction_builder_tests {
     use chain_core::init::MAX_COIN;
     use chain_core::state::tendermint::BlockHeight;
     use chain_core::tx::data::address::ExtendedAddr;
-    use chain_core::tx::data::input::TxoIndex;
+    use chain_core::tx::data::input::TxoSize;
     use chain_core::tx::fee::{LinearFee, Milli};
     use chain_core::tx::witness::tree::RawXOnlyPubkey;
     use chain_core::tx::{TxEnclaveAux, TxObfuscated};
@@ -1229,7 +1229,7 @@ mod raw_transfer_transaction_builder_tests {
                 SignedTransaction::TransferTransaction(tx, _) => {
                     Ok(TxAux::EnclaveTx(TxEnclaveAux::TransferTx {
                         inputs: tx.inputs.clone(),
-                        no_of_outputs: tx.outputs.len() as TxoIndex,
+                        no_of_outputs: tx.outputs.len() as TxoSize,
                         payload: TxObfuscated {
                             txid: [0; 32],
                             key_from: BlockHeight::genesis(),

--- a/client-core/src/wallet/syncer_logic.rs
+++ b/client-core/src/wallet/syncer_logic.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use chain_core::init::coin::{sum_coins, Coin, CoinError};
 use chain_core::tx::{
     data::{
-        input::{TxoIndex, TxoPointer},
+        input::{TxoPointer, TxoSize},
         output::TxOut,
         TxId,
     },
@@ -25,7 +25,7 @@ pub enum SyncerLogicError {
     #[error("Total output amount exceeds maximum allowed value(txid: {0})")]
     TotalOutputOutOfBound(String),
     #[error("Input index is invalid(txid: {0}, index: {1})")]
-    InputIndexInvalid(String, TxoIndex),
+    InputIndexInvalid(String, TxoSize),
     #[error("Inputs come from multiple wallets(txid: {0})")]
     InputFromMultipleWallets(String),
 }

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -529,7 +529,7 @@ mod tests {
     use chain_core::state::tendermint::BlockHeight;
     use chain_core::state::tendermint::TendermintValidatorPubKey;
     use chain_core::state::ChainState;
-    use chain_core::tx::data::input::TxoIndex;
+    use chain_core::tx::data::input::TxoSize;
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::Fee;
     use chain_core::tx::{PlainTxAux, TxEnclaveAux, TxObfuscated};
@@ -573,7 +573,7 @@ mod tests {
                 SignedTransaction::WithdrawUnbondedStakeTransaction(tx, _, witness) => {
                     let plain = PlainTxAux::WithdrawUnbondedStakeTx(tx.clone());
                     Ok(TxAux::EnclaveTx(TxEnclaveAux::WithdrawUnbondedStakeTx {
-                        no_of_outputs: tx.outputs.len() as TxoIndex,
+                        no_of_outputs: tx.outputs.len() as TxoSize,
                         witness,
                         payload: TxObfuscated {
                             txid: tx.id(),

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -437,7 +437,7 @@ pub mod tests {
     use chain_core::init::coin::CoinError;
     use chain_core::state::tendermint::BlockHeight;
     use chain_core::state::ChainState;
-    use chain_core::tx::data::input::TxoIndex;
+    use chain_core::tx::data::input::TxoSize;
     use chain_core::tx::data::TxId;
     use chain_core::tx::fee::{Fee, FeeAlgorithm};
     use chain_core::tx::{PlainTxAux, TransactionId, TxAux, TxEnclaveAux, TxObfuscated};
@@ -487,7 +487,7 @@ pub mod tests {
                 SignedTransaction::TransferTransaction(tx, _) => {
                     Ok(TxAux::EnclaveTx(TxEnclaveAux::TransferTx {
                         inputs: tx.inputs.clone(),
-                        no_of_outputs: tx.outputs.len() as TxoIndex,
+                        no_of_outputs: tx.outputs.len() as TxoSize,
                         payload: TxObfuscated {
                             txid: tx.id(),
                             key_from: BlockHeight::genesis(),
@@ -511,7 +511,7 @@ pub mod tests {
                 SignedTransaction::WithdrawUnbondedStakeTransaction(tx, _, witness) => {
                     let plain = PlainTxAux::WithdrawUnbondedStakeTx(tx.clone());
                     Ok(TxAux::EnclaveTx(TxEnclaveAux::WithdrawUnbondedStakeTx {
-                        no_of_outputs: tx.outputs.len() as TxoIndex,
+                        no_of_outputs: tx.outputs.len() as TxoSize,
                         witness,
                         payload: TxObfuscated {
                             txid: tx.id(),


### PR DESCRIPTION
Solution: rename TxoIndex to TxoSize
this is just renaming type "TxoIndex", that is u16

other code is the same.