### PR TITLE
Problem: no progess api in sync rpc #1440

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v0.4.0
 
 ### Breaking changes
+* *client-rpc* [1443](https://github.com/crypto-com/chain/pull/1443): add progress, and multi-thread to sync api
 * *chain-abci* [1239](https://github.com/crypto-com/chain/pull/1239): basic versioning
 * *chain-abci* [1090](https://github.com/crypto-com/chain/pull/1090): upper bounds of reward parameters changed
 * *chain-abci* [1100](https://github.com/crypto-com/chain/pull/1100): account nonce increased after reward distribution

--- a/client-rpc/src/rpc.rs
+++ b/client-rpc/src/rpc.rs
@@ -1,5 +1,6 @@
 pub mod multisig_rpc;
 pub mod staking_rpc;
 pub mod sync_rpc;
+pub mod sync_worker;
 pub mod transaction_rpc;
 pub mod wallet_rpc;

--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -1,6 +1,5 @@
-use jsonrpc_core::Result;
-use jsonrpc_derive::rpc;
-
+use super::sync_worker::SyncWorker;
+use super::sync_worker::WorkerShared;
 use crate::server::to_rpc_error;
 use client_common::tendermint::Client;
 use client_common::Storage;
@@ -9,11 +8,16 @@ use client_core::wallet::syncer::ProgressReport;
 use client_core::wallet::syncer::{ObfuscationSyncerConfig, WalletSyncer};
 use client_core::wallet::WalletRequest;
 use client_core::TransactionObfuscation;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::Mutex;
-
+use std::thread;
+// seconds
+const NOTIFICATION_TIME: u64 = 2;
 pub trait CBindingCallback: Send + Sync {
-    fn progress(&self, current: u64, start: u64, end: u64) -> i32;
+    fn progress(&mut self, current: u64, start: u64, end: u64) -> i32;
     fn set_user(&mut self, user: u64);
     fn get_user(&self) -> u64;
 }
@@ -23,16 +27,47 @@ pub struct CBindingCore {
     pub data: Arc<Mutex<dyn CBindingCallback>>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct RunSyncResult {
+    name: String,
+    message: String,
+    progress: RunSyncProgressResult,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct RunSyncProgressResult {
+    pub name: String,
+    pub message: String,
+    pub percent: f32,
+    pub current: u64,
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SyncRequest {
+    blocking: bool,
+    reset: bool,
+    do_loop: bool,
+}
+
+impl Default for SyncRequest {
+    fn default() -> Self {
+        Self {
+            blocking: true,
+            reset: false,
+            do_loop: false,
+        }
+    }
+}
+
 #[rpc]
 pub trait SyncRpc: Send + Sync {
     #[rpc(name = "sync")]
-    fn sync(&self, request: WalletRequest) -> Result<()>;
+    fn sync(&self, request: WalletRequest, sync_reqeust: SyncRequest) -> Result<RunSyncResult>;
 
-    #[rpc(name = "sync_all")]
-    fn sync_all(&self, request: WalletRequest) -> Result<()>;
-
-    #[rpc(name = "sync_unlockWallet")]
-    fn sync_unlock_wallet(&self, request: WalletRequest) -> Result<()>;
+    #[rpc(name = "sync_progress")]
+    fn sync_progress(&self, request: WalletRequest) -> Result<RunSyncProgressResult>;
 
     #[rpc(name = "sync_stop")]
     fn sync_stop(&self, request: WalletRequest) -> Result<()>;
@@ -47,6 +82,153 @@ where
     config: ObfuscationSyncerConfig<S, C, O>,
     polling_synchronizer: PollingSynchronizer,
     progress_callback: Option<CBindingCore>,
+    worker: WorkerShared,
+}
+
+fn process_sync<S, C, O>(
+    config: ObfuscationSyncerConfig<S, C, O>,
+    request: WalletRequest,
+    reset: bool,
+    progress_callback: Option<CBindingCore>,
+) -> Result<()>
+where
+    S: Storage,
+    C: Client,
+    O: TransactionObfuscation,
+{
+    let syncer = WalletSyncer::with_obfuscation_config(config, request.name, request.enckey)
+        .map_err(to_rpc_error)?;
+    if reset {
+        syncer.reset_state().map_err(to_rpc_error)?;
+    }
+
+    if progress_callback.is_none() {
+        return syncer.sync(|_| true).map_err(to_rpc_error);
+    }
+
+    let mut init_block_height = 0;
+    let mut final_block_height = 0;
+    syncer
+        .sync(|report: ProgressReport| -> bool {
+            match report {
+                ProgressReport::Init {
+                    start_block_height,
+                    finish_block_height,
+                    ..
+                } => {
+                    init_block_height = start_block_height;
+                    final_block_height = finish_block_height;
+                    if let Some(delegator) = &progress_callback {
+                        {
+                            let mut user_callback =
+                                delegator.data.lock().expect("get cbinding callback");
+                            user_callback.progress(0, init_block_height, final_block_height);
+                            return true;
+                        }
+                    }
+                    true
+                }
+                ProgressReport::Update {
+                    current_block_height,
+                    ..
+                } => {
+                    if let Some(delegator) = &progress_callback {
+                        {
+                            let mut user_callback =
+                                delegator.data.lock().expect("get cbinding callback");
+                            return 1
+                                == user_callback.progress(
+                                    current_block_height,
+                                    init_block_height,
+                                    final_block_height,
+                                );
+                        }
+                    }
+                    true
+                }
+            }
+        })
+        .map_err(to_rpc_error)
+}
+
+impl<S, C, O> SyncRpcImpl<S, C, O>
+where
+    S: Storage + 'static,
+    C: Client + 'static,
+    O: TransactionObfuscation + 'static,
+{
+    fn do_run_sync(
+        &self,
+        request: WalletRequest,
+        reset: bool,
+        do_loop: bool,
+    ) -> Result<RunSyncResult> {
+        log::info!("run_sync");
+        let config = self.config.clone();
+
+        let name = request.name.clone();
+        let worker = self.worker.clone();
+        let userrequest = request.clone();
+
+        let progress = worker
+            .lock()
+            .expect("get sync worker lock")
+            .get_progress(&name);
+        if let Ok(value) = progress {
+            return Ok(RunSyncResult {
+                message: "already syncing wallet".to_string(),
+                name: request.name,
+                progress: value,
+            });
+        }
+
+        thread::spawn(move || {
+            let localworker = worker;
+            localworker.lock().expect("get sync worker lock").add(&name);
+            let node = localworker.lock().expect("get sync worker lock").get(&name);
+            let syncnode = node.expect("get progress callback");
+            let usercallback = Some(CBindingCore { data: syncnode });
+            loop {
+                let result = process_sync(
+                    config.clone(),
+                    userrequest.clone(),
+                    reset,
+                    usercallback.clone(),
+                );
+                log::info!("process_sync finished {} {:?}", name, result);
+                if result.is_err() {
+                    break;
+                }
+
+                if localworker
+                    .lock()
+                    .expect("get sync worker lock")
+                    .get_stop(&name)
+                {
+                    break;
+                }
+
+                // notify
+                log::info!("wait for notification {}", name);
+                std::thread::sleep(std::time::Duration::from_secs(NOTIFICATION_TIME));
+
+                if !do_loop {
+                    break;
+                }
+            }
+            localworker
+                .lock()
+                .expect("get sync worker lock")
+                .remove(&name);
+            log::info!("sync thread finished {}", name);
+        });
+
+        Ok(RunSyncResult {
+            message: "started sync wallet".to_string(),
+            name: request.name,
+            progress: RunSyncProgressResult::default(),
+        })
+    }
 }
 
 impl<S, C, O> SyncRpc for SyncRpcImpl<S, C, O>
@@ -56,26 +238,35 @@ where
     O: TransactionObfuscation + 'static,
 {
     #[inline]
-    fn sync(&self, request: WalletRequest) -> Result<()> {
-        self.do_sync(request, false)
+    fn sync(&self, request: WalletRequest, sync_request: SyncRequest) -> Result<RunSyncResult> {
+        log::info!("sync {:?}", sync_request);
+        if sync_request.blocking {
+            process_sync(
+                self.config.clone(),
+                request,
+                sync_request.reset,
+                self.progress_callback.clone(),
+            )?;
+            Ok(RunSyncResult::default())
+        } else {
+            self.do_run_sync(request, sync_request.reset, sync_request.do_loop)
+        }
     }
 
     #[inline]
-    fn sync_all(&self, request: WalletRequest) -> Result<()> {
-        self.do_sync(request, true)
-    }
-
-    #[inline]
-    fn sync_unlock_wallet(&self, request: WalletRequest) -> Result<()> {
-        self.polling_synchronizer
-            .add_wallet(request.name, request.enckey);
-        Ok(())
+    fn sync_progress(&self, request: WalletRequest) -> Result<RunSyncProgressResult> {
+        self.worker
+            .lock()
+            .expect("get sync worker lock")
+            .get_progress(&request.name)
     }
 
     #[inline]
     fn sync_stop(&self, request: WalletRequest) -> Result<()> {
-        self.polling_synchronizer.remove_wallet(&request.name);
-        Ok(())
+        self.worker
+            .lock()
+            .expect("get sync worker lock")
+            .stop(&request.name)
     }
 }
 
@@ -96,67 +287,8 @@ where
             config,
             polling_synchronizer,
             progress_callback,
+            worker: Arc::new(Mutex::new(SyncWorker::new())),
         }
-    }
-
-    fn do_sync(&self, request: WalletRequest, reset: bool) -> Result<()> {
-        let syncer = WalletSyncer::with_obfuscation_config(
-            self.config.clone(),
-            request.name,
-            request.enckey,
-        )
-        .map_err(to_rpc_error)?;
-        if reset {
-            syncer.reset_state().map_err(to_rpc_error)?;
-        }
-
-        if self.progress_callback.is_none() {
-            return syncer.sync(|_| true).map_err(to_rpc_error);
-        }
-
-        let mut init_block_height = 0;
-        let mut final_block_height = 0;
-        syncer
-            .sync(|report: ProgressReport| -> bool {
-                match report {
-                    ProgressReport::Init {
-                        start_block_height,
-                        finish_block_height,
-                        ..
-                    } => {
-                        init_block_height = start_block_height;
-                        final_block_height = finish_block_height;
-                        if let Some(delegator) = &self.progress_callback {
-                            {
-                                let user_callback =
-                                    delegator.data.lock().expect("get cbinding callback");
-                                user_callback.progress(0, init_block_height, final_block_height);
-                                return true;
-                            }
-                        }
-                        true
-                    }
-                    ProgressReport::Update {
-                        current_block_height,
-                        ..
-                    } => {
-                        if let Some(delegator) = &self.progress_callback {
-                            {
-                                let user_callback =
-                                    delegator.data.lock().expect("get cbinding callback");
-                                return 1
-                                    == user_callback.progress(
-                                        current_block_height,
-                                        init_block_height,
-                                        final_block_height,
-                                    );
-                            }
-                        }
-                        true
-                    }
-                }
-            })
-            .map_err(to_rpc_error)
     }
 }
 

--- a/client-rpc/src/rpc/sync_worker.rs
+++ b/client-rpc/src/rpc/sync_worker.rs
@@ -1,0 +1,144 @@
+use super::sync_rpc::{CBindingCallback, RunSyncProgressResult};
+use crate::server::rpc_error_from_string;
+use jsonrpc_core::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Instant;
+pub struct SyncWorkerNode {
+    pub user_data: u64,
+    pub progress: RunSyncProgressResult,
+    pub stop: bool,
+    counter: Instant,
+}
+impl SyncWorkerNode {
+    fn new(name: &str) -> Self {
+        let mut ret = SyncWorkerNode {
+            progress: RunSyncProgressResult::default(),
+            user_data: 0,
+            stop: false,
+            counter: Instant::now(),
+        };
+        ret.progress.name = name.to_string();
+        ret
+    }
+    fn set_stop(&mut self, flag: bool) {
+        log::info!("stop sync wallet {} flag {}", self.progress.name, flag);
+        self.stop = flag;
+    }
+}
+
+impl CBindingCallback for SyncWorkerNode {
+    fn set_user(&mut self, user: u64) {
+        self.user_data = user;
+    }
+
+    fn get_user(&self) -> u64 {
+        self.user_data
+    }
+
+    fn progress(&mut self, current: u64, start: u64, end: u64) -> i32 {
+        let rate = if current >= start && end > start {
+            let gap: f32 = (end - start) as f32;
+            ((current - start) as f32) / gap * 100.0
+        } else {
+            0.0
+        };
+
+        let status: String;
+        if current == end || self.counter.elapsed().as_millis() > 250 {
+            status = format!(
+                "sync {} progress {} percent  {} {}~{}",
+                self.progress.name, rate, current, start, end
+            );
+            log::info!("{}", status);
+            self.counter = Instant::now();
+        } else {
+            status = format!(
+                "sync {} progress {} percent  {} {}~{}",
+                self.progress.name, rate, current, start, end
+            );
+            log::debug!("{}", status);
+        }
+
+        self.progress.percent = rate;
+        self.progress.current = current;
+        self.progress.start = start;
+        self.progress.end = end;
+        self.progress.message = status;
+
+        // OK
+        if self.stop {
+            0 // stop
+        } else {
+            1 // cotninue
+        }
+    }
+}
+pub type NodeShared = Arc<Mutex<SyncWorkerNode>>;
+
+#[derive(Default)]
+pub struct SyncWorker {
+    works: HashMap<String, NodeShared>,
+}
+
+impl SyncWorker {
+    pub fn new() -> Self {
+        SyncWorker {
+            works: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<NodeShared> {
+        if let Some(value) = self.works.get(name) {
+            Some(value.clone())
+        } else {
+            None
+        }
+    }
+    pub fn add(&mut self, newthread: &str) {
+        self.works.insert(
+            newthread.to_string(),
+            Arc::new(Mutex::new(SyncWorkerNode::new(newthread))),
+        );
+        log::info!("add sync thread {} total {}", newthread, self.works.len());
+    }
+    pub fn remove(&mut self, removethread: &str) {
+        self.works.remove(removethread);
+        log::info!(
+            "remove sync thread {} total {}",
+            removethread,
+            self.works.len()
+        );
+    }
+    pub fn get_progress(&self, key: &str) -> Result<RunSyncProgressResult> {
+        if let Some(value) = self.works.get(key) {
+            Ok(value.lock().unwrap().progress.clone())
+        } else {
+            Err(rpc_error_from_string(
+                "wallet is not running sync".to_owned(),
+            ))
+        }
+    }
+
+    pub fn stop(&self, key: &str) -> Result<()> {
+        if let Some(value) = self.works.get(key) {
+            value.lock().unwrap().set_stop(true);
+            Ok(())
+        } else {
+            Err(rpc_error_from_string(
+                "wallet is not running sync".to_owned(),
+            ))
+        }
+    }
+
+    pub fn get_stop(&self, key: &str) -> bool {
+        if let Some(value) = self.works.get(key) {
+            value.lock().unwrap().stop
+        } else {
+            true
+        }
+    }
+}
+
+pub type WorkerShared = Arc<Mutex<SyncWorker>>;

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -138,7 +138,7 @@ impl CBindingCallback for CBindingData {
         self.user_data
     }
 
-    fn progress(&self, current: u64, start: u64, end: u64) -> i32 {
+    fn progress(&mut self, current: u64, start: u64, end: u64) -> i32 {
         let back = &self.progress_callback;
         (back)(
             current,

--- a/integration-tests/bot/chainrpc.py
+++ b/integration-tests/bot/chainrpc.py
@@ -158,13 +158,13 @@ class Wallet(BaseService):
             to_address, str(amount), view_keys or [])
 
     def sync(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync', [name, enckey or get_enckey()])
+        return self.call('sync', [name, enckey or get_enckey()],{"blocking":True, "reset":False, "do_loop":False})
 
     def sync_all(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync_all', [name, enckey or get_enckey()])
+        return self.call('sync', [name, enckey or get_enckey()],{"blocking":True, "reset":True, "do_loop":False})
 
     def sync_unlock(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync_unlockWallet', [name, enckey or get_enckey()])
+        return self.call('sync', [name, enckey or get_enckey()],{"blocking":False, "reset":False, "do_loop":True})
 
     def sync_stop(self, name=DEFAULT_WALLET, enckey=None):
         return self.call('sync_stop', [name, enckey or get_enckey()])

--- a/integration-tests/client-rpc/test/core/rpc.ts
+++ b/integration-tests/client-rpc/test/core/rpc.ts
@@ -7,7 +7,11 @@ export const syncWallet = async (
 	walletRequest: WalletRequest,
 ): Promise<void> => {
 	console.log(`[Log] Synchronizing wallet "${walletRequest.name}"`);
-	await rpcClient.request("sync", [walletRequest]);
+	await rpcClient.request("sync", [walletRequest, {
+		blocking: true,
+		reset: false,
+		do_loop: false,
+	}]);
 };
 
 // Continuously check for TxId existence until found

--- a/integration-tests/client-rpc/test/hdrestore-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/hdrestore-auto-sync.test.ts
@@ -114,8 +114,16 @@ describe("HDWallet Restore Auto-sync", () => {
 			"Error when waiting transfer transaction confirmation",
 		);
 
-		await zeroFeeRpcClient.request("sync_unlockWallet", [senderWalletRequest]);
-		await zeroFeeRpcClient.request("sync_unlockWallet", [receiverWalletRequest]);
+		await zeroFeeRpcClient.request("sync", [senderWalletRequest, {
+			blocking: false,
+			reset: false,
+			do_loop: false,
+		}]);
+		await zeroFeeRpcClient.request("sync", [receiverWalletRequest, {
+			blocking: false,
+			reset: false,
+			do_loop: false,
+		}]);
 		console.info(
 			`[Log] Enabled auto-sync for wallets "${senderWalletRequest.name}" and "${receiverWalletName}"`,
 		);

--- a/integration-tests/client-rpc/test/hdwallet-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/hdwallet-auto-sync.test.ts
@@ -113,8 +113,16 @@ describe("HDWallet Auto-sync", () => {
 			"Error when waiting transfer transaction confirmation",
 		);
 
-		await zeroFeeRpcClient.request("sync_unlockWallet", [senderWalletRequest]);
-		await zeroFeeRpcClient.request("sync_unlockWallet", [receiverWalletRequest]);
+		await zeroFeeRpcClient.request("sync", [senderWalletRequest,{
+			blocking: false,
+			reset: false,
+			do_loop: false,
+		}]);
+		await zeroFeeRpcClient.request("sync", [receiverWalletRequest,{
+			blocking: false,
+			reset: false,
+			do_loop: false,
+		}]);
 		console.info(
 			`[Log] Enabled auto-sync for wallets "${senderWalletRequest.name}" and "${receiverWalletName}"`,
 		);

--- a/integration-tests/client-rpc/test/wallet-auto-sync.test.ts
+++ b/integration-tests/client-rpc/test/wallet-auto-sync.test.ts
@@ -113,8 +113,16 @@ describe("Wallet Auto-sync", () => {
 			"Error when waiting transfer transaction confirmation",
 		);
 
-		await zeroFeeRpcClient.request("sync_unlockWallet", [senderWalletRequest]);
-		await zeroFeeRpcClient.request("sync_unlockWallet", [receiverWalletRequest]);
+		await zeroFeeRpcClient.request("sync", [senderWalletRequest,{
+			blocking: false,
+			reset: false,
+			do_loop: false,
+		}]);
+		await zeroFeeRpcClient.request("sync", [receiverWalletRequest,{
+			blocking: false,
+			reset: false,
+			do_loop: false,
+		}]);
 		console.info(
 			`[Log] Enabled auto-sync for wallets "${senderWalletRequest.name}" and "${receiverWalletName}"`,
 		);

--- a/integration-tests/pytests/test_wallet_offline.py
+++ b/integration-tests/pytests/test_wallet_offline.py
@@ -93,12 +93,26 @@ def test_wallet_offline():
     time.sleep(2)
     print("transfer address: ", transfer_address_watchonly)
     enckey_default = rpc.wallet.enckey()
-    print("default enckey:", enckey_default)
+    loop=0
+    current_balance = rpc.wallet.balance()
+    start=time.time();
+    while int(current_balance["pending"]) != 0 and loop < 60:
+        rpc.wallet.sync()
+        current_balance = rpc.wallet.balance()
+        time.sleep(1)
+        loop += 1     
+    end=time.time()
+    elapsed = end - start
+    assert 0==int(current_balance["pending"])
+    assert int(current_balance["available"]) > 0
+    current_balance=rpc.wallet.balance();
+    print("current balance: ", current_balance)    
+    print("waited time for sync: ", elapsed);
     wait_for_tx(rpc, rpc.wallet.send(to_address=transfer_address_watchonly,
                                      amount=amount,
-                                     view_keys=[view_key_offline]))
-    rpc.wallet.sync()
-    rpc.wallet.sync(name=name_watchonly, enckey = enckey_watchonly)
+                                     view_keys=[view_key_offline]))    
+    rpc.wallet.sync()    
+    rpc.wallet.sync(name=name_watchonly, enckey = enckey_watchonly)    
 
     balance_watchonly1 = rpc.wallet.balance(name_watchonly, enckey=enckey_watchonly)
     print("balance watchonly", balance_watchonly1)


### PR DESCRIPTION
Solution: add asynchronous SYNC and  get_progress api
currently, when we sync with testnet, it took a lot of time.
so "run_sync" is added, sync is now can be done in multi-threaded,
for each wallet, one thread can be activated.

by run_sync_progress, we can get current progress.

moved current sync code by using spawning thread,
to get information, i used Arc and Mutex

React, or Angular now can poll via "run_sync_progress", update UI
when it's done, can close the progress UI.

"sync" api will behave exactly the same as before.



