### PR TITLE
Problem: security flaw in external dependency (RUSTSEC-2020-0006)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
 name = "byte-slice-cast"


### PR DESCRIPTION
Solution: `cargo update -p bumpalo`
it seems this was just a compile-time dependency of some wasm-related tools