### PR TITLE
Problem: tx-query-app cannot be built and aesm not running in PSW 2.9 (fix #1392)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -e; \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list; \
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -; \
     apt-get update; \
-    apt-get install -y libzmq3-dev libssl1.1 libprotobuf10 libsgx-launch libsgx-urts libsgx-epid libsgx-urts  libsgx-quote-ex libsgx-urts; \
+    apt-get install -y libzmq3-dev libssl1.1 libprotobuf10 libsgx-launch libsgx-urts libsgx-epid libsgx-quote-ex; \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=tendermint/tendermint:v0.32.9 /usr/bin/tendermint /usr/bin/tendermint
@@ -91,7 +91,7 @@ RUN set -e; \
       tx-query-app \
       tx_query_enclave.signed.so \
       tx_validation_enclave.signed.so ; \
-    do mv "./target/debug/${bin}" /output; done; \
+    do mv "./target/${BUILD_PROFILE}/${bin}" /output; done; \
     cargo clean;
 
 FROM RUNTIME_BASE

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ run-client-rpc:
 	--chain-id=$(CHAIN_ID) \
 	--storage-dir=/crypto-chain/wallet \
 	--websocket-url=ws://$(prefix)tendermint:26657/websocket \
+	--disable-fast-forward
 
 .PHONY: sgx-query chain-abci tendermint client-rpc
 

--- a/ci-scripts/Dockerfile
+++ b/ci-scripts/Dockerfile
@@ -1,11 +1,27 @@
 FROM baiduxlab/sgx-rust:1804-1.1.1
 LABEL maintainer="Crypto.com"
 
+ENV PATH=/root/.cargo/bin:/root/.local/bin:$PATH
+ENV RUST_BACKTRACE=1
+ENV RUSTFLAGS "-Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
+
 RUN echo 'source /opt/sgxsdk/environment' >> /root/.docker_bashrc && \
     echo 'source /root/.cargo/env' >> /root/.docker_bashrc
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libzmq3-dev clang && \
+RUN set -e; \
+    rustup set profile minimal; \
+    rustup toolchain install nightly-2020-03-22; \
+    rustup default nightly-2020-03-22; \
+    apt-get update; \
+    apt-get install -y \
+    cmake \
+    libgflags-dev \
+    libzmq3-dev \
+    libssl1.1 \
+    libprotobuf10 \
+    libcurl4-openssl-dev \
+    pkg-config \
+    clang; \
     rm -rf /var/lib/apt/lists/*
 
 ARG SGX_MODE=HW

--- a/ci-scripts/run_chain_abci.sh
+++ b/ci-scripts/run_chain_abci.sh
@@ -5,7 +5,8 @@ echo "[Config] SGX_MODE=${SGX_MODE}"
 echo "[Config] NETWORK_ID=${NETWORK_ID}"
 
 if [ x"${SGX_MODE}" == "xHW" ]; then
-  LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service &
+  mkdir -p /var/run/aesmd/
+  NAME=aesm_service AESM_PATH=/opt/intel/sgx-aesm-service/aesm LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service &
 
   echo "[aesm_service] Running in background ..."
 fi

--- a/ci-scripts/run_tx_query.sh
+++ b/ci-scripts/run_tx_query.sh
@@ -4,8 +4,8 @@ set -e
 echo "[Config] SGX_MODE=${SGX_MODE}"
 echo "[Config] TX_QUERY_TIMEOUT=${TX_QUERY_TIMEOUT}"
 
-LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service &
-
+mkdir -p /var/run/aesmd/
+NAME=aesm_service AESM_PATH=/opt/intel/sgx-aesm-service/aesm LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service &
 echo "[aesm_service] Running in background ..."
 # Wait for aesm_service to initialize
 sleep 4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,18 @@
 From ubuntu:18.04
 
-RUN apt-get update && apt-get install -y \
-    make \
-    libzmq3-dev \
-    libssl1.1 \
-    curl \
-    libprotobuf-dev \
-    libssl-dev && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y \
+  make \
+  libzmq3-dev \
+  libssl1.1 \
+  curl \
+  wget \
+  gnupg \
+  libcurl4-openssl-dev \
+  libprotobuf-dev \
+  libssl-dev \
+  libgflags-dev \
+  libprotobuf10 && \
+  rm -rf /var/lib/apt/lists/*
 
 arg BUILD_MODE
 
@@ -25,17 +30,15 @@ COPY ./docker/wait-for-it.sh /usr/local/bin
 COPY ci-scripts/run_tx_query.sh /usr/local/bin
 COPY ci-scripts/run_chain_abci.sh /usr/local/bin
 
-# install sgx enclave pws
-ARG SGX_ENCLAVE=https://download.01.org/intel-sgx/sgx-linux/2.7.1/distro/ubuntu18.04-server/libsgx-enclave-common_2.7.101.3-bionic1_amd64.deb
-# TODO
-# update PSW to 2.8
-# ARG SGX_ENCLAVE=https://download.01.org/intel-sgx/sgx-linux/2.8/distro/ubuntu18.04-server/debian_pkgs/libs/libsgx-enclave-common/libsgx-enclave-common_2.8.100.3-bionic1_amd64.deb
-
+# install sgx enclave pws 2.9
 RUN mkdir -p /opt/intel && \
-    cd /opt/intel && \
-    set -eux; \
-    curl -L  ${SGX_ENCLAVE} -o common.deb &&\
-    dpkg -i common.deb; rm common.deb;
+  cd /opt/intel && \
+  set -eux; \
+  echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list; \
+  wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -; \
+  apt-get update; \
+  apt-get install -y libsgx-launch libsgx-epid libsgx-quote-ex libsgx-urts libsgx-uae-service; \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/bin
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
Solution:
    - update ci-scripts/Dockerfile for build issue
    - update docker/Dockerfile, ci-scripts/run_tx_query.sh and ci-scripts/run_chain_abci.sh for PSW 2.9
    - add `--disable-fast-forward` in makefile to avoid sync issue in #1398 