### PR TITLE
Problem: (fix #1413) Milli::new and Milli:: integral may overflow

### DIFF
--- a/chain-abci/benches/tx.rs
+++ b/chain-abci/benches/tx.rs
@@ -86,7 +86,10 @@ fn init_chain_for(addresses: &Vec<RedeemAddress>) -> ChainNodeApp {
     );
 
     let params = InitNetworkParameters {
-        initial_fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
+        initial_fee_policy: LinearFee::new(
+            Milli::try_new(1, 1).unwrap(),
+            Milli::try_new(1, 1).unwrap(),
+        ),
         required_council_node_stake: remaining,
         unbonding_period: 1,
     };

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -142,7 +142,10 @@ fn nonhex_hash_should_panic() {
 
 fn get_dummy_network_params() -> NetworkParameters {
     NetworkParameters::Genesis(InitNetworkParameters {
-        initial_fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
+        initial_fee_policy: LinearFee::new(
+            Milli::try_new(1, 1).unwrap(),
+            Milli::try_new(1, 1).unwrap(),
+        ),
         required_council_node_stake: Coin::unit(),
         unbonding_period: 86400,
         jailing_config: JailingParameters {
@@ -319,7 +322,10 @@ fn init_chain_panics_with_different_app_hash() {
     .cloned()
     .collect();
     let params = InitNetworkParameters {
-        initial_fee_policy: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1)),
+        initial_fee_policy: LinearFee::new(
+            Milli::try_new(1, 1).unwrap(),
+            Milli::try_new(1, 1).unwrap(),
+        ),
         required_council_node_stake: Coin::unit(),
         unbonding_period: 1,
         jailing_config: JailingParameters {

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -150,9 +150,12 @@ fn get_address<C: Signing>(
 
 fn get_chain_info(txaux: &TxAux) -> ChainInfo {
     ChainInfo {
-        min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
-            .calculate_for_txaux(&txaux)
-            .expect("invalid fee policy"),
+        min_fee_computed: LinearFee::new(
+            Milli::try_new(1, 1).unwrap(),
+            Milli::try_new(1, 1).unwrap(),
+        )
+        .calculate_for_txaux(&txaux)
+        .expect("invalid fee policy"),
         chain_hex_id: DEFAULT_CHAIN_ID,
         block_time: 0,
         unbonding_period: 1,
@@ -1308,9 +1311,12 @@ fn check_unjail_transaction() {
     let txaux =
         prepare_unjail_transaction(&secret_key, StakedStateAddress::BasicRedeem(address), 1);
     let extra_info = ChainInfo {
-        min_fee_computed: LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
-            .calculate_for_txaux(&TxAux::PublicTx(txaux.clone()))
-            .expect("invalid fee policy"),
+        min_fee_computed: LinearFee::new(
+            Milli::try_new(1, 1).unwrap(),
+            Milli::try_new(1, 1).unwrap(),
+        )
+        .calculate_for_txaux(&TxAux::PublicTx(txaux.clone()))
+        .expect("invalid fee policy"),
         chain_hex_id: DEFAULT_CHAIN_ID,
         block_time: 101,
         block_height: BlockHeight::genesis(),

--- a/chain-abci/tests/validator_changes.rs
+++ b/chain-abci/tests/validator_changes.rs
@@ -154,7 +154,7 @@ fn check_rejoin() {
             parameters.unbonding_period = 3600 * 24 * 10000;
             parameters.rewards_config.reward_period_seconds = 365 * 24 * 3600;
             parameters.required_council_node_stake = (Coin::max() / 4).unwrap();
-            parameters.rewards_config.monetary_expansion_r0 = Milli::new(1, 0);
+            parameters.rewards_config.monetary_expansion_r0 = Milli::try_new(1, 0).unwrap();
             parameters.rewards_config.monetary_expansion_tau = 1000_0000_0000_0000_0000;
             parameters.rewards_config.monetary_expansion_decay = 0;
         },

--- a/chain-core/src/init/params.rs
+++ b/chain-core/src/init/params.rs
@@ -197,7 +197,7 @@ impl RewardsParameters {
     /// check if reward parameters are correct
     /// TODO: hide values and check these in `new` + deserialize/decode?
     pub fn validate(&self) -> Result<(), &'static str> {
-        if self.monetary_expansion_r0 > Milli::integral(1) {
+        if self.monetary_expansion_r0 > Milli::integral(1).unwrap() {
             return Err("R0 can't > 1");
         }
         if self.monetary_expansion_tau == 0 {

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -55,8 +55,8 @@ fn test_verify_test_example_snapshot() {
         };
         dist.insert(account.address, (dest, amount));
     }
-    let constant_fee = Milli::new(1, 25);
-    let coefficient_fee = Milli::new(1, 1);
+    let constant_fee = Milli::try_new(1, 25).unwrap();
+    let coefficient_fee = Milli::try_new(1, 1).unwrap();
     let fee_policy = LinearFee::new(constant_fee, coefficient_fee);
     let expansion_cap = Coin::new(951_6484_5705_9733_7034).unwrap();
     let mut params = InitNetworkParameters {

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -336,7 +336,8 @@ mod default_wallet_transaction_builder_tests {
         let return_address = wallet_client.new_transfer_address(name, &enckey).unwrap();
 
         let signer_manager = WalletSignerManager::new(storage.clone(), HwKeyService::default());
-        let fee_algorithm = LinearFee::new(Milli::new(1, 1), Milli::new(1, 1));
+        let fee_algorithm =
+            LinearFee::new(Milli::try_new(1, 1).unwrap(), Milli::try_new(1, 1).unwrap());
 
         let transaction_builder = DefaultWalletTransactionBuilder::new(
             signer_manager,
@@ -459,7 +460,8 @@ mod default_wallet_transaction_builder_tests {
         let return_address = wallet_client.new_transfer_address(name, &enckey).unwrap();
 
         let signer_manager = WalletSignerManager::new(storage.clone(), HwKeyService::default());
-        let fee_algorithm = LinearFee::new(Milli::new(1, 1), Milli::new(1, 1));
+        let fee_algorithm =
+            LinearFee::new(Milli::try_new(1, 1).unwrap(), Milli::try_new(1, 1).unwrap());
 
         let transaction_builder = DefaultWalletTransactionBuilder::new(
             signer_manager,

--- a/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
+++ b/client-core/src/transaction_builder/raw_transfer_transaction_builder.rs
@@ -1231,7 +1231,7 @@ mod raw_transfer_transaction_builder_tests {
     }
 
     fn create_testing_fee_algorithm() -> LinearFee {
-        LinearFee::new(Milli::new(1, 1), Milli::new(1, 1))
+        LinearFee::new(Milli::try_new(1, 1).unwrap(), Milli::try_new(1, 1).unwrap())
     }
 
     fn create_key_pair_and_transfer_addr() -> (PrivateKey, PublicKey, ExtendedAddr) {

--- a/cro-clib/src/types.rs
+++ b/cro-clib/src/types.rs
@@ -96,7 +96,7 @@ pub struct CroFee {
 
 impl Default for CroFee {
     fn default() -> Self {
-        let fee = LinearFee::new(Milli::new(0, 0), Milli::new(0, 0));
+        let fee = LinearFee::new(Milli::try_new(0, 0).unwrap(), Milli::try_new(0, 0).unwrap());
         CroFee { fee }
     }
 }

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -85,7 +85,10 @@ pub fn create_storage() -> Storage {
 
 pub fn get_init_network_params(expansion_cap: Coin) -> InitNetworkParameters {
     InitNetworkParameters {
-        initial_fee_policy: LinearFee::new(Milli::new(0, 0), Milli::new(0, 0)),
+        initial_fee_policy: LinearFee::new(
+            Milli::try_new(0, 0).unwrap(),
+            Milli::try_new(0, 0).unwrap(),
+        ),
         required_council_node_stake: Coin::unit(),
         unbonding_period: 61,
         jailing_config: JailingParameters {


### PR DESCRIPTION
solution:
* add a `try_new` function, when overflow, return Error.