### PR TITLE
Problem: jellyfish merkle tree don't allow empty version

### DIFF
--- a/architecture-docs/adr-003.md
+++ b/architecture-docs/adr-003.md
@@ -4,6 +4,7 @@
 * 02-04-2020: Initial Draft
 * 02-04-2020: Minor Edits + Decision Updated
 * 03-04-2020: Root Hash Kept in Chain Node State (for light client verification)
+* 11-04-2020: Use dedicated version number rather than block height
 
 ## Context
 For the authenticated integrity-checking storage of staking states, the prototype code has been using the [starling](https://crates.io/crates/starling) crate that implements "Merkle Binary Indexed Tree". This was choice, however, temporary
@@ -34,7 +35,10 @@ unnecessary dependencies.
 ### Integration
 The existing code will be adapted in the following way:
 
-- A new column `COL_TRIE_NODE` will be added to store trie nodes in the same key-value store as other information.
+- A `staking_version: Version` field will be added to `ChainNodeState`, which is initialized to zero, and increased by
+  one when a block with at least one staking modifications commit.
+
+- Two new columns `COL_TRIE_NODE`/`COL_STALE_NODE` will be added to store trie nodes in the same key-value store as other information.
 
 - The `jellyfish_merkle::TreeReader` trait will be implemented for `GetKV`.
 
@@ -54,14 +58,12 @@ The existing code will be adapted in the following way:
   }
   ```
 
-- The `StakingGetter` with `JellyfishMerkleTree` will be implemented against any `GetKV`,
+- The `StakingGetter` with `JellyfishMerkleTree` will be implemented against any `GetKV`.
 
-  `BlockHeight` will be used as the version number.
-  
   ```rust
   pub struct StakingGetter<'a, S: GetKV> {
       storage: &'a S,
-      block_height: BlockHeight,
+      version: Version,
   }
   
   impl<'a, S: GetKV> Get for StakingGetter<'a, S> {
@@ -69,7 +71,7 @@ The existing code will be adapted in the following way:
       type Value = StakedState;
       fn get(&self, key: &Self::Key) -> Option<Self::Value> {
           JellyfishMerkleTree::new(&KVReader::new(self.storage))
-              .get_with_proof(HashValue::new(to_stake_key(key)), self.block_height.into())
+              .get_with_proof(HashValue::new(to_stake_key(key)), self.version)
               .expect("merkle trie internal error")
               .0
               .map(|blob| {
@@ -92,7 +94,7 @@ its nodes will be written into the `StoreKV` buffer, which is the buffered key-v
   ```rust
   pub fn flush_stakings<S: StoreKV>(
       storage: &mut S,
-      block_height: BlockHeight,
+      version: Version,
       buffer: StakingBuffer,
   ) -> Result<(usize, usize)> {
       let reader = KVReader::new(storage);
@@ -102,13 +104,13 @@ its nodes will be written into the `StoreKV` buffer, which is the buffered key-v
               .values()
               .map(|staking| (HashValue::new(staking.key()), staking.encode().into()))
               .collect::<Vec<_>>()],
-          block_height.into(),
+          version,
       )?;
       for (key, node) in batch.node_batch.iter() {
           storage.set((COL_TRIE_NODE, key.encode()?), node.encode()?);
       }
       storage.set(
-          (COL_STALED_NODE, block_height.encode()), 
+          (COL_STALE_NODE, version.encode()), 
           batch.stale_node_index_batch.encode()
       );
       Ok((batch.num_new_leaves, batch.num_stale_leaves))
@@ -118,7 +120,7 @@ its nodes will be written into the `StoreKV` buffer, which is the buffered key-v
 - The complete block commit processing will be done as follows at the end:
   
   ```rust
-  flush_staking(&mut kv_store!(self), block_height, staking_buffer);
+  flush_staking(&mut kv_store!(self), version, staking_buffer);
   flush_kv(&mut self.kvdb, kv_buffer);  // Write to the disk atomically.
   ```
 
@@ -126,11 +128,10 @@ its nodes will be written into the `StoreKV` buffer, which is the buffered key-v
 
 - `AccountStorage` will be removed from `ChainNodeApp` (as the node storage will be in the dedicated `COL_TRIE_NODE` column).
 
-- In ABCIQuery, the block height from the request will be used to query historical states directly.
 
 ### Staled Trie Nodes Cleanup
 
-When a node is modified, its old version is staled. The keys of staled trie nodes will be stored in the dedicated `COL_STALED_NODE` columned, indexed by the block height where they became staled.
+When a node is modified, its old version is staled. The keys of staled trie nodes will be stored in the dedicated `COL_STALED_NODE` columned, indexed by the version number where they became staled.
 
 Pruning of these staled trie nodes (e.g. in the context of validator operation where only the most recent version is needed)
 is outside of the scope of this ADR.
@@ -152,7 +153,6 @@ Accepted
 
 - Better integration with the existing buffer storage abstraction; all Chain node state modifications can be done in a  single batch write operation during the BlockCommit request processing
 - More robust trie data structure and algorithms
-- No need to store the block height to root hash mapping for ABCI querying
 
 ### Negative
 
@@ -164,6 +164,7 @@ Accepted
 (or equivalent deterministic-finality consensus algorithms), but for probabilistic-finality consensus algorithms
 - One more repository
 - One "rocksdb" instance (as the nodes will be stored in one column rather than in a separate database instance)
+- When query history staking state, convert the request block height to version number through history `ChainNodeState` first
 
 ## References
 


### PR DESCRIPTION
Solution:
- Change adr-003 to use dedicated version number rather than block height.

The reason for this is the library doesn't allow empty versions, but we have empty blocks, so we can't use block height as the version number.
So we need to use a dedicated version number, it's also the number of blocks which have at least a staking modifications.