### PR TITLE
Problem (Fix #1475): lite client verifier crash fails occasionally in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.12.0-rc0"
-source = "git+https://github.com/crypto-com/tendermint-rs.git?rev=defa15f676eb4a3fca6c5a896be61fb63df408fc#defa15f676eb4a3fca6c5a896be61fb63df408fc"
+source = "git+https://github.com/crypto-com/tendermint-rs.git?rev=2469450f39c29020e64c2f1c2ee4de8965791b88#2469450f39c29020e64c2f1c2ee4de8965791b88"
 dependencies = [
  "anomaly",
  "async-trait",

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -27,7 +27,7 @@ secstr = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = { version = "0.31.0", optional = true }
-tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "defa15f676eb4a3fca6c5a896be61fb63df408fc" }
+tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "2469450f39c29020e64c2f1c2ee4de8965791b88" }
 tokio = { version = "0.2", features = ["rt-threaded", "sync", "time", "tcp"], optional = true }
 tokio-tungstenite = { version = "0.10", features = ["tls"], optional = true }
 zeroize = "1.1"

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -37,7 +37,7 @@ tiny-bip39 = { version = "0.7", default-features = false }
 unicase = "2.6.0"
 lazy_static = "1.4.0"
 ring = "0.16.12"
-tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "defa15f676eb4a3fca6c5a896be61fb63df408fc" }
+tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "2469450f39c29020e64c2f1c2ee4de8965791b88" }
 thiserror = { version = "1.0", default-features = false }
 non-empty-vec = "0.1"
 zxcvbn = "2.0"

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 hex = "0.4.2"
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "745bc8d8dc80cb921d5788e863a3536d3b6498a1", features = ["recovery"] }
-tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "defa15f676eb4a3fca6c5a896be61fb63df408fc" }
+tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "2469450f39c29020e64c2f1c2ee4de8965791b88" }
 
 [dev-dependencies]
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "745bc8d8dc80cb921d5788e863a3536d3b6498a1", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -22,7 +22,7 @@ parity-scale-codec = { features = ["derive"], version = "1.3" }
 base64 = "0.11"
 hex = "0.4"
 
-tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "defa15f676eb4a3fca6c5a896be61fb63df408fc" }
+tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "2469450f39c29020e64c2f1c2ee4de8965791b88" }
 chain-core = { path = "../chain-core" }
 chain-abci = { path = "../chain-abci" }
 chain-storage = { path = "../chain-storage" }


### PR DESCRIPTION
Solution:
- Fix block_id of empty vote in tendermint-rs