### PR TITLE
Problem: inclusion proof does not verify that hash(leaf_value) == path.leaf_hash

### DIFF
--- a/chain-abci/src/app/query.rs
+++ b/chain-abci/src/app/query.rs
@@ -11,7 +11,6 @@ use chain_core::state::ChainState;
 use chain_core::tx::data::{txid_hash, TXID_HASH_ID};
 use chain_storage::LookupItem;
 use parity_scale_codec::{Decode, Encode};
-use serde_json;
 
 /// Generate generic ABCI ProofOp for the witness
 fn get_witness_proof_op(witness: &[u8]) -> ProofOp {

--- a/chain-core/src/common/merkle_tree.rs
+++ b/chain-core/src/common/merkle_tree.rs
@@ -209,8 +209,9 @@ impl<T> Proof<T> {
     where
         T: AsRef<[u8]>,
     {
-        // FIXME: https://github.com/crypto-com/chain/issues/1329
-        root_hash == self.path.hash() && self.path.verify()
+        root_hash == self.path.hash()
+            && self.path.verify()
+            && hash_leaf(&self.value) == self.path.leaf_hash
     }
 
     /// Returns a borrow of value contained in this proof

--- a/chain-core/src/common/merkle_tree.rs
+++ b/chain-core/src/common/merkle_tree.rs
@@ -809,4 +809,17 @@ mod tests {
             .unwrap()
             .verify(&new_tree.root_hash()));
     }
+
+    #[test]
+    fn check_wrong_leaf_value() {
+        let values = vec!["one", "two", "three", "four"];
+        let tree = MerkleTree::new(values);
+
+        let mut proof = tree.generate_proof("one").unwrap();
+        assert!(proof.verify(&tree.root_hash()));
+
+        // Intentionally change the value in proof
+        proof.value = "two";
+        assert!(!proof.verify(&tree.root_hash()));
+    }
 }


### PR DESCRIPTION
Solution: Added a check to verify that `hash(leaf_value) == path.leaf_hash`. Fixes #1329