### PR TITLE
Problem: incorrect ordering of keys() in MemoreyStorage#1294

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "serde_json",
  "sha2 0.8.1",
  "sled",
+ "tempfile",
  "tendermint",
  "websocket",
  "zeroize 1.1.0",

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -33,6 +33,7 @@ indexmap = "1.3"
 
 [dev-dependencies]
 quickcheck = "0.9"
+tempfile="3.1.0"
 
 [features]
 default = ["sled", "websocket-rpc"]

--- a/client-common/src/storage.rs
+++ b/client-common/src/storage.rs
@@ -53,6 +53,8 @@ pub trait Storage: Send + Sync + Clone {
         F: Fn(Option<&[u8]>) -> Result<Option<Vec<u8>>>;
 
     /// Returns a vector of stored keys in a keyspace.
+    /// ordering can be arbitrary
+    /// to ensure ordering, consider sorting before iteration
     fn keys<S: AsRef<[u8]>>(&self, keyspace: S) -> Result<Vec<Vec<u8>>>;
 
     /// Returns `true` if the storage contains a value for the specified key in given keyspace, `false` otherwise.

--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -182,6 +182,12 @@ fn read_pubkey<S: SecureStorage>(storage: &S, keyspace: &str, key: &str) -> Resu
     }
 }
 
+// compute index value to string from binary
+// so that db iteration is the same with index_value
+fn compute_key(index_value: u64) -> String {
+    hex::encode(&u64::to_be_bytes(index_value as u64))
+}
+
 fn write_pubkey<S: SecureStorage>(
     storage: &S,
     keyspace: &str,
@@ -285,7 +291,7 @@ pub fn load_wallet<S: SecureStorage>(
         let stakingkey_count: u64 =
             read_number(storage, &info_keyspace, "stakingkeyindex", Some(0))?;
         for i in 0..stakingkey_count {
-            let stakingkey = read_pubkey(storage, &staking_keyspace, &format!("{}", i))?;
+            let stakingkey = read_pubkey(storage, &staking_keyspace, &compute_key(i))?;
             new_wallet.staking_keys.insert(stakingkey);
         }
 
@@ -510,7 +516,7 @@ where
         let publickey_count: u64 = read_number(&self.storage, &info_keyspace, "publicindex", None)?;
 
         for i in 0..publickey_count {
-            let pubkey = read_pubkey(&self.storage, &public_keyspace, &format!("{}", i))?;
+            let pubkey = read_pubkey(&self.storage, &public_keyspace, &compute_key(i))?;
             ret.insert(pubkey);
         }
         Ok(ret)
@@ -531,7 +537,7 @@ where
         let staking_count: u64 =
             read_number(&self.storage, &info_keyspace, "stakingkeyindex", None)?;
         for i in 0..staking_count {
-            let pubkey = read_pubkey(&self.storage, &stakingkey_keyspace, &format!("{}", i))?;
+            let pubkey = read_pubkey(&self.storage, &stakingkey_keyspace, &compute_key(i))?;
             ret.insert(pubkey);
         }
         Ok(ret)
@@ -632,7 +638,7 @@ where
         write_pubkey(
             &self.storage,
             &public_keyspace,
-            &format!("{}", index_value),
+            &compute_key(index_value),
             &public_key,
         )?;
 
@@ -671,7 +677,7 @@ where
         write_pubkey(
             &self.storage,
             &stakingkey_keyspace,
-            &format!("{}", index_value),
+            &compute_key(index_value),
             &staking_key,
         )?;
 


### PR DESCRIPTION
Solution: replace hashmap with btreemap
memory stroages used hashmap, which keys ordering is different.

so in some integration test(multinode), address list order is very important, 
hashmap can break it sometimes.

solution is to replace hashmap with btreemap, which is the same with sled or rocksdb.


