### PR TITLE
Problem: tx-query not yet ported to EDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,15 +231,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -751,10 +742,11 @@ dependencies = [
  "non-empty-vec",
  "num-bigint 0.2.6",
  "parity-scale-codec",
+ "ra-client",
  "rand 0.7.3",
  "ring 0.16.13",
  "ripemd160",
- "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.17.0",
  "secp256k1zkp",
  "secstr",
  "serde",
@@ -3535,8 +3527,7 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.16.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
+source = "git+https://github.com/crypto-com/ring.git?rev=4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa#4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa"
 dependencies = [
  "cc",
  "libc",
@@ -3586,6 +3577,15 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "rs-libc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ecb2603155fa7473cac8df6f080f06bea5282a7a900dd71d361a351883d4f9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3653,25 +3653,12 @@ name = "rustls"
 version = "0.16.0"
 source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#ce26c885355fde79d45a27a6bbca490d9e8fcc0e"
 dependencies = [
- "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
+ "base64 0.10.1",
  "log 0.4.8 (git+https://github.com/mesalock-linux/log-sgx)",
  "ring 0.16.11",
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
  "sgx_tstd",
  "webpki 0.21.2 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
-]
-
-[[package]]
-name = "rustls"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
-dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.13",
- "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4453,6 +4440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-pool"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521ce173ddcb414aff269069162a767bd6503470f8dbd00cf6b576059b143c94"
+dependencies = [
+ "num_cpus",
+ "two-lock-queue",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,6 +4815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "two-lock-queue"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdabfad4e8dcb814adfc10fbe446a7388a7e0eea8453d419dbc272101dc82fa9"
+
+[[package]]
 name = "tx-query-app"
 version = "0.5.0"
 dependencies = [
@@ -4838,7 +4841,7 @@ dependencies = [
 name = "tx-query-enclave"
 version = "0.5.0"
 dependencies = [
- "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
+ "base64 0.10.1",
  "bit-vec 0.6.1",
  "cc",
  "chain-core",
@@ -4850,7 +4853,7 @@ dependencies = [
  "lazy_static",
  "num-bigint 0.2.5",
  "parity-scale-codec",
- "rustls 0.16.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
+ "rustls 0.16.0",
  "secp256k1zkp",
  "sgx_rand",
  "sgx_tcrypto",
@@ -4883,7 +4886,19 @@ dependencies = [
 name = "tx-query2-enclave-app"
 version = "0.5.0"
 dependencies = [
+ "chain-core",
  "enclave-protocol",
+ "enclave-utils",
+ "env_logger",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec",
+ "ra-enclave",
+ "rand 0.7.3",
+ "rs-libc",
+ "rustls 0.17.0",
+ "secp256k1zkp",
+ "thread-pool",
+ "zeroize",
 ]
 
 [[package]]
@@ -5393,8 +5408,3 @@ dependencies = [
  "quick-error",
  "regex",
 ]
-
-[[patch.unused]]
-name = "ring"
-version = "0.16.12"
-source = "git+https://github.com/crypto-com/ring.git?rev=f9afbd8a6d571f1a726e1bd1610328623622f2c0#f9afbd8a6d571f1a726e1bd1610328623622f2c0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,4 @@ default-members = [
 ]
 
 [patch.crates-io]
-ring = { git = "https://github.com/crypto-com/ring.git", rev = "f9afbd8a6d571f1a726e1bd1610328623622f2c0" }
+ring = { git = "https://github.com/crypto-com/ring.git", rev = "4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa" }

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [features]
 default = ["serde", "bech32", "hex", "base64", "secp256k1zkp/serde", "secp256k1zkp/std"]
+edp = ["secp256k1zkp/edp"]
 mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx"]
 
 

--- a/chain-tx-enclave/enclave-ra/ra-enclave/Cargo.toml
+++ b/chain-tx-enclave/enclave-ra/ra-enclave/Cargo.toml
@@ -26,4 +26,4 @@ ra-sp-client = { path = "../ra-sp-client" }
 
 # Add these lines in workpace Cargo.toml
 # [patch.crates-io]
-# ring = { git = "https://github.com/crypto-com/ring.git", rev = "f9afbd8a6d571f1a726e1bd1610328623622f2c0" }
+# ring = { git = "https://github.com/crypto-com/ring.git", rev = "4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa" }

--- a/chain-tx-enclave/tx-query-next/app-runner/src/main.rs
+++ b/chain-tx-enclave/tx-query-next/app-runner/src/main.rs
@@ -1,129 +1,17 @@
+mod zmq_helper;
+
+use std::env;
+use std::io::Result;
+use std::pin::Pin;
+
 use aesm_client::AesmClient;
-use enclave_protocol::FLAGS;
 use enclave_runner::usercalls::{AsyncStream, UsercallExtension};
 use enclave_runner::EnclaveBuilder;
 use futures::future::{Future, FutureExt};
-use log::{debug, error, info, trace};
+use log::{error, info};
 use sgxs_loaders::isgx::Device as IsgxDevice;
-use std::env;
-use std::io::{Read, Result, Write};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::prelude::Async;
-use tokio::sync::lock::Lock;
-use zmq::{Context, Socket, REQ};
 
-/// temporary bridging between the old code and EDP
-/// in the long term, it may go away completely:
-/// 1) decryption requests may include the sealed payload in them (so no need to request them via zmq)
-/// 2) encryption requests may be done via a direct attested secure channel (instead of this passing of sealed requests)
-struct ZmqStreamHelper {
-    /// lock is there to enforce the synchronous order (tokio async stuff tasks?) + thread-safety (zmq isn't thread safe)
-    /// Vec<u8> -- buffer for writing/reading the response
-    /// AtomicBool -- a flag to denote whether the last message was read/processed
-    /// Socket -- zmq socket
-    ///
-    /// TODO: could this break with multiple enclave threads?
-    /// TODO: could there be deadlocks (enclave code "writes", but never "reads" for one request)?
-    socket: Lock<(Vec<u8>, AtomicBool, Socket)>,
-}
-
-impl ZmqStreamHelper {
-    pub fn new(connection_str: &str) -> Self {
-        let ctx = Context::new();
-        let socket = ctx.socket(REQ).expect("failed to init zmq context");
-        socket
-            .connect(connection_str)
-            .expect("failed to connect to the tx validation enclave zmq");
-        Self {
-            socket: Lock::new((Vec::new(), AtomicBool::new(true), socket)),
-        }
-    }
-}
-
-impl Read for ZmqStreamHelper {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        debug!("enclave runner: read");
-        match self.socket.poll_lock() {
-            Async::NotReady => {
-                trace!("read no ready");
-                Err(std::io::ErrorKind::WouldBlock.into())
-            }
-            Async::Ready(mut lg) => {
-                let next_msg = lg.1.load(Ordering::Relaxed);
-                if next_msg {
-                    debug!("enclave runner: new message not written yet");
-                    Err(std::io::ErrorKind::WouldBlock.into())
-                } else {
-                    let n = Read::read(&mut lg.0.as_slice(), buf)?;
-                    *lg.1.get_mut() = true;
-                    Ok(n)
-                }
-            }
-        }
-    }
-}
-
-impl Write for ZmqStreamHelper {
-    /// for some reason "flush" doesn't get called
-    /// so this assumes the whole zmq request is in buf
-    /// and sends it immediately and waits for reply
-    /// (instead of the expected semantics:
-    ///  1) write or perhaps multiple writes -- save in temp buffer,
-    ///  2) flush -- send to zmq server,
-    ///  3) read reply)
-    ///
-    /// TODO: does this local synchronous REQ-REP zmq exchange break any async stuff?
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        debug!("enclave helper: write");
-        match self.socket.poll_lock() {
-            Async::NotReady => {
-                trace!("write no ready");
-                Err(std::io::ErrorKind::WouldBlock.into())
-            }
-            Async::Ready(mut lg) => {
-                let next_msg = lg.1.load(Ordering::Relaxed);
-                if next_msg {
-                    debug!("enclave runner: send to zmq");
-                    lg.2.send(buf, FLAGS)?;
-
-                    debug!("enclave runner: receiving from zmq");
-                    let msg = lg.2.recv_bytes(FLAGS)?;
-                    debug!("enclave runner: received from zmq");
-                    lg.0.clear();
-                    lg.0.extend(msg);
-                    *lg.1.get_mut() = false;
-
-                    Ok(buf.len())
-                } else {
-                    debug!("enclave runner: previous message not read yet");
-                    Err(std::io::ErrorKind::WouldBlock.into())
-                }
-            }
-        }
-    }
-
-    fn flush(&mut self) -> Result<()> {
-        // for some reason, even with explicit "flush" call in enclave on that zmq stream, this didn't get called
-        debug!("enclave helper: flush");
-        match self.socket.poll_lock() {
-            Async::NotReady => {
-                trace!("flush not ready");
-                Err(std::io::ErrorKind::WouldBlock.into())
-            }
-            Async::Ready(_) => Ok(()),
-        }
-    }
-}
-
-impl AsyncRead for ZmqStreamHelper {}
-
-impl AsyncWrite for ZmqStreamHelper {
-    fn shutdown(&mut self) -> tokio::prelude::Poll<(), std::io::Error> {
-        Ok(().into())
-    }
-}
+use self::zmq_helper::ZmqHelper;
 
 #[derive(Debug)]
 struct ZmqService {
@@ -131,11 +19,6 @@ struct ZmqService {
 }
 
 impl UsercallExtension for ZmqService {
-    /// the original example had a return type -> Result<Option<Box<dyn AsyncStream>>>
-    /// but in nightly-2020-03-18, I get this error:
-    /// expected enum `std::result::Result<std::option::Option<std::boxed::Box<(dyn enclave_runner::usercalls::AsyncStream + 'static)>>, std::io::Error>`
-    /// found struct `std::pin::Pin<std::boxed::Box<dyn core::future::future::Future<Output = std::result::Result<std::option::Option<std::boxed::Box<dyn enclave_runner::usercalls::AsyncStream>>, _>>>>`
-    ///
     fn connect_stream<'a>(
         &'a self,
         addr: &'a str,
@@ -146,7 +29,7 @@ impl UsercallExtension for ZmqService {
             match &*addr {
                 "zmq" => {
                     info!("enclave helper: connecting to zmq");
-                    let stream = ZmqStreamHelper::new(&self.connection_str);
+                    let stream = ZmqHelper::new(&self.connection_str);
                     let boxed_stream: Box<dyn AsyncStream> = Box::new(stream);
                     let option: Option<Box<dyn AsyncStream>> = Some(boxed_stream);
                     Ok(option)

--- a/chain-tx-enclave/tx-query-next/app-runner/src/zmq_helper.rs
+++ b/chain-tx-enclave/tx-query-next/app-runner/src/zmq_helper.rs
@@ -1,0 +1,204 @@
+use std::{
+    convert::TryInto,
+    io::{self, Read, Write},
+};
+
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    prelude::Async,
+    sync::lock::Lock,
+};
+use zmq::{Context, Message, Result, Socket, REQ};
+
+use enclave_protocol::FLAGS;
+
+macro_rules! lock {
+    ($e:expr) => {
+        match $e.poll_lock() {
+            Async::Ready(inner) => inner,
+            Async::NotReady => return Ok(Async::NotReady),
+        }
+    };
+}
+
+macro_rules! try_lock {
+    ($e:expr) => {
+        match $e.poll_lock() {
+            Async::Ready(inner) => inner,
+            Async::NotReady => return Err(io::ErrorKind::WouldBlock.into()),
+        }
+    };
+}
+
+macro_rules! try_poll {
+    ($e:expr) => {
+        match $e {
+            Async::Ready(inner) => inner,
+            Async::NotReady => return Err(io::ErrorKind::WouldBlock.into()),
+        }
+    };
+}
+
+/// Temporary bridging between the old code and EDP. In the long term, it may go away completely.
+///
+/// 1. Decryption requests may include the sealed payload in them (so no need to request them via zmq)
+/// 2. Encryption requests may be done via a direct attested secure channel (instead of this passing of sealed requests)
+pub struct ZmqHelper {
+    inner: Lock<Inner>,
+}
+
+/// Inner struct to hold values in a `Lock`
+///
+/// `Lock` is there to enforce the synchronous order as zmq isn't thread safe
+struct Inner {
+    /// State of ZeroMQ socket
+    state: SocketState,
+    /// ZeroMQ socket
+    socket: Socket,
+}
+
+/// State of ZeroMQ socket
+#[derive(Debug)]
+enum SocketState {
+    /// Denotes that a new request can be sent on ZeroMQ socket
+    Ready,
+    /// Denotes that a request is sent to ZeroMQ socket but response is not received yet
+    RequestSent,
+    /// Denotes that response to a previously sent request is received
+    ResponseReceived(Message),
+}
+
+impl ZmqHelper {
+    /// Creates a new instance of ZeroMQ helper
+    pub fn new(connection_str: &str) -> Self {
+        let ctx = Context::new();
+        let socket = ctx.socket(REQ).expect("failed to init zmq context");
+        socket
+            .connect(connection_str)
+            .expect("failed to connect to the tx validation enclave zmq");
+
+        let inner = Inner {
+            state: SocketState::Ready,
+            socket,
+        };
+
+        log::debug!("Successfully created ZeroMQ helper");
+
+        Self {
+            inner: Lock::new(inner),
+        }
+    }
+
+    /// Sends a message to ZeroMQ socket
+    pub fn send<S: Into<Message>>(&mut self, message: S) -> Result<Async<()>> {
+        log::debug!("Sending message to ZeroMQ");
+        let mut inner = lock!(self.inner);
+
+        match inner.state {
+            SocketState::Ready => {
+                inner.socket.send(message, FLAGS)?;
+                inner.state = SocketState::RequestSent;
+                Ok(Async::Ready(()))
+            }
+            _ => {
+                log::debug!("Unable to send message. Previous response isn't processed");
+                Ok(Async::NotReady)
+            }
+        }
+    }
+
+    /// Returns `true` if previous request was sent. `false` otherwise.
+    pub fn is_request_sent(&mut self) -> Result<Async<bool>> {
+        let inner = lock!(self.inner);
+        Ok(Async::Ready(matches!(
+            inner.state,
+            SocketState::RequestSent
+        )))
+    }
+
+    /// Returns `true` if response was received. `false` otherwise.
+    pub fn is_response_received(&mut self) -> Result<Async<bool>> {
+        let inner = lock!(self.inner);
+        Ok(Async::Ready(matches!(
+            inner.state,
+            SocketState::ResponseReceived(_)
+        )))
+    }
+
+    /// Returns the length of message received from ZeroMQ
+    pub fn get_message_len(&mut self) -> Result<Async<usize>> {
+        let mut inner = lock!(self.inner);
+
+        let message = match inner.state {
+            SocketState::RequestSent => inner.socket.recv_msg(FLAGS)?,
+            _ => {
+                log::debug!("Unable to receive message. Previous request wasn't sent");
+                return Ok(Async::NotReady);
+            }
+        };
+
+        let message_len = message.len();
+        inner.state = SocketState::ResponseReceived(message);
+
+        Ok(Async::Ready(message_len))
+    }
+
+    /// Returns the message received from ZeroMQ
+    pub fn get_message(&mut self) -> Result<Async<Message>> {
+        log::debug!("Receiving response to ZeroMQ");
+        let mut inner = lock!(self.inner);
+
+        if matches!(inner.state, SocketState::ResponseReceived(_)) {
+            let mut socket_state = SocketState::Ready;
+            std::mem::swap(&mut socket_state, &mut inner.state);
+
+            if let SocketState::ResponseReceived(message) = socket_state {
+                Ok(Async::Ready(message))
+            } else {
+                unreachable!("Socket state cannot be anything other than `ResponseReceived`")
+            }
+        } else {
+            log::debug!("Unable to receive message. Previous request wasn't sent");
+            Ok(Async::NotReady)
+        }
+    }
+}
+
+impl Read for ZmqHelper {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if try_poll!(self.is_request_sent()?) {
+            let message_len: u32 = try_poll!(self.get_message_len()?)
+                .try_into()
+                .expect("Message length exceeds `u32` bounds");
+
+            buf.copy_from_slice(&message_len.to_le_bytes());
+            Ok(core::mem::size_of::<u32>())
+        } else if try_poll!(self.is_response_received()?) {
+            let message = try_poll!(self.get_message()?);
+            buf.copy_from_slice(&message);
+            Ok(message.len())
+        } else {
+            Err(io::ErrorKind::WouldBlock.into())
+        }
+    }
+}
+
+impl Write for ZmqHelper {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        try_poll!(self.send(buf)?);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        try_lock!(self.inner);
+        Ok(())
+    }
+}
+
+impl AsyncRead for ZmqHelper {}
+
+impl AsyncWrite for ZmqHelper {
+    fn shutdown(&mut self) -> io::Result<Async<()>> {
+        Ok(().into())
+    }
+}

--- a/chain-tx-enclave/tx-query-next/enclave-app/.cargo/config
+++ b/chain-tx-enclave/tx-query-next/enclave-app/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-fortanix-unknown-sgx"

--- a/chain-tx-enclave/tx-query-next/enclave-app/Cargo.toml
+++ b/chain-tx-enclave/tx-query-next/enclave-app/Cargo.toml
@@ -2,6 +2,23 @@
 name = "tx-query2-enclave-app"
 version = "0.5.0"
 authors = ["Crypto.com <chain@crypto.com>"]
+edition = "2018"
 
 [dependencies]
-enclave-protocol   = { path = "../../../enclave-protocol" }
+env_logger = { version = "0.7", default-features = false }
+log = "0.4"
+parity-scale-codec = "1.3"
+rand = "0.7"
+rs-libc = "0.2"
+rustls = "0.17"
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["edp"] }
+thread-pool = "0.1"
+zeroize = "1.1"
+
+chain-core = { path = "../../../chain-core", default-features = false, features = ["edp"] }
+enclave-protocol = { path = "../../../enclave-protocol", features = ["edp"] }
+enclave-utils = { path = "../../enclave-utils", features = ["sgxstd"] }
+ra-enclave = { path = "../../enclave-ra/ra-enclave" }
+
+[patch.crates-io]
+ring = { git = "https://github.com/crypto-com/ring.git", rev = "4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa" }

--- a/chain-tx-enclave/tx-query-next/enclave-app/src/handler.rs
+++ b/chain-tx-enclave/tx-query-next/enclave-app/src/handler.rs
@@ -1,0 +1,9 @@
+mod decryption_request;
+mod encryption_request;
+
+pub use self::{
+    decryption_request::{
+        get_random_challenge, handle_decryption_request, verify_decryption_request,
+    },
+    encryption_request::handle_encryption_request,
+};

--- a/chain-tx-enclave/tx-query-next/enclave-app/src/handler/decryption_request.rs
+++ b/chain-tx-enclave/tx-query-next/enclave-app/src/handler/decryption_request.rs
@@ -1,0 +1,130 @@
+use std::{
+    convert::TryInto,
+    io::{Read, Write},
+    net::TcpStream,
+    sync::{Arc, Mutex},
+};
+
+use parity_scale_codec::{Decode, Encode};
+use secp256k1::{key::PublicKey, Secp256k1};
+use zeroize::Zeroize;
+
+use chain_core::{
+    common::H256,
+    state::account::WithdrawUnbondedTx,
+    tx::{
+        data::{access::TxAccessPolicy, attribute::TxAttributes, Tx},
+        TxWithOutputs,
+    },
+};
+use enclave_protocol::{DecryptionRequest, DecryptionResponse, EnclaveRequest, EnclaveResponse};
+use enclave_utils::SealedData;
+
+pub fn get_random_challenge() -> H256 {
+    rand::random()
+}
+
+pub fn verify_decryption_request(decryption_request: &DecryptionRequest, challenge: H256) -> bool {
+    !decryption_request
+        .verify(&Secp256k1::verification_only(), challenge)
+        .is_err()
+}
+
+pub fn handle_decryption_request(
+    decryption_request: &DecryptionRequest,
+    zmq_stream: Arc<Mutex<TcpStream>>,
+) -> Result<DecryptionResponse, String> {
+    // Prepare enclave request
+    let enclave_request = EnclaveRequest::GetSealedTxData {
+        txids: decryption_request.body.txs.clone(),
+    }
+    .encode();
+
+    let mut zmq_stream = zmq_stream.lock().unwrap();
+
+    // Send request to ZeroMQ
+    zmq_stream
+        .write_all(&enclave_request)
+        .map_err(|err| format!("Error while writing request to ZeroMQ: {}", err))?;
+
+    // Read reponse length from ZeroMQ (little endian u32 bytes)
+    let mut response_len = [0u8; 4];
+    zmq_stream
+        .read(&mut response_len)
+        .map_err(|err| format!("Error while reading reponse length from ZeroMQ: {}", err))?;
+
+    let response_len: usize = u32::from_le_bytes(response_len)
+        .try_into()
+        .expect("Response length exceeds `usize` bounds");
+
+    // Read result from ZeroMQ
+    let mut result_buf = vec![0u8; response_len];
+    zmq_stream
+        .read(&mut result_buf)
+        .map_err(|err| format!("Error while reading response from ZeroMQ: {}", err))?;
+
+    match EnclaveResponse::decode(&mut result_buf.as_ref()) {
+        Ok(EnclaveResponse::GetSealedTxData(Some(sealed_logs))) => {
+            let txids = decryption_request.body.txs.clone();
+            let view_key = decryption_request.body.view_key;
+            let mut return_result = Vec::with_capacity(sealed_logs.len());
+
+            for (txid, sealed_log) in txids.into_iter().zip(sealed_logs.into_iter()) {
+                let sealed_data = match SealedData::try_copy_from(&sealed_log) {
+                    Some(sealed_data) => sealed_data,
+                    None => {
+                        return Err("Unable to parse sealed data returned from ZeroMQ".to_owned())
+                    }
+                };
+
+                if sealed_data.aes_data.additional_txt != txid {
+                    return Err("Transaction ID does not match in sealed data".to_owned());
+                }
+
+                let mut unsealed_data = sealed_data
+                    .unseal()
+                    .map_err(|e| format!("Error while unsealing sealed data: {:?}", e))?;
+                let otx = TxWithOutputs::decode(&mut unsealed_data.as_slice());
+                let push: bool;
+
+                match &otx {
+                    Ok(TxWithOutputs::Transfer(Tx {
+                        attributes: TxAttributes { allowed_view, .. },
+                        ..
+                    })) => {
+                        push = is_allowed_view(&allowed_view, &view_key);
+                    }
+                    Ok(TxWithOutputs::StakeWithdraw(WithdrawUnbondedTx {
+                        attributes: TxAttributes { allowed_view, .. },
+                        ..
+                    })) => {
+                        push = is_allowed_view(&allowed_view, &view_key);
+                    }
+                    _ => {
+                        return Err("Invalid transaction type".to_owned());
+                    }
+                }
+
+                if push {
+                    return_result.push(otx.unwrap());
+                }
+
+                unsealed_data.zeroize();
+            }
+
+            let decryption_response = DecryptionResponse { txs: return_result };
+            Ok(decryption_response)
+        }
+        Ok(_) => Err("Unexpected response from ZeroMQ".to_owned()),
+        Err(err) => Err(format!(
+            "Error while decoding response from ZeroMQ: {}",
+            err
+        )),
+    }
+}
+
+#[inline]
+fn is_allowed_view(allowed_views: &[TxAccessPolicy], view_key: &PublicKey) -> bool {
+    // TODO: policy != alldata + const eq?
+    allowed_views.iter().any(|x| x.view_key == *view_key)
+}

--- a/chain-tx-enclave/tx-query-next/enclave-app/src/handler/encryption_request.rs
+++ b/chain-tx-enclave/tx-query-next/enclave-app/src/handler/encryption_request.rs
@@ -1,0 +1,137 @@
+use std::{
+    convert::TryInto,
+    io::{Read, Write},
+    net::TcpStream,
+    sync::{Arc, Mutex},
+};
+
+use parity_scale_codec::{Decode, Encode};
+
+use chain_core::tx::{data::input::TxoSize, TransactionId, TxEnclaveAux};
+use enclave_protocol::{
+    EnclaveRequest, EnclaveResponse, EncryptionRequest, EncryptionResponse, QueryEncryptRequest,
+};
+use enclave_utils::SealedData;
+
+pub fn handle_encryption_request(
+    encryption_request: Box<EncryptionRequest>,
+    request_len: usize,
+    zmq_stream: Arc<Mutex<TcpStream>>,
+) -> Result<EncryptionResponse, String> {
+    let request = construct_request(&*encryption_request, request_len);
+
+    match request {
+        None => Err("Failed to seal request data".to_owned()),
+        Some(request) => {
+            // Prepare enclave request
+            let enclave_request = EnclaveRequest::EncryptTx(Box::new(request)).encode();
+
+            let mut zmq_stream = zmq_stream.lock().unwrap();
+
+            // Send request to ZeroMQ
+            zmq_stream
+                .write_all(&enclave_request)
+                .map_err(|err| format!("Error while writing request to ZeroMQ: {}", err))?;
+
+            // Read reponse length from ZeroMQ (little endian u32 bytes)
+            let mut response_len = [0u8; 4];
+            zmq_stream.read(&mut response_len).map_err(|err| {
+                format!("Error while reading reponse length from ZeroMQ: {}", err)
+            })?;
+
+            let response_len: usize = u32::from_le_bytes(response_len)
+                .try_into()
+                .expect("Response length exceeds `usize` bounds");
+
+            // Read result from ZeroMQ
+            let mut result_buf = vec![0u8; response_len];
+            zmq_stream
+                .read(&mut result_buf)
+                .map_err(|err| format!("Error while reading response from ZeroMQ: {}", err))?;
+
+            match EnclaveResponse::decode(&mut result_buf.as_ref()) {
+                Ok(EnclaveResponse::EncryptTx(enclave_response)) => {
+                    let encryption_response = match enclave_response {
+                        Ok(payload) => {
+                            let tx = match *encryption_request {
+                                EncryptionRequest::TransferTx(tx, _) => {
+                                    let inputs = tx.inputs;
+                                    let no_of_outputs = tx.outputs.len() as TxoSize;
+                                    TxEnclaveAux::TransferTx {
+                                        inputs,
+                                        no_of_outputs,
+                                        payload,
+                                    }
+                                }
+                                EncryptionRequest::DepositStake(tx, _) => {
+                                    TxEnclaveAux::DepositStakeTx { tx, payload }
+                                }
+                                EncryptionRequest::WithdrawStake(tx, witness) => {
+                                    let no_of_outputs = tx.outputs.len() as TxoSize;
+                                    TxEnclaveAux::WithdrawUnbondedStakeTx {
+                                        no_of_outputs,
+                                        witness,
+                                        payload,
+                                    }
+                                }
+                            };
+
+                            EncryptionResponse { resp: Ok(tx) }
+                        }
+                        Err(e) => EncryptionResponse { resp: Err(e) },
+                    };
+
+                    Ok(encryption_response)
+                }
+                Ok(_) => Err("Unexpected response from ZeroMQ".to_owned()),
+                Err(err) => Err(format!(
+                    "Error while decoding response from ZeroMQ: {}",
+                    err
+                )),
+            }
+        }
+    }
+}
+
+fn construct_request(req: &EncryptionRequest, req_len: usize) -> Option<QueryEncryptRequest> {
+    let (txid, sealed, tx_inputs, tx_size, op_sig) = match req {
+        // TODO: are the size estimates ok?
+        EncryptionRequest::TransferTx(tx, _) => {
+            let txid = tx.id();
+            let sealed = SealedData::seal(&req.encode(), txid).ok();
+            let tx_inputs = Some(tx.inputs.clone());
+            (
+                txid,
+                sealed,
+                tx_inputs,
+                req_len + 34 * tx.inputs.len() + 74,
+                None,
+            )
+        }
+        EncryptionRequest::DepositStake(tx, _) => {
+            let txid = tx.id();
+            let sealed = SealedData::seal(&req.encode(), txid).ok();
+            let tx_inputs = Some(tx.inputs.clone());
+            (
+                txid,
+                sealed,
+                tx_inputs,
+                req_len + 34 * tx.inputs.len() + 74,
+                None,
+            )
+        }
+        EncryptionRequest::WithdrawStake(tx, witness) => {
+            let txid = tx.id();
+            let sealed = SealedData::seal(&req.encode(), txid).ok();
+            (txid, sealed, None, req_len + 73, Some(witness.clone()))
+        }
+    };
+    sealed.map(|sealed_enc_request| QueryEncryptRequest {
+        txid,
+        sealed_enc_request,
+        tx_inputs,
+        // TODO: checks, but this should fit, as all things are bounded more like u16::max
+        tx_size: tx_size as u32,
+        op_sig,
+    })
+}

--- a/chain-tx-enclave/tx-query-next/enclave-app/src/main.rs
+++ b/chain-tx-enclave/tx-query-next/enclave-app/src/main.rs
@@ -1,42 +1,157 @@
-/// somehow this is needed with `cargo +nightly build --target=x86_64-fortanix-unknown-sgx`
-extern crate enclave_protocol;
+mod handler;
 
-use enclave_protocol::ENCRYPTION_REQUEST_SIZE;
-use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+pub use rs_libc::alloc::*;
+
+use std::{
+    convert::TryInto,
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::{Arc, Mutex},
+};
+
+use parity_scale_codec::{Decode, Encode};
+use rustls::{ServerConfig, ServerSession, StreamOwned};
+use thread_pool::ThreadPool;
+
+use enclave_protocol::{
+    DecryptionRequest, TxQueryInitRequest, TxQueryInitResponse, ENCRYPTION_REQUEST_SIZE,
+};
+use ra_enclave::{EnclaveRaConfig, EnclaveRaContext};
+
+use self::handler::{
+    get_random_challenge, handle_decryption_request, handle_encryption_request,
+    verify_decryption_request,
+};
 
 fn main() -> std::io::Result<()> {
-    // FIXME: this doesn't do yet anything interesting due to several missing pieces
-    println!("enclave: connecting to zmq");
-    let mut zmq_stream = TcpStream::connect("zmq")?;
-    // currently, it's not possible to pass arguments
-    // FIXME: fix that or bind via Usercall extensions?
+    std::env::set_var("RUST_LOG", "debug");
+    env_logger::init();
+
+    log::info!("Connecting to ZeroMQ");
+    let zmq_stream = Arc::new(Mutex::new(TcpStream::connect("zmq")?));
+
+    // Currently, it's not possible to pass arguments to enclave code
+    // FIXME: Fix that or bind via Usercall extensions?
     // ref: https://github.com/fortanix/rust-sgx/issues/136
     // ref: https://github.com/fortanix/rust-sgx/blob/master/examples/usercall-extension-bind/runner/src/main.rs#L26
-    let listener = TcpListener::bind("0.0.0.0:3443")?;
-    println!("enclave: listening");
+    let addrs = "0.0.0.0:3443";
+    let num_threads = 4;
+    let config = EnclaveRaConfig {
+        sp_addr: "0.0.0.0:8989".to_string(),
+        certificate_validity_secs: 86400,
+    };
+
+    let context =
+        EnclaveRaContext::new(&config).expect("Unable to create new remote attestation context");
+    let certificate = context
+        .get_certificate()
+        .expect("Unable to create remote attestation certificate");
+    let tls_server_config: Arc<ServerConfig> = Arc::new(
+        certificate
+            .try_into()
+            .expect("Unable to create TLS server config"),
+    );
+
+    log::info!("Successfully created remote attestation certificate!");
+    log::info!("Starting TLS Server at: {}", addrs);
+
+    let listener = TcpListener::bind(addrs)?;
+
+    let (thread_pool_sender, thread_pool) = ThreadPool::fixed_size(num_threads);
+
     for stream in listener.incoming() {
-        // FIXME: TLS https://github.com/crypto-com/chain/issues/860
-        // (some deps -- probably to be done in / via app-runner)
-        // attestation https://github.com/crypto-com/chain/issues/817
-        // nonce in quotes: https://github.com/fortanix/rust-sgx/issues/116
-        // unlinkable quotes: https://github.com/fortanix/rust-sgx/issues/113
-        let mut from_connection = vec![0u8; ENCRYPTION_REQUEST_SIZE];
-        let mut zmq_resp = vec![0u8; ENCRYPTION_REQUEST_SIZE];
-        match stream {
-            Ok(mut stream) => {
-                println!("enclave: new connection");
-                if let Ok(n) = stream.read(&mut from_connection) {
-                    let _ = zmq_stream.write(&from_connection[..n]);
-                    let _ = zmq_stream.flush();
-                    if let Ok(m) = zmq_stream.read(&mut zmq_resp) {
-                        let _ = stream.write(&zmq_resp[..m]);
-                        let _ = stream.flush();
+        let tls_server_config = tls_server_config.clone();
+        let zmq_stream = zmq_stream.clone();
+
+        thread_pool_sender
+            .send(move || {
+                let tls_session = ServerSession::new(&tls_server_config);
+                let stream = StreamOwned::new(tls_session, stream.unwrap());
+
+                handle_connection(stream, zmq_stream);
+            })
+            .expect("Unable to send tasks to thread pool");
+    }
+
+    thread_pool.shutdown();
+    Ok(())
+}
+
+fn handle_connection<T: Read + Write>(mut stream: T, zmq_stream: Arc<Mutex<TcpStream>>) {
+    let mut bytes = vec![0u8; ENCRYPTION_REQUEST_SIZE];
+
+    match stream.read(&mut bytes) {
+        Ok(len) => {
+            match TxQueryInitRequest::decode(&mut &bytes.as_slice()[0..len]) {
+                Ok(TxQueryInitRequest::Encrypt(request)) => {
+                    let response = handle_encryption_request(request, len, zmq_stream);
+
+                    let response = match response {
+                        Ok(response) => TxQueryInitResponse::Encrypt(response),
+                        Err(message) => {
+                            log::error!("Error while handling encryption request: {}", message);
+                            return;
+                        }
+                    };
+
+                    if let Err(err) = stream.write_all(&response.encode()) {
+                        log::error!(
+                            "Error while writing encryption response back to TLS stream: {}",
+                            err
+                        );
                     }
                 }
-            }
-            Err(_) => {}
+                Ok(TxQueryInitRequest::DecryptChallenge) => {
+                    let challenge = get_random_challenge();
+
+                    if let Err(err) = stream.write_all(&challenge) {
+                        log::error!("Unable to write random challenge to TLS stream: {}", err);
+                        return;
+                    }
+
+                    match stream.read(&mut bytes) {
+                        Ok(len) => {
+                            match DecryptionRequest::decode(&mut &bytes.as_slice()[0..len]) {
+                                Ok(decryption_request) => {
+                                    if !verify_decryption_request(&decryption_request, challenge) {
+                                        log::error!("Decryption request is invalid");
+                                        return;
+                                    }
+
+                                    match handle_decryption_request(&decryption_request, zmq_stream)
+                                    {
+                                        Ok(decryption_response) => {
+                                            if let Err(err) =
+                                                stream.write_all(&decryption_response.encode())
+                                            {
+                                                log::error!("Error while writing decryption response back to TLS stream: {}", err);
+                                            }
+                                        }
+                                        Err(err) => log::error!(
+                                            "Error while handling decryption request: {}",
+                                            err
+                                        ),
+                                    }
+                                }
+                                Err(err) => {
+                                    log::error!("Unable to decode decryption request: {}", err)
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            log::error!(
+                                "Unable to read challenge response from TLS stream: {}",
+                                err
+                            );
+                        }
+                    }
+                }
+                Err(err) => {
+                    log::error!("Error while decoding tx-query init request: {}", err);
+                    return;
+                }
+            };
         }
+        Err(err) => log::error!("Error while reading bytes from TLS stream: {}", err),
     }
-    Ok(())
 }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -12,6 +12,7 @@ chain-tx-filter = { path = "../chain-tx-filter" }
 enclave-protocol = { path = "../enclave-protocol" }
 chain-tx-validation = { path = "../chain-tx-validation" }
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
+ra-client = { path = "../chain-tx-enclave/enclave-ra/ra-client", optional = true }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 chrono = { version = "0.4", features = ["serde"] }
@@ -23,8 +24,8 @@ secstr = { version = "0.4.0", features = ["serde"] }
 itertools = "0.9"
 base64 = "0.11"
 webpki = "0.21"
-rustls =  {version = "0.16", features = ["dangerous_configuration"]}
-yasna = { version = "0.3.1", features = ["bit-vec", "num-bigint", "chrono"] }
+rustls =  { version = "0.17", features = ["dangerous_configuration"] }
+yasna = { version = "0.3.1", features = ["bit-vec", "num-bigint", "chrono"], optional = true }
 bit-vec = "0.6.1"
 num-bigint = "0.2.5"
 serde_json = "1.0.52"
@@ -50,7 +51,9 @@ ripemd160 = "0.8.0"
 test-common = { path = "../test-common" }
 
 [features]
-default = ["sled"]
+default = ["sled", "sgx-obfuscation"]
 sled = ["client-common/sled"]
 websocket-rpc = ["client-common/websocket-rpc"]
 mock-hardware-wallet = []
+sgx-obfuscation = ["yasna"]
+edp-obfuscation = ["ra-client"]

--- a/client-core/src/cipher.rs
+++ b/client-core/src/cipher.rs
@@ -1,8 +1,10 @@
 //! Utilities for encryption and decryption
 mod default;
 
+#[cfg(feature = "sgx-obfuscation")]
 pub mod cert;
 pub mod mock;
+#[cfg(feature = "sgx-obfuscation")]
 pub mod sgx;
 
 pub use default::DefaultTransactionObfuscation;

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -9,6 +9,9 @@
 //! - Balance tracking
 //! - Transaction history
 //! - Transaction creation and signing (with automatic unspent transaction selection)
+#[cfg(all(feature = "sgx-obfuscation", feature = "edp-obfuscation"))]
+compile_error!("Features `sgx-obfuscation` and `edp-obfuscation` are mutually exclusive and cannot be enabled at same time");
+
 pub mod cipher;
 pub mod hd_seed;
 pub mod hd_wallet;

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [features]
 default = ["chain-core/default"]
+edp = ["chain-core/edp", "secp256k1zkp/edp"]
 mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx", "chain-tx-validation/mesalock_sgx"]
 
 [dependencies]


### PR DESCRIPTION
Solution:

- Implemented `tx-query` code using EDP in `tx-query-next`
- Added `"edp"` feature flag in `chain-core` (compiles `secp256k1` with
`"edp"` flag)
- Added `"edp-obfuscation"` and `"sgx-obfuscation"` feature flags in
client-core. `"edp-obfuscation"` compiles client with remote attestation
using EDP for connecting to `tx-query`. `"sgx-obfuscation"` compiles
client with remote attestation using SGX SDK for connecting to `tx-query`.
- `tx-query-next` internally uses a thread from a thread pool for each connection.
- Modified `ZmqHelper` in `app-runner`

Fixes #1301.