### PR TITLE
Problem (Fix #1436): Performance of merkle library is not clear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,10 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -425,6 +428,15 @@ name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "cbindgen"
@@ -538,6 +550,7 @@ dependencies = [
  "bit-vec 0.6.1",
  "blake3",
  "chain-core",
+ "criterion",
  "integer-encoding",
  "jellyfish-merkle",
  "kvdb",
@@ -869,6 +882,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.8.2",
+ "lazy_static",
+ "num-traits 0.2.11",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+dependencies = [
+ "cast",
+ "itertools 0.8.2",
+]
+
+[[package]]
 name = "cro-clib"
 version = "0.4.0"
 dependencies = [
@@ -973,6 +1021,28 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
  "subtle 1.0.0",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2592,6 +2662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,6 +2921,18 @@ name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+
+[[package]]
+name = "plotters"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
+dependencies = [
+ "js-sys",
+ "num-traits 0.2.11",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "polyval"
@@ -3270,6 +3358,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+dependencies = [
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3438,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3562,6 +3683,15 @@ name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -4363,6 +4493,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,6 +5061,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.8",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -236,8 +236,8 @@ impl InitConfig {
         }
 
         let accounts = self.get_account(genesis_time);
+        #[cfg(debug_assertions)]
         for staking in accounts.iter() {
-            #[cfg(debug_assertions)]
             staking.check_invariants(self.network_params.required_council_node_stake);
         }
         let rewards_pool = RewardsPoolState::new(

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -20,3 +20,8 @@ jellyfish-merkle = { git = "https://github.com/crypto-com/jellyfish-merkle-tree.
 
 [dev-dependencies]
 quickcheck = "0.9"
+criterion = "0.3"
+
+[[bench]]
+name = "jellyfish"
+harness = false

--- a/chain-storage/benches/jellyfish.rs
+++ b/chain-storage/benches/jellyfish.rs
@@ -1,0 +1,92 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+use chain_core::state::account::{StakedState, StakedStateAddress};
+use chain_storage::buffer::MemStore;
+use chain_storage::jellyfish::{get_with_proof, put_stakings, Version};
+
+fn bench_insert_256(b: &mut Bencher) {
+    let stakings = (0x00u8..=0x0fu8)
+        .map(|version| {
+            (0x00u8..=0x0fu8)
+                .map(|i| {
+                    let mut seed = [0; 20];
+                    seed[0] = version;
+                    seed[1] = i;
+                    StakedState::default(StakedStateAddress::BasicRedeem(seed.into()))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    b.iter(|| {
+        let mut store = MemStore::new();
+        for (version, xs) in stakings.iter().enumerate() {
+            put_stakings(&mut store, version as Version, xs.iter())
+                .expect("jellyfish error with in memory storage");
+        }
+    });
+}
+
+fn bench_insert(b: &mut Bencher) {
+    let stakings = (0x00u8..=0x0fu8)
+        .map(|version| {
+            (0x00u8..=0x0fu8)
+                .map(|i| {
+                    let mut seed = [0; 20];
+                    seed[0] = version;
+                    seed[1] = i;
+                    StakedState::default(StakedStateAddress::BasicRedeem(seed.into()))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut store = MemStore::new();
+    for (version, xs) in stakings.iter().enumerate() {
+        put_stakings(&mut store, version as Version, xs.iter())
+            .expect("jellyfish error with in memory storage");
+    }
+    let mut seed = [0; 20];
+    seed[0] = 0x10;
+    let stakings = vec![StakedState::default(StakedStateAddress::BasicRedeem(
+        seed.into(),
+    ))];
+    b.iter(|| {
+        put_stakings(&mut store, 0x10, stakings.iter()).unwrap();
+    });
+}
+
+fn bench_get(b: &mut Bencher) {
+    let stakings = (0x00u8..=0x0fu8)
+        .map(|version| {
+            (0x00u8..=0x0fu8)
+                .map(|i| {
+                    let mut seed = [0; 20];
+                    seed[0] = version;
+                    seed[1] = i;
+                    StakedState::default(StakedStateAddress::BasicRedeem(seed.into()))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut store = MemStore::new();
+    for (version, xs) in stakings.iter().enumerate() {
+        put_stakings(&mut store, version as Version, xs.iter())
+            .expect("jellyfish error with in memory storage");
+    }
+
+    b.iter(|| {
+        get_with_proof(
+            &store,
+            0x0f,
+            &stakings.last().unwrap().last().unwrap().address,
+        );
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("jellyfish, insert 256", bench_insert_256);
+    c.bench_function("jellyfish, insert", bench_insert);
+    c.bench_function("jellyfish, get_with_proof", bench_get);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/chain-storage/examples/bench_jellyfish_disk.rs
+++ b/chain-storage/examples/bench_jellyfish_disk.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+use chain_core::state::account::StakedStateAddress;
+use chain_storage::jellyfish::get_with_proof;
+use chain_storage::NUM_COLUMNS;
+
+fn bench_get(b: &mut Bencher) {
+    let store = kvdb_rocksdb::Database::open(
+        &kvdb_rocksdb::DatabaseConfig::with_columns(NUM_COLUMNS),
+        &std::env::var("DBPATH").unwrap_or("/tmp/db".to_owned()),
+    )
+    .unwrap();
+    let address: StakedStateAddress = std::env::var("STAKING_ADDRESS")
+        .unwrap_or("0000000000000000000000000000000000000000".to_owned())
+        .parse()
+        .unwrap();
+
+    b.iter(|| {
+        get_with_proof(&store, 0, &address);
+    });
+}
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("jellyfish_disk, get_with_proof", bench_get);
+}
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/chain-storage/examples/disk_storage.rs
+++ b/chain-storage/examples/disk_storage.rs
@@ -1,0 +1,35 @@
+use chain_core::state::account::{StakedState, StakedStateAddress};
+use chain_storage::buffer::{flush_kvdb, BufferStore, KVBuffer};
+use chain_storage::jellyfish::{put_stakings, Version};
+use chain_storage::NUM_COLUMNS;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let db_path = args.next().unwrap();
+    let version: u64 = args.next().unwrap().parse().unwrap();
+    let num_stakings: u64 = args.next().unwrap().parse().unwrap();
+    let db = kvdb_rocksdb::Database::open(
+        &kvdb_rocksdb::DatabaseConfig::with_columns(NUM_COLUMNS),
+        &db_path,
+    )
+    .unwrap();
+    let mut buffer = KVBuffer::new();
+
+    for version in 0..version {
+        let stakings = (0..num_stakings)
+            .map(|i| {
+                let mut seed = [0; 20];
+                seed[..8].clone_from_slice(&version.to_le_bytes());
+                seed[8..16].clone_from_slice(&i.to_le_bytes());
+                StakedState::default(StakedStateAddress::BasicRedeem(seed.into()))
+            })
+            .collect::<Vec<_>>();
+        put_stakings(
+            &mut BufferStore::new(&db, &mut buffer),
+            version as Version,
+            stakings.iter(),
+        )
+        .expect("jellyfish error with in memory storage");
+        flush_kvdb(&db, std::mem::take(&mut buffer)).unwrap();
+    }
+}

--- a/chain-storage/examples/jellyfish_nodes.rs
+++ b/chain-storage/examples/jellyfish_nodes.rs
@@ -1,0 +1,90 @@
+use anyhow::{ensure, Result};
+use jellyfish_merkle::{node_type::Node, HashValue, JellyfishMerkleTree};
+use parity_scale_codec::Encode;
+
+use chain_core::common::H256;
+use chain_core::state::account::{StakedState, StakedStateAddress};
+use chain_storage::buffer::{MemStore, StoreKV};
+use chain_storage::jellyfish::{KVReader, Version};
+use chain_storage::COL_TRIE_NODE;
+
+const HELP: &str = "jellyfish_nodes versions stakings";
+
+/// Put stakings into the merkle tree, remove stale nodes immediatelly
+fn put_stakings<'a, S: StoreKV>(
+    storage: &mut S,
+    version: Version,
+    stakings: impl Iterator<Item = &'a StakedState>,
+) -> Result<H256> {
+    let reader = KVReader::new(storage);
+    let tree = JellyfishMerkleTree::new(&reader);
+    let stakings = stakings
+        .map(|staking| (HashValue::new(staking.key()), staking.encode().into()))
+        .collect::<Vec<_>>();
+    ensure!(!stakings.is_empty(), "can't put empty stakings");
+    let (root_hashes, batch) = tree.put_blob_sets(vec![stakings], version)?;
+    assert_eq!(root_hashes.len(), 1);
+    for (key, node) in batch.node_batch.iter() {
+        storage.set((COL_TRIE_NODE, key.encode()?), node.encode()?);
+    }
+    for key in batch.stale_node_index_batch {
+        storage.delete((COL_TRIE_NODE, key.node_key.encode()?));
+    }
+    Ok(*root_hashes[0].as_ref())
+}
+
+fn avg_fill_rate(store: &MemStore<(u32, Vec<u8>), Vec<u8>>) -> f64 {
+    let mut full = 0;
+    let mut num = 0;
+    for v in store.0.values() {
+        let (full_, num_) = match Node::decode(&v).unwrap() {
+            Node::Internal(internal) => (16, internal.num_children()),
+            _ => (0, 0),
+        };
+        full += full_;
+        num += num_;
+    }
+    num as f64 / full as f64
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let version: u64 = match args.next() {
+        Some(arg) => arg.parse().unwrap(),
+        None => {
+            println!("{}", HELP);
+            return;
+        }
+    };
+    let num_stakings: u64 = match args.next() {
+        Some(arg) => arg.parse().unwrap(),
+        None => {
+            println!("{}", HELP);
+            return;
+        }
+    };
+
+    let mut store = MemStore::new();
+    for version in 0..version {
+        let stakings = (0..num_stakings)
+            .map(|i| {
+                let mut seed = [0; 20];
+                seed[..8].clone_from_slice(&version.to_le_bytes());
+                seed[8..16].clone_from_slice(&i.to_le_bytes());
+                StakedState::default(StakedStateAddress::BasicRedeem(seed.into()))
+            })
+            .collect::<Vec<_>>();
+        put_stakings(&mut store, version as Version, stakings.iter())
+            .expect("jellyfish error with in memory storage");
+
+        let leafs = ((version + 1) * num_stakings) as usize;
+        let internals = store.0.len() - leafs;
+        println!(
+            "internal/leaf: {} / {} = {}",
+            internals,
+            leafs,
+            (internals as f64 / leafs as f64)
+        );
+        println!("internal avg fill rate: {}", avg_fill_rate(&store));
+    }
+}

--- a/chain-storage/src/buffer.rs
+++ b/chain-storage/src/buffer.rs
@@ -212,7 +212,7 @@ where
 
 /// Dummy storage implemented with a HashMap in memory.
 #[derive(Debug, Clone)]
-pub struct MemStore<K: Hash + Eq, V>(HashMap<K, V>);
+pub struct MemStore<K: Hash + Eq, V>(pub HashMap<K, V>);
 
 impl<K: Hash + Eq, V> MemStore<K, V> {
     pub fn new() -> Self {


### PR DESCRIPTION
### Benchmark result on laptop

#### Internal node fill rate

10000 stakings per version, commit 1000 versions in memory.

Internal node fill rate: 0.22 - 0.25, when the number of stakings is under 10M.

```
$ cargo run --example jellyfish_nodes -p chain-storage 1000 10000
...
internal/leaf: 65557 / 170000 = 0.3856294117647059
internal avg fill rate: 0.22457174672422472
...
internal/leaf: 807343 / 2060000 = 0.39191407766990294
internal avg fill rate: 0.22197365308177566
...
internal/leaf: 1090517 / 2840000 = 0.3839848591549296
internal avg fill rate: 0.2252667771341483
...
internal/leaf: 3333197 / 10000000 = 0.3333197
internal avg fill rate: 0.2500076503128978
```

#### In memory operations benchmark

```
$ cargo bench -p chain-storage
jellyfish, insert 256   time:   [4.6825 ms 4.6957 ms 4.7107 ms]
jellyfish, insert       time:   [30.993 us 31.144 us 31.313 us]
jellyfish, get_with_proof
                        time:   [15.605 us 15.721 us 15.877 us]
```

#### Disk usage

10000 stakings per version, no pruning.

```
$ cargo run --example disk_storage -p chain-storage /tmp/db 10 10000
$ du -sh /tmp/db
 37M	/tmp/db
$ rm -r /tmp/db
$ cargo run --example disk_storage -p chain-storage /tmp/db 100 10000
$ du -sh /tmp/db
 625M	/tmp/db
```

#### Disk get benchmark

Get staking from db with existing address:

```
$ DBPATH=/tmp/db STAKING_ADDRESS=0000000000000000000000000000000000000000  cargo run --example bench_jellyfish_disk -p chain-storage -- --bench
jellyfish_disk, get_with_proof
                        time:   [505.86 us 511.42 us 517.79 us]
```

Not exist address:
```
$ DBPATH=/tmp/db STAKING_ADDRESS=ffffffffffffffffffffffffffffffffffffffff cargo run --example bench_jellyfish_disk -p chain-storage -- --bench
jellyfish_disk, get_with_proof
                        time:   [370.42 us 375.35 us 383.60 us]
```