### PR TITLE
Problem: redundant leaf_hash stored in merkle proof (fixes #1333)

### DIFF
--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -865,7 +865,7 @@ fn all_valid_tx_types_should_commit() {
     let utxo1 = TxoPointer::new(*txid, 0);
     let mut tx1 = Tx::new();
     tx1.add_input(utxo1);
-    tx1.add_output(TxOut::new(eaddr, Coin::from(99999685u32)));
+    tx1.add_output(TxOut::new(eaddr, Coin::from(99999717u32)));
     let txid1 = tx1.id();
     let witness1 = vec![TxInWitness::TreeSig(
         schnorr_sign(&secp, &Message::from_slice(&txid1).unwrap(), &secret_key),

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -243,7 +243,7 @@ fn prepare_app_valid_transfer_tx(
     tx.add_output(TxOut::new(addr, Coin::new(9).unwrap()));
     let sk2 = SecretKey::from_slice(&[0x11; 32]).expect("32 bytes, within curve order");
     let addr2 = get_address(&secp, &sk2).0;
-    tx.add_output(TxOut::new(addr2, Coin::new(99999634).unwrap()));
+    tx.add_output(TxOut::new(addr2, Coin::new(99999666).unwrap()));
 
     let witness: Vec<TxInWitness> = vec![get_tx_witness(secp, &tx.id(), &secret_key, &merkle_tree)];
     let plain_txaux = PlainTxAux::new(tx.clone(), witness.clone().into());


### PR DESCRIPTION
Solution: removed leaf_hash and using the computed value
+ updated the related internal API
- note this reduced the TX size, so fee in some tests also decreased that were updated

