### PR TITLE
Problem: tx and staking state not accounting for TDBE (fixes #1303)

### DIFF
--- a/chain-abci/src/staking/mod.rs
+++ b/chain-abci/src/staking/mod.rs
@@ -15,7 +15,8 @@ mod tests {
     use chain_core::init::config::SlashRatio;
     use chain_core::init::params::NetworkParameters;
     use chain_core::state::account::{
-        CouncilNode, PunishmentKind, StakedState, StakedStateAddress, UnbondTx, Validator,
+        ConfidentialInit, CouncilNode, PunishmentKind, StakedState, StakedStateAddress, UnbondTx,
+        Validator,
     };
     use chain_core::state::tendermint::{BlockHeight, TendermintValidatorPubKey};
     use chain_core::state::validator::NodeJoinRequestTx;
@@ -53,6 +54,9 @@ mod tests {
         staking.bonded = bonded;
         staking.validator = Some(Validator::new(CouncilNode::new(
             TendermintValidatorPubKey::Ed25519(seed.clone()),
+            ConfidentialInit {
+                cert: b"FIXME".to_vec(),
+            },
         )));
         staking
     }
@@ -104,7 +108,12 @@ mod tests {
             nonce: 0,
             address: addr4,
             attributes: Default::default(),
-            node_meta: CouncilNode::new(val_pk4.clone()),
+            node_meta: CouncilNode::new(
+                val_pk4.clone(),
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
+            ),
         };
         table.node_join(&mut store, 10, &node_join).unwrap();
         assert_eq!(table.end_block(&store, 3), vec![]);
@@ -195,7 +204,12 @@ mod tests {
             nonce: 0,
             address: addr1,
             attributes: Default::default(),
-            node_meta: CouncilNode::new(val_pk_new),
+            node_meta: CouncilNode::new(
+                val_pk_new,
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
+            ),
         };
         assert!(matches!(
             table.node_join(&mut store, 3, &node_join),
@@ -230,7 +244,12 @@ mod tests {
             nonce: 1,
             address: addr1,
             attributes: Default::default(),
-            node_meta: CouncilNode::new(val_pk_new),
+            node_meta: CouncilNode::new(
+                val_pk_new,
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
+            ),
         };
         // change to new validator key
         table.node_join(&mut store, 1, &node_join).unwrap();
@@ -243,7 +262,12 @@ mod tests {
             nonce: 0,
             address: addr_new,
             attributes: Default::default(),
-            node_meta: CouncilNode::new(val_pk1),
+            node_meta: CouncilNode::new(
+                val_pk1,
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
+            ),
         };
         // can't join with used key
         assert!(matches!(

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -14,7 +14,7 @@ use chain_core::init::config::{
     JailingParameters, RewardsParameters, SlashRatio, SlashingParameters,
 };
 use chain_core::state::account::{
-    to_stake_key, CouncilNode, DepositBondTx, StakedState, StakedStateAddress,
+    to_stake_key, ConfidentialInit, CouncilNode, DepositBondTx, StakedState, StakedStateAddress,
     StakedStateDestination, StakedStateOpAttributes, StakedStateOpWitness, UnbondTx,
     WithdrawUnbondedTx,
 };
@@ -249,7 +249,14 @@ fn init_chain_for(address: RedeemAddress) -> ChainNodeApp<MockClient> {
     let pub_key =
         TendermintValidatorPubKey::from_base64(b"MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
             .unwrap();
-    let node_pubkey = ("test".to_owned(), None, pub_key.clone());
+    let node_pubkey = (
+        "test".to_owned(),
+        None,
+        pub_key.clone(),
+        ConfidentialInit {
+            cert: b"FIXME".to_vec(),
+        },
+    );
     let validator = ValidatorUpdate {
         pub_key: Some(PubKey {
             field_type: "ed25519".to_owned(),
@@ -969,7 +976,12 @@ fn all_valid_tx_types_should_commit() {
         1,
         addr.into(),
         StakedStateOpAttributes::new(0),
-        CouncilNode::new(TendermintValidatorPubKey::Ed25519([2u8; 32])),
+        CouncilNode::new(
+            TendermintValidatorPubKey::Ed25519([2u8; 32]),
+            ConfidentialInit {
+                cert: b"FIXME".to_vec(),
+            },
+        ),
     );
     let secp = Secp256k1::new();
     let witness = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &tx.id(), &secret_key));

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -17,7 +17,8 @@ use chain_core::state::account::StakedState;
 use chain_core::state::account::StakedStateAddress;
 use chain_core::state::account::StakedStateOpAttributes;
 use chain_core::state::account::{
-    DepositBondTx, StakedStateOpWitness, UnbondTx, UnjailTx, Validator, WithdrawUnbondedTx,
+    ConfidentialInit, DepositBondTx, StakedStateOpWitness, UnbondTx, UnjailTx, Validator,
+    WithdrawUnbondedTx,
 };
 use chain_core::state::tendermint::BlockHeight;
 use chain_core::state::tendermint::TendermintValidatorPubKey;
@@ -1493,7 +1494,12 @@ fn prepare_jailed_accounts() -> (
         0,
         addr.into(),
         Some(Validator {
-            council_node: CouncilNode::new(TendermintValidatorPubKey::Ed25519([0xcd; 32])),
+            council_node: CouncilNode::new(
+                TendermintValidatorPubKey::Ed25519([0xcd; 32]),
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
+            ),
             jailed_until: Some(100),
             inactive_time: Some(0),
             inactive_block: Some(BlockHeight::genesis()),
@@ -1737,6 +1743,9 @@ fn prepare_nodejoin_transaction(
             name: "test".to_string(),
             security_contact: None,
             consensus_pubkey: TendermintValidatorPubKey::Ed25519([1u8; 32]),
+            confidential_init: ConfidentialInit {
+                cert: b"FIXME".to_vec(),
+            },
         },
     };
     let witness = get_account_op_witness(secp, &tx.id(), &secret_key);
@@ -1769,6 +1778,9 @@ fn prepare_valid_nodejoin_tx(
         if validator {
             Some(Validator::new(CouncilNode::new(
                 TendermintValidatorPubKey::Ed25519([1u8; 32]),
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
             )))
         } else {
             None

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -4,8 +4,8 @@ use crate::init::coin::{sum_coins, Coin, CoinError};
 pub use crate::init::params::*;
 use crate::init::MAX_COIN;
 use crate::state::account::{
-    CouncilNode, StakedState, StakedStateAddress, StakedStateDestination, ValidatorName,
-    ValidatorSecurityContact,
+    ConfidentialInit, CouncilNode, StakedState, StakedStateAddress, StakedStateDestination,
+    ValidatorName, ValidatorSecurityContact,
 };
 use crate::state::tendermint::{TendermintValidatorPubKey, TendermintVotePower};
 use crate::state::RewardsPoolState;
@@ -87,6 +87,7 @@ pub struct InitConfig {
             ValidatorName,
             ValidatorSecurityContact,
             TendermintValidatorPubKey,
+            ConfidentialInit,
         ),
     >,
 }
@@ -108,6 +109,7 @@ impl InitConfig {
                 ValidatorName,
                 ValidatorSecurityContact,
                 TendermintValidatorPubKey,
+                ConfidentialInit,
             ),
         >,
     ) -> Self {
@@ -147,14 +149,15 @@ impl InitConfig {
 
     fn get_council_node(&self, address: &RedeemAddress) -> Result<CouncilNode, DistributionError> {
         self.check_validator_address(address)?;
-        let (name, security_contact, pubkey) = self
-            .council_nodes
-            .get(address)
-            .ok_or(DistributionError::InvalidValidatorAccount)?;
+        let (name, security_contact, pubkey, confidential_init) =
+            self.council_nodes
+                .get(address)
+                .ok_or(DistributionError::InvalidValidatorAccount)?;
         Ok(CouncilNode::new_with_details(
             name.clone(),
             security_contact.clone(),
             pubkey.clone(),
+            confidential_init.clone(),
         ))
     }
 

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -4,7 +4,7 @@ use chain_core::init::config::{
     InitConfig, InitNetworkParameters, JailingParameters, RewardsParameters, SlashRatio,
     SlashingParameters,
 };
-use chain_core::state::account::StakedStateDestination;
+use chain_core::state::account::{ConfidentialInit, StakedStateDestination};
 use chain_core::state::tendermint::TendermintValidatorPubKey;
 use chain_core::tx::fee::{LinearFee, Milli};
 use serde::Deserialize;
@@ -34,7 +34,15 @@ fn test_verify_test_example_snapshot() {
         TendermintValidatorPubKey::from_base64(b"EIosObgfONUsnWCBGRpFlRFq5lSxjGIChRlVrVWVkcE=")
             .unwrap();
     let mut nodes = BTreeMap::new();
-    nodes.insert(node_address, ("no-name".to_owned(), None, node_pubkey));
+    nodes.insert(
+        node_address,
+        (
+            "no-name".to_owned(),
+            None,
+            node_pubkey,
+            ConfidentialInit { cert: vec![] },
+        ),
+    );
 
     let mut dist: BTreeMap<RedeemAddress, (StakedStateDestination, Coin)> = BTreeMap::new();
 

--- a/chain-storage/src/account/mod.rs
+++ b/chain-storage/src/account/mod.rs
@@ -148,7 +148,7 @@ mod test {
     use chain_core::init::address::RedeemAddress;
     use chain_core::init::coin::Coin;
     use chain_core::state::account::{
-        CouncilNode, Nonce, StakedState, StakedStateAddress, Validator,
+        ConfidentialInit, CouncilNode, Nonce, StakedState, StakedStateAddress, Validator,
     };
     use chain_core::state::tendermint::{BlockHeight, TendermintValidatorPubKey};
     use kvdb_memorydb::create;
@@ -175,8 +175,14 @@ mod test {
                 } else {
                     None
                 };
+                // TODO: cert
+                let cert: Vec<u8> = Vec::arbitrary(g);
+                let init_confid = ConfidentialInit { cert };
                 Some(Validator {
-                    council_node: CouncilNode::new(TendermintValidatorPubKey::Ed25519(raw_pubkey)),
+                    council_node: CouncilNode::new(
+                        TendermintValidatorPubKey::Ed25519(raw_pubkey),
+                        init_confid,
+                    ),
                     jailed_until,
                     inactive_time: Some(0),
                     inactive_block: Some(BlockHeight::genesis()),

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -8,7 +8,9 @@ use std::str::FromStr;
 use chain_core::common::{Timespec, HASH_SIZE_256};
 use chain_core::init::coin::Coin;
 use chain_core::init::network::get_network_id;
-use chain_core::state::account::{CouncilNode, StakedStateAddress, StakedStateOpAttributes};
+use chain_core::state::account::{
+    ConfidentialInit, CouncilNode, StakedStateAddress, StakedStateOpAttributes,
+};
 use chain_core::state::tendermint::TendermintValidatorPubKey;
 use chain_core::tx::data::access::{TxAccess, TxAccessPolicy};
 use chain_core::tx::data::address::ExtendedAddr;
@@ -985,5 +987,8 @@ fn ask_node_metadata() -> Result<CouncilNode> {
         name,
         security_contact: None,
         consensus_pubkey: TendermintValidatorPubKey::Ed25519(pubkey_bytes),
+        confidential_init: ConfidentialInit {
+            cert: b"FIXME".to_vec(),
+        },
     })
 }

--- a/client-common/src/tendermint/mock.rs
+++ b/client-common/src/tendermint/mock.rs
@@ -82,7 +82,8 @@ const DEFAULT_GENESIS_JSON: &str = r#"{
                 {
                     "type": "tendermint/PubKeyEd25519",
                     "value": "2H0sZxyy5iOU6q0/F+ZCQ3MyJJxg8odE5NMsGIyfFV0="
-                }
+                },
+                {"cert": "RklYTUU="}
             ]
         }
     }

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -489,7 +489,9 @@ mod tests {
 
     use chain_core::init::address::RedeemAddress;
     use chain_core::init::coin::CoinError;
-    use chain_core::state::account::{StakedState, StakedStateOpAttributes, Validator};
+    use chain_core::state::account::{
+        ConfidentialInit, StakedState, StakedStateOpAttributes, Validator,
+    };
     use chain_core::state::tendermint::BlockHeight;
     use chain_core::state::tendermint::TendermintValidatorPubKey;
     use chain_core::state::ChainState;
@@ -617,7 +619,12 @@ mod tests {
                 0,
                 StakedStateAddress::BasicRedeem(RedeemAddress::default()),
                 Some(Validator {
-                    council_node: CouncilNode::new(TendermintValidatorPubKey::Ed25519([0xcd; 32])),
+                    council_node: CouncilNode::new(
+                        TendermintValidatorPubKey::Ed25519([0xcd; 32]),
+                        ConfidentialInit {
+                            cert: b"FIXME".to_vec(),
+                        },
+                    ),
                     jailed_until: Some(100),
                     inactive_time: Some(0),
                     inactive_block: Some(BlockHeight::genesis()),
@@ -1102,6 +1109,9 @@ mod tests {
             name: "test".to_owned(),
             security_contact: None,
             consensus_pubkey: TendermintValidatorPubKey::Ed25519(validator_pubkey),
+            confidential_init: ConfidentialInit {
+                cert: b"FIXME".to_vec(),
+            },
         };
 
         let transaction = network_ops_client

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -6,7 +6,7 @@ use jsonrpc_derive::rpc;
 use crate::server::{rpc_error_from_string, to_rpc_error};
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{
-    CouncilNode, StakedState, StakedStateAddress, StakedStateOpAttributes,
+    ConfidentialInit, CouncilNode, StakedState, StakedStateAddress, StakedStateOpAttributes,
 };
 use chain_core::state::tendermint::TendermintValidatorPubKey;
 use chain_core::tx::data::access::{TxAccess, TxAccessPolicy};
@@ -444,5 +444,8 @@ fn get_node_metadata(validator_name: &str, validator_pubkey: &str) -> Result<Cou
         name: validator_name.to_string(),
         security_contact: None,
         consensus_pubkey: TendermintValidatorPubKey::Ed25519(pubkey_bytes),
+        confidential_init: ConfidentialInit {
+            cert: b"FIXME".to_vec(),
+        },
     })
 }

--- a/cro-clib/src/transaction_staking.rs
+++ b/cro-clib/src/transaction_staking.rs
@@ -2,7 +2,8 @@ use crate::types::get_string;
 use crate::types::{CroAddress, CroAddressPtr, CroResult};
 pub use chain_core::init::network::Network;
 use chain_core::state::account::{
-    CouncilNode, StakedStateAddress, StakedStateOpAttributes, StakedStateOpWitness, UnjailTx,
+    ConfidentialInit, CouncilNode, StakedStateAddress, StakedStateOpAttributes,
+    StakedStateOpWitness, UnjailTx,
 };
 use chain_core::state::tendermint::TendermintValidatorPubKey;
 use chain_core::state::validator::NodeJoinRequestTx;
@@ -110,6 +111,9 @@ fn create_encoded_signed_join(
         security_contact: Some(validator_contact.to_string()),
         // 32 bytes
         consensus_pubkey: pubkey,
+        confidential_init: ConfidentialInit {
+            cert: b"FIXME".to_vec(),
+        },
     };
     let transaction: NodeJoinRequestTx = NodeJoinRequestTx {
         nonce,

--- a/dev-utils/src/commands/genesis_command.rs
+++ b/dev-utils/src/commands/genesis_command.rs
@@ -245,7 +245,7 @@ pub fn generate_genesis(
 
 fn generate_validators(genesis_dev_config: &GenesisDevConfig) -> Result<Vec<TendermintValidator>> {
     let mut validators: Vec<TendermintValidator> = Vec::new();
-    for (redeem_addr, (validator_name, _, validator_pubkey)) in
+    for (redeem_addr, (validator_name, _, validator_pubkey, _confidential_init)) in
         genesis_dev_config.council_nodes.iter()
     {
         let address = TendermintValidatorAddress::from(validator_pubkey);

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -7,7 +7,7 @@ use chain_core::init::{
     coin::Coin,
     config::{JailingParameters, RewardsParameters, SlashRatio, SlashingParameters},
 };
-use chain_core::state::account::{ValidatorName, ValidatorSecurityContact};
+use chain_core::state::account::{ConfidentialInit, ValidatorName, ValidatorSecurityContact};
 use chain_core::state::tendermint::TendermintValidatorPubKey;
 
 #[derive(Deserialize, Debug)]
@@ -25,6 +25,7 @@ pub struct GenesisDevConfig {
             ValidatorName,
             ValidatorSecurityContact,
             TendermintValidatorPubKey,
+            ConfidentialInit,
         ),
     >,
 }

--- a/dev-utils/src/commands/init_command.rs
+++ b/dev-utils/src/commands/init_command.rs
@@ -9,7 +9,10 @@ use secstr::SecUtf8;
 use serde_json::json;
 
 use chain_core::init::{address::RedeemAddress, coin::Coin, config::InitConfig};
-use chain_core::state::tendermint::{TendermintValidator, TendermintValidatorPubKey};
+use chain_core::state::{
+    account::ConfidentialInit,
+    tendermint::{TendermintValidator, TendermintValidatorPubKey},
+};
 use client_common::storage::SledStorage;
 use client_common::tendermint::types::Time;
 use client_common::{Error, ErrorKind, Result, ResultExt};
@@ -181,9 +184,17 @@ impl InitCommand {
             .staking_account_address
             .parse::<RedeemAddress>()
             .unwrap();
-        self.genesis_dev_config
-            .council_nodes
-            .insert(address, ("dev test".to_owned(), None, pubkey));
+        self.genesis_dev_config.council_nodes.insert(
+            address,
+            (
+                "dev test".to_owned(),
+                None,
+                pubkey,
+                ConfidentialInit {
+                    cert: b"FIXME".to_vec(),
+                },
+            ),
+        );
         Ok(())
     }
 

--- a/docker/config/devnet/dev-conf.json
+++ b/docker/config/devnet/dev-conf.json
@@ -34,7 +34,8 @@
             {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "FF5JxhRrCUNLj6UZmYdjv/AWgSWUeiomeOMeJG71owE="
-            }
+            },
+            {"cert": "RklYTUU="}
         ]
     }
 }

--- a/docker/config/devnet/tendermint/genesis.json
+++ b/docker/config/devnet/tendermint/genesis.json
@@ -1,5 +1,5 @@
 {
-    "app_hash": "617BB72DA13E19B284213AE13F5EB1DF05612FD90C76E89BEE41771285BDBA0C",
+    "app_hash": "667EBBD3C77E2022FB7D29502F3FD7B7E190186E3344BF102789D8BE38239125",
     "app_state": {
       "council_nodes": {
         "0x45c1851c2f0dc6138935857b9e23b173185fea15": [
@@ -8,7 +8,8 @@
           {
             "type": "tendermint/PubKeyEd25519",
             "value": "FF5JxhRrCUNLj6UZmYdjv/AWgSWUeiomeOMeJG71owE="
-          }
+          },
+          {"cert": "RklYTUU="}
         ]
       },
       "distribution": {

--- a/integration-tests/bot/chainbot.py
+++ b/integration-tests/bot/chainbot.py
@@ -205,7 +205,8 @@ def app_state_cfg(cfg):
                 {
                     'type': 'tendermint/PubKeyEd25519',
                     'value': SigningKey(node['validator_seed']).pub_key_base64(),
-                }
+                },
+                {'cert': "RklYTUU="} # FIXME: to be designed and implemented
             ]
             for node in cfg['nodes'] if node['bonded_coin'] > 0
         },

--- a/test-common/src/block_generator.rs
+++ b/test-common/src/block_generator.rs
@@ -25,7 +25,9 @@ use chain_core::init::config::NetworkParameters;
 use chain_core::init::{
     address::RedeemAddress, coin::Coin, config::InitConfig, network::Network, params,
 };
-use chain_core::state::account::{CouncilNode, StakedStateAddress, StakedStateDestination};
+use chain_core::state::account::{
+    ConfidentialInit, CouncilNode, StakedStateAddress, StakedStateDestination,
+};
 use chain_core::state::tendermint::{
     TendermintValidatorAddress, TendermintValidatorPubKey, TendermintVotePower,
 };
@@ -91,6 +93,9 @@ impl Node {
             name: self.name.clone(),
             security_contact: Some(format!("{}@example.com", self.name)),
             consensus_pubkey: self.tendermint_pub_key(),
+            confidential_init: ConfidentialInit {
+                cert: b"FIXME".to_vec(),
+            },
         }
     }
 
@@ -247,7 +252,14 @@ impl TestnetSpec {
         for node in &self.nodes {
             council_nodes.insert(
                 node.redeem_address(0),
-                (node.name.clone(), None, node.tendermint_pub_key()),
+                (
+                    node.name.clone(),
+                    None,
+                    node.tendermint_pub_key(),
+                    ConfidentialInit {
+                        cert: b"FIXME".to_vec(),
+                    },
+                ),
             );
         }
 

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -22,9 +22,9 @@ use chain_core::init::config::{
     SlashRatio, SlashingParameters,
 };
 use chain_core::state::account::{
-    CouncilNode, StakedState, StakedStateAddress, StakedStateDestination, StakedStateOpAttributes,
-    StakedStateOpWitness, UnbondTx, Validator as ChainValidator, ValidatorName,
-    ValidatorSecurityContact,
+    ConfidentialInit, CouncilNode, StakedState, StakedStateAddress, StakedStateDestination,
+    StakedStateOpAttributes, StakedStateOpWitness, UnbondTx, Validator as ChainValidator,
+    ValidatorName, ValidatorSecurityContact,
 };
 use chain_core::state::tendermint::{
     TendermintValidatorAddress, TendermintValidatorPubKey, TendermintVotePower,
@@ -122,6 +122,7 @@ pub fn get_nodes(
         ValidatorName,
         ValidatorSecurityContact,
         TendermintValidatorPubKey,
+        ConfidentialInit,
     ),
 > {
     addresses
@@ -129,7 +130,14 @@ pub fn get_nodes(
         .map(|acct| {
             (
                 acct.address,
-                (acct.name.clone(), None, acct.validator_pub_key.clone()),
+                (
+                    acct.name.clone(),
+                    None,
+                    acct.validator_pub_key.clone(),
+                    ConfidentialInit {
+                        cert: b"FIXME".to_vec(),
+                    },
+                ),
             )
         })
         .collect()


### PR DESCRIPTION
Solution:
- added a struct that's meant to contain x509 cert to be used in joining MLS group
ref: https://github.com/crypto-com/chain-docs/blob/master/plan.md#key-generation-and-rotation
and architecture audit report

It's hard to tell whether this is enough information, but one will at least need to have:
- "userinitkey"
- crendetial + attestation payload

both of which can be contained within x509 cert -- attestation as that cert extension
as in TLS settings -- so it may make sense to reuse that for this TDBE MLS group joining/init
