### PR TITLE
Problem (Fix #1478): cargo kcov doesn't run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ rust: &rust
       # a small hack, as kcov doesn't have an option to only build default members
       sed 's/"chain-tx-enclave/#"chain-tx-enclave/g' -i Cargo.toml;
       # more hacks for kcov :(
-      sed 's/default = \[\]/default = \["mock-validation"\]/g' -i chain-abci/Cargo.toml;
+      sed 's/default = \[\]/default = \["mock-enclave"\]/g' -i chain-abci/Cargo.toml;
       sed 's/sgx/#sgx/g' -i chain-abci/Cargo.toml;
       sed 's/enclave-u-common/#enclave-u-common/g' -i chain-abci/Cargo.toml;
       sed 's/CARGO/_CARGO/g' -i chain-abci/build.rs;


### PR DESCRIPTION
Solution:
- "mock-validation" -> "mock-enclave"