### PR TITLE
Problem (WIP #1313): light client doesn't verify the fetched staking state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *Unreleased*
 ## v0.5.0
 ### Breaking changes
+
+- *chain-storage* [1466](https://github.com/crypto-com/chain/pull/1466): add a colume to store historical staking versions
+
 ### Features
 ### Improvements
 ### Bug Fixes

--- a/chain-abci/src/app/app_init.rs
+++ b/chain-abci/src/app/app_init.rs
@@ -67,6 +67,10 @@ impl StoredChainState for ChainNodeState {
     fn get_last_app_hash(&self) -> H256 {
         self.last_apphash
     }
+
+    fn get_staking_version(&self) -> Version {
+        self.staking_version
+    }
 }
 
 impl ChainNodeState {

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -760,8 +760,21 @@ fn query_should_return_an_account() {
     qreq.data = hex::decode(&addr).unwrap();
     qreq.path = "account".into();
     let qresp = app.query(&qreq);
-    let account = StakedState::decode(&mut qresp.value.as_slice());
-    assert!(account.is_ok());
+    let account = StakedState::decode(&mut qresp.value.as_slice()).unwrap();
+    assert_eq!(account.address, StakedStateAddress::from_str(addr).unwrap());
+}
+
+#[test]
+fn staking_query_should_return_an_account() {
+    let addr = "fe7c045110b8dbf29765047380898919c5cb56f9";
+    let mut app = init_chain_for(addr.parse().unwrap());
+    let mut qreq = RequestQuery::new();
+    qreq.data = hex::decode(&addr).unwrap();
+    qreq.path = "staking".into();
+    let qresp = app.query(&qreq);
+    let (account, _): (StakedState, serde_json::Value) =
+        serde_json::from_slice(&qresp.value).unwrap();
+    assert_eq!(account.address, StakedStateAddress::from_str(addr).unwrap());
 }
 
 fn block_commit(app: &mut ChainNodeApp<MockClient>, tx: TxAux, block_height: i64) {

--- a/chain-storage/src/lib.rs
+++ b/chain-storage/src/lib.rs
@@ -29,7 +29,7 @@ pub const COL_NODE_INFO: u32 = 4;
 pub const COL_MERKLE_PROOFS: u32 = 5;
 /// Column for tracking app hashes: height => app hash
 pub const COL_APP_HASHS: u32 = 6;
-/// Column for tracking app states: height => ChainNodeState, only available when tx_query_address set
+/// Column for tracking app states: height => ChainState, only available when tx_query_address set
 pub const COL_APP_STATES: u32 = 7;
 /// Column for sealed transction payload: TxId => sealed tx payload (to MRSIGNER on a particular machine)
 pub const COL_ENCLAVE_TX: u32 = 8;
@@ -37,8 +37,10 @@ pub const COL_ENCLAVE_TX: u32 = 8;
 pub const COL_TRIE_NODE: u32 = 9;
 /// Column for staled node key in merkle trie
 pub const COL_TRIE_STALED: u32 = 10;
+/// Column to store block height -> staking version
+pub const COL_STAKING_VERSIONS: u32 = 11;
 /// Number of columns in DB
-pub const NUM_COLUMNS: u32 = 11;
+pub const NUM_COLUMNS: u32 = 12;
 
 pub const CHAIN_ID_KEY: &[u8] = b"chain_id";
 pub const GENESIS_APP_HASH_KEY: &[u8] = b"genesis_app_hash";
@@ -134,6 +136,8 @@ pub trait StoredChainState {
     fn get_encoded_top_level(&self) -> Vec<u8>;
     /// the last committed application hash
     fn get_last_app_hash(&self) -> H256;
+    /// the staking version
+    fn get_staking_version(&self) -> Version;
 }
 
 #[repr(u32)]
@@ -217,6 +221,10 @@ impl Storage {
 
     pub fn get_historical_state(&self, height: BlockHeight) -> Option<Vec<u8>> {
         get_historical_state(self, height)
+    }
+
+    pub fn get_historical_staking_version(&self, height: BlockHeight) -> Option<Version> {
+        get_historical_staking_version(self, height)
     }
 
     pub fn get_historical_app_hash(&self, height: BlockHeight) -> Option<H256> {


### PR DESCRIPTION
Solution:
- Support query merkle inclusion proof
- Also support query historical staking state
- Query json encoded staking from abci_query directly #1464

This feature(query historical staked state) is also needed to make the reward integration tests more stable.
Added a new abci_query path "staking" which is like "account", but it returns JSON directly, also support the new features (historical query, proof), the next step will be update the "staking_state" API in client-rpc and client-cli to use the new one.