### PR TITLE
Problem: Unfair rewards distribution

### DIFF
--- a/chain-abci/src/app/rewards.rs
+++ b/chain-abci/src/app/rewards.rs
@@ -103,7 +103,7 @@ mod tests {
 
         let total_staking = dist;
 
-        // propose block by first validator.
+        // sign block by first validator.
         let state = app.last_state.as_ref().unwrap();
         let top_level = &state.top_level;
         let reward1 = monetary_expansion(
@@ -112,7 +112,7 @@ mod tests {
             top_level.network_params.get_rewards_monetary_expansion_r0(),
             top_level.network_params.get_rewards_reward_period_seconds(),
         );
-        let mut req = env.req_begin_block(1, 0);
+        let mut req = env.req_begin_block(2, 0);
         req.mut_header().set_time(seconds_to_timestamp(
             state.block_time + top_level.network_params.get_rewards_reward_period_seconds(),
         ));
@@ -138,11 +138,10 @@ mod tests {
             top_level.network_params.get_rewards_monetary_expansion_r0(),
             top_level.network_params.get_rewards_reward_period_seconds(),
         );
-        let mut req = env.req_begin_block(2, 1);
+        let mut req = env.req_begin_block(3, 1);
         req.mut_header().set_time(seconds_to_timestamp(
             state.block_time + top_level.network_params.get_rewards_reward_period_seconds(),
         ));
-        req.set_last_commit_info(env.last_commit_info_signed());
         app.begin_block(&req);
         app.end_block(&RequestEndBlock::new());
         app.commit(&RequestCommit::new());

--- a/chain-abci/src/staking/table.rs
+++ b/chain-abci/src/staking/table.rs
@@ -80,18 +80,18 @@ impl Into<ValidatorSortKey> for &mut StakedState {
 
 /// StakedState indexes, and other tracking data structures.
 /// The heap of records are stored outside.
-/// Primary key is `StakedStateAddress`, secodary index reference the primary key.
+/// Primary key is `StakedStateAddress`, secondary index reference the primary key.
 ///
-/// Invarient 2.1: The secondary indexes should always be consistent with the heap
+/// Invariant 2.1: The secondary indexes should always be consistent with the heap
 ///
-/// Invarient 2.2:
+/// Invariant 2.2:
 ///   All the secondary indexes should be partial index with condition `validator is not null`
 ///   This shouldn't be prone to DoS as long as minimum required stake is high enough.
 ///   Combined with 2.1, it means that all addresses recorded in `idx_*` should also exist on heap,
 ///   and have validator record;
 ///   Proof: always update index when validator record created or removed.
 ///
-/// Invarient 2.3:
+/// Invariant 2.3:
 ///   Key set of `liveness` should be the same as addresses in `idx_*`.
 ///   Combined with 2.1, it means that all liveness tracking addresses should exist on heap, and have
 ///   validator record.
@@ -101,7 +101,7 @@ pub struct StakingTable {
     // Selected validator voting powers of last executed end block
     chosen_validators: BTreeMap<StakedStateAddress, TendermintVotePower>,
     liveness: BTreeMap<StakedStateAddress, LivenessTracker>,
-    proposer_stats: BTreeMap<StakedStateAddress, u64>,
+    participator_stats: BTreeMap<StakedStateAddress, u64>,
 
     // Call `initialize` to populate the indexes after deserialized.
     // Keep the recent value of minimal_required_staking to do sanity check on validator states.
@@ -190,19 +190,18 @@ impl StakingTable {
     }
 
     /// Handle reward statistics record
-    /// TODO change to vote statistics
     pub fn reward_record(
         &mut self,
         heap: &impl GetStaking,
         val_addr: &TendermintValidatorAddress,
     ) -> bool {
         if let Some(addr) = self.idx_validator_address.get(val_addr) {
-            // Invarient 2.1
+            // Invariant 2.1
             let staking = heap.get(addr).unwrap();
-            // Invarient 2.2
+            // Invariant 2.2
             let val = staking.validator.as_ref().unwrap();
             if val.is_active() {
-                self.proposer_stats
+                self.participator_stats
                     .entry(*addr)
                     .and_modify(|count| *count = count.saturating_add(1))
                     .or_insert(1);
@@ -230,7 +229,7 @@ impl StakingTable {
         heap: &mut impl StoreStaking,
         total_rewards: Coin,
     ) -> (Coin, RewardsDistribution) {
-        let total_blocks = self.proposer_stats.iter().map(|(_, count)| count).sum();
+        let total_blocks = self.participator_stats.iter().map(|(_, count)| count).sum();
         if total_blocks == 0 {
             return (total_rewards, vec![]);
         }
@@ -239,7 +238,7 @@ impl StakingTable {
 
         let mut distributed = Vec::new();
         let mut remainder = total_rewards;
-        let stats = std::mem::take(&mut self.proposer_stats);
+        let stats = std::mem::take(&mut self.participator_stats);
         for (addr, count) in stats.into_iter() {
             let mut staking = self.get_or_default(heap, &addr);
             let amount = (share * count).unwrap();
@@ -448,7 +447,7 @@ impl StakingTable {
             }
             assert!(self.idx_sort.remove(&(&staking).into()));
             assert!(self.liveness.remove(addr).is_some());
-            self.proposer_stats.remove(addr);
+            self.participator_stats.remove(addr);
 
             staking.validator = None;
             set_staking(heap, staking, self.minimal_required_staking);
@@ -532,7 +531,7 @@ impl StakingTable {
                         block_height,
                         params.get_unbonding_period() as Timespec,
                     );
-                    self.proposer_stats.remove(addr);
+                    self.participator_stats.remove(addr);
                     slashes.push((*addr, PunishmentKind::ByzantineFault));
                     set_staking(heap, staking, self.minimal_required_staking);
                 }

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -367,14 +367,28 @@ impl ChainEnv {
         }
     }
 
-    pub fn req_begin_block(&self, height: i64, proposed_by: usize) -> RequestBeginBlock {
+    pub fn req_begin_block(&self, height: i64, signed_by: usize) -> RequestBeginBlock {
         RequestBeginBlock {
             header: Some(Header {
                 time: Some(Timestamp::new()).into(),
                 chain_id: TEST_CHAIN_ID.to_owned(),
                 height,
-                proposer_address: Into::<[u8; 20]>::into(&self.validator_address(proposed_by))
-                    .to_vec(),
+                ..Default::default()
+            })
+            .into(),
+            last_commit_info: Some(LastCommitInfo {
+                round: 1,
+                votes: vec![VoteInfo {
+                    signed_last_block: true,
+                    validator: Some(Validator {
+                        address: Into::<[u8; 20]>::into(&self.validator_address(signed_by))
+                            .to_vec(),
+                        ..Default::default()
+                    })
+                    .into(),
+                    ..Default::default()
+                }]
+                .into(),
                 ..Default::default()
             })
             .into(),
@@ -385,7 +399,7 @@ impl ChainEnv {
     pub fn req_begin_block_with_time(
         &self,
         height: i64,
-        proposed_by: usize,
+        signed_by: usize,
         time_sec: i64,
     ) -> RequestBeginBlock {
         RequestBeginBlock {
@@ -397,8 +411,22 @@ impl ChainEnv {
                 .into(),
                 chain_id: TEST_CHAIN_ID.to_owned(),
                 height,
-                proposer_address: Into::<[u8; 20]>::into(&self.validator_address(proposed_by))
-                    .to_vec(),
+                ..Default::default()
+            })
+            .into(),
+            last_commit_info: Some(LastCommitInfo {
+                round: 1,
+                votes: vec![VoteInfo {
+                    signed_last_block: true,
+                    validator: Some(Validator {
+                        address: Into::<[u8; 20]>::into(&self.validator_address(signed_by))
+                            .to_vec(),
+                        ..Default::default()
+                    })
+                    .into(),
+                    ..Default::default()
+                }]
+                .into(),
                 ..Default::default()
             })
             .into(),


### PR DESCRIPTION
Currently, rewards are distributed based on the block proposer, which is unfair for other validators participating in voting process for that block. This PR changes rewards distribution based on the validators who signed the last block.

Fixes #1141.

Work in progress:
- [ ] Fix integration tests