### PR TITLE
 Problem: Unfair rewards distribution

### DIFF
--- a/chain-abci/src/app/rewards.rs
+++ b/chain-abci/src/app/rewards.rs
@@ -116,6 +116,7 @@ mod tests {
         req.mut_header().set_time(seconds_to_timestamp(
             state.block_time + top_level.network_params.get_rewards_reward_period_seconds(),
         ));
+        req.set_last_commit_info(env.last_commit_info_signed_by(0));
         app.begin_block(&req);
         app.end_block(&RequestEndBlock::new());
         app.commit(&RequestCommit::new());
@@ -142,7 +143,7 @@ mod tests {
         req.mut_header().set_time(seconds_to_timestamp(
             state.block_time + top_level.network_params.get_rewards_reward_period_seconds(),
         ));
-        req.set_last_commit_info(env.last_commit_info_signed());
+        req.set_last_commit_info(env.last_commit_info_signed_by(1));
         app.begin_block(&req);
         app.end_block(&RequestEndBlock::new());
         app.commit(&RequestCommit::new());

--- a/chain-abci/tests/validator_changes.rs
+++ b/chain-abci/tests/validator_changes.rs
@@ -165,7 +165,9 @@ fn check_rejoin() {
     let tm_address = &env.validator_address(0);
     let staking_address = *state.staking_table.lookup_address(&tm_address).unwrap();
     // Begin Block
-    app.begin_block(&env.req_begin_block(1, 0));
+    let mut req = env.req_begin_block(1, 0);
+    req.set_last_commit_info(env.last_commit_info_signed_by(0));
+    app.begin_block(&req);
 
     // Unbond Transaction (this'll change voting power to zero)
     let amount = Coin::one();

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -385,6 +385,8 @@ impl ChainEnv {
     }
 
     pub fn last_commit_info(&self, index: usize, signed_last_block: bool) -> LastCommitInfo {
+        let power: TendermintVotePower = self.share().into();
+
         LastCommitInfo {
             votes: self
                 .accounts
@@ -393,6 +395,7 @@ impl ChainEnv {
                 .map(|(i, _)| VoteInfo {
                     validator: Some(Validator {
                         address: <[u8; 20]>::from(&self.validator_address(i)).to_vec(),
+                        power: power.into(),
                         ..Default::default()
                     })
                     .into(),
@@ -405,6 +408,8 @@ impl ChainEnv {
     }
 
     pub fn last_commit_info_signed(&self) -> LastCommitInfo {
+        let power: TendermintVotePower = self.share().into();
+
         LastCommitInfo {
             votes: self
                 .accounts
@@ -413,6 +418,7 @@ impl ChainEnv {
                 .map(|(i, _)| VoteInfo {
                     validator: Some(Validator {
                         address: <[u8; 20]>::from(&self.validator_address(i)).to_vec(),
+                        power: power.into(),
                         ..Default::default()
                     })
                     .into(),
@@ -420,6 +426,25 @@ impl ChainEnv {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
+        }
+    }
+
+    pub fn last_commit_info_signed_by(&self, signed_by: usize) -> LastCommitInfo {
+        let power: TendermintVotePower = self.share().into();
+
+        LastCommitInfo {
+            votes: vec![VoteInfo {
+                signed_last_block: true,
+                validator: Some(Validator {
+                    power: power.into(),
+                    address: Into::<[u8; 20]>::into(&self.validator_address(signed_by)).to_vec(),
+                    ..Default::default()
+                })
+                .into(),
+                ..Default::default()
+            }]
+            .into(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Currently, rewards are distributed based on the block proposer, which is unfair for other validators participating in voting process for that block. This PR changes rewards distribution based on the validators who signed the last block.

Fixes #1141.