### PR TITLE
Problem (Fix #1273): "deposit_amount" test failed occationally

### DIFF
--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -245,7 +245,7 @@ where
                 tx_pending,
             )
             .map_err(to_rpc_error)?;
-        Ok(hex::encode(tx_id))
+        Ok(hex::encode(transaction.tx_id()))
     }
 
     fn state(&self, address: StakedStateAddress) -> Result<StakedState> {


### PR DESCRIPTION
Solution:
- make deposit amount return the tx id of the last transaction,
  rather than the first one.
