### PR TITLE
Problem (Fix #1313): light client doesn't verify the fetched staking state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "bit-vec 0.6.1",
  "byteorder",
  "chain-core",
+ "chain-storage",
  "chain-tx-filter",
  "chain-tx-validation",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -778,6 +779,7 @@ version = "0.5.0"
 dependencies = [
  "base64 0.11.0",
  "chain-core",
+ "chain-storage",
  "chain-tx-validation",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-common",

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -149,7 +149,7 @@ impl InitConfig {
 
     /// returns the initial accounts
     /// assumes one called [validate_config_get_genesis], otherwise it may panic
-    fn get_account(&self, genesis_time: Timespec) -> Vec<StakedState> {
+    pub fn get_account(&self, genesis_time: Timespec) -> Vec<StakedState> {
         self.distribution
             .iter()
             .map(|(address, (destination, amount))| {

--- a/chain-core/src/state/account/address.rs
+++ b/chain-core/src/state/account/address.rs
@@ -121,3 +121,11 @@ impl FromStr for StakedStateAddress {
         Ok(StakedStateAddress::BasicRedeem(RedeemAddress::from_str(s)?))
     }
 }
+
+impl AsRef<[u8]> for StakedStateAddress {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            StakedStateAddress::BasicRedeem(a) => &a,
+        }
+    }
+}

--- a/client-cli/src/command/transaction_command.rs
+++ b/client-cli/src/command/transaction_command.rs
@@ -602,6 +602,7 @@ fn new_withdraw_transaction<T: WalletClient, N: NetworkOpsClient>(
         &from_address,
         to_address,
         attributes,
+        true,
     )
 }
 
@@ -613,7 +614,8 @@ fn new_unbond_transaction<N: NetworkOpsClient>(
     let attributes = StakedStateOpAttributes::new(get_network_id());
     let address = ask_staking_address()?;
     let value = ask_cro()?;
-    network_ops_client.create_unbond_stake_transaction(name, enckey, address, value, attributes)
+    network_ops_client
+        .create_unbond_stake_transaction(name, enckey, address, value, attributes, true)
 }
 
 fn new_deposit_transaction<T: WalletClient, N: NetworkOpsClient>(
@@ -644,6 +646,7 @@ fn new_deposit_transaction<T: WalletClient, N: NetworkOpsClient>(
         transactions,
         to_address,
         attributes,
+        true,
     )
 }
 
@@ -701,6 +704,7 @@ fn new_deposit_amount_transaction<T: WalletClient, N: NetworkOpsClient>(
         transactions,
         to_staking_address,
         attr,
+        true,
     )?;
     let tx_id = transaction.tx_id();
     success(&format!(
@@ -758,7 +762,7 @@ fn new_unjail_transaction<N: NetworkOpsClient>(
     let attributes = StakedStateOpAttributes::new(get_network_id());
     let address = ask_staking_address()?;
 
-    network_ops_client.create_unjail_transaction(name, enckey, address, attributes)
+    network_ops_client.create_unjail_transaction(name, enckey, address, attributes, true)
 }
 
 fn new_node_join_transaction<N: NetworkOpsClient>(
@@ -776,6 +780,7 @@ fn new_node_join_transaction<N: NetworkOpsClient>(
         staking_account_address,
         attributes,
         node_metadata,
+        true,
     )
 }
 

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -11,6 +11,7 @@ client-common = { path = "../client-common" }
 chain-tx-filter = { path = "../chain-tx-filter" }
 enclave-protocol = { path = "../enclave-protocol" }
 chain-tx-validation = { path = "../chain-tx-validation" }
+chain-storage = { path = "../chain-storage" }
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }

--- a/client-core/src/service/sync_state_service.rs
+++ b/client-core/src/service/sync_state_service.rs
@@ -1,3 +1,4 @@
+use chain_core::common::H256;
 use client_common::tendermint::lite;
 use client_common::{ErrorKind, Result, ResultExt, Storage};
 use parity_scale_codec::{Decode, Encode};
@@ -15,15 +16,18 @@ pub struct SyncState {
     pub last_app_hash: String,
     /// current trusted state for lite client verification
     pub trusted_state: lite::TrustedState,
+    /// current trusted staking_root
+    pub staking_root: H256,
 }
 
 impl SyncState {
     /// construct genesis global state
-    pub fn genesis(genesis_validators: Vec<validator::Info>) -> SyncState {
+    pub fn genesis(genesis_validators: Vec<validator::Info>, staking_root: H256) -> SyncState {
         SyncState {
             last_block_height: 0,
             last_app_hash: "".to_owned(),
             trusted_state: lite::TrustedState::genesis(genesis_validators),
+            staking_root,
         }
     }
 }
@@ -131,6 +135,7 @@ mod tests {
                         "3891040F29C6A56A5E36B17DCA6992D8F91D1EAAB4439D008D19A9D703271D3C"
                             .to_string(),
                     trusted_state: TrustedState::genesis(vec![]),
+                    staking_root: [0u8; 32],
                 }
             )
             .is_ok());
@@ -174,7 +179,7 @@ mod tests {
             gen.validators.clone(),
         )
         .into();
-        let mut state = SyncState::genesis(vec![]);
+        let mut state = SyncState::genesis(vec![], [0u8; 32]);
         state.last_block_height = 1;
         state.last_app_hash =
             "0F46E113C21F9EACB26D752F9523746CF8D47ECBEA492736D176005911F973A5".to_owned();

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -29,7 +29,7 @@ use client_common::{
 use serde::{Deserialize, Serialize};
 
 use crate::hd_wallet::HardwareKind;
-use crate::service::WalletInfo;
+use crate::service::{SyncState, WalletInfo};
 use crate::transaction_builder::{SignedTransferTransaction, UnsignedTransferTransaction};
 use crate::types::{AddressType, TransactionChange, TransactionPending, WalletBalance, WalletKind};
 use crate::{InputSelectionStrategy, Mnemonic, UnspentTransactions};
@@ -379,6 +379,9 @@ pub trait WalletClient: Send + Sync {
         enckey: &SecKey,
         signed_tx: SignedTransferTransaction,
     ) -> Result<TxId>;
+
+    /// Get current sync state of wallet, return genesis one if not exists.
+    fn get_sync_state(&self, name: &str) -> Result<SyncState>;
 }
 
 /// Interface for a generic wallet for multi-signature transactions

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -5,7 +5,7 @@ use crate::transaction_builder::{SignedTransferTransaction, UnsignedTransferTran
 use crate::types::{
     AddressType, BalanceChange, TransactionChange, TransactionPending, WalletBalance, WalletKind,
 };
-use crate::wallet::syncer::AddressRecovery;
+use crate::wallet::syncer::{get_genesis_sync_state, AddressRecovery};
 use crate::wallet::syncer_logic::create_transaction_change;
 use crate::{
     InputSelectionStrategy, Mnemonic, MultiSigWalletClient, UnspentTransactions, WalletClient,
@@ -1083,6 +1083,16 @@ where
                 "Transaction is not transfer transaction",
             ))
         }
+    }
+
+    fn get_sync_state(&self, name: &str) -> Result<SyncState> {
+        let mstate = self.sync_state_service.get_global_state(name)?;
+        let sync_state = if let Some(sync_state) = mstate {
+            sync_state
+        } else {
+            get_genesis_sync_state(&self.tendermint_client)?
+        };
+        Ok(sync_state)
     }
 }
 

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 chain-core = { path = "../chain-core" }
 chain-tx-validation = { path = "../chain-tx-validation" }
+chain-storage = { path = "../chain-storage" }
 client-common = { path = "../client-common" }
 client-core = { path = "../client-core" }
 secstr = { version = "0.4.0", features = ["serde"] }

--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -28,6 +28,7 @@ pub trait NetworkOpsClient: Send + Sync {
         transaction: Vec<(TxoPointer, TxOut)>,
         to_address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
+        verify_staking: bool,
     ) -> Result<(TxAux, TransactionPending)>;
 
     /// creates a new transaction for unbonding stake transaction
@@ -38,6 +39,7 @@ pub trait NetworkOpsClient: Send + Sync {
         address: StakedStateAddress,
         value: Coin,
         attributes: StakedStateOpAttributes,
+        verify_staking: bool,
     ) -> Result<TxAux>;
 
     /// Creates a new transaction for withdrawing unbonded stake from an account
@@ -48,6 +50,7 @@ pub trait NetworkOpsClient: Send + Sync {
         from_address: &StakedStateAddress,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
+        verify_staking: bool,
     ) -> Result<(TxAux, TransactionPending)>;
 
     /// Creates a new transaction for withdrawing all unbonded stake from an account
@@ -58,6 +61,7 @@ pub trait NetworkOpsClient: Send + Sync {
         from_address: &StakedStateAddress,
         to_address: ExtendedAddr,
         attributes: TxAttributes,
+        verify_staking: bool,
     ) -> Result<(TxAux, TransactionPending)>;
 
     /// Creates a new transaction for un-jailing a previously jailed account
@@ -67,6 +71,7 @@ pub trait NetworkOpsClient: Send + Sync {
         enckey: &SecKey,
         address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
+        verify_staking: bool,
     ) -> Result<TxAux>;
 
     /// Creates a new transaction for a node joining validator set
@@ -77,8 +82,14 @@ pub trait NetworkOpsClient: Send + Sync {
         staking_account_address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
         node_metadata: CouncilNode,
+        verify_staking: bool,
     ) -> Result<TxAux>;
 
     /// Returns staked stake corresponding to given address
-    fn get_staked_state(&self, address: &StakedStateAddress) -> Result<StakedState>;
+    fn get_staked_state(
+        &self,
+        name: &str,
+        address: &StakedStateAddress,
+        verify: bool,
+    ) -> Result<StakedState>;
 }

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -14,6 +14,7 @@ use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::fee::FeeAlgorithm;
 use chain_core::tx::{TxAux, TxPublicAux};
+use chain_storage::jellyfish::SparseMerkleProof;
 use chain_tx_validation::{check_inputs_basic, check_outputs_basic, verify_unjailed};
 use client_common::tendermint::types::AbciQueryExt;
 use client_common::tendermint::Client;
@@ -70,34 +71,6 @@ where
     /// Returns current underlying wallet client
     pub fn get_wallet_client(&self) -> &W {
         &self.wallet_client
-    }
-
-    /// Get account info
-    fn get_account(&self, staked_state_address: &[u8]) -> Result<StakedState> {
-        let bytes = self
-            .client
-            .query("account", staked_state_address, None, false)?
-            .bytes();
-
-        StakedState::decode(&mut bytes.as_slice()).chain(|| {
-            (
-                ErrorKind::DeserializationError,
-                format!(
-                    "Cannot deserialize staked state for address: {}",
-                    hex::encode(staked_state_address)
-                ),
-            )
-        })
-    }
-
-    /// Get staked state info
-    fn get_staked_state_account(
-        &self,
-        to_staked_account: &StakedStateAddress,
-    ) -> Result<StakedState> {
-        match to_staked_account {
-            StakedStateAddress::BasicRedeem(ref a) => self.get_account(&a.0),
-        }
     }
 
     /// Calculate the withdraw unbounded fee
@@ -164,11 +137,12 @@ where
         transactions: Vec<(TxoPointer, TxOut)>,
         to_address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
+        verify_staking: bool,
     ) -> Result<(TxAux, TransactionPending)> {
         // if the to_address belongs to current wallet, we do not check the state
         let staking_addresses = self.wallet_client.staking_addresses(name, enckey)?;
         if !staking_addresses.contains(&to_address) {
-            let staked_state = self.get_staked_state(&to_address)?;
+            let staked_state = self.get_staked_state(name, &to_address, verify_staking)?;
             verify_unjailed(&staked_state).map_err(|e| {
                 Error::new(
                     ErrorKind::ValidationError,
@@ -220,8 +194,9 @@ where
         address: StakedStateAddress,
         value: Coin,
         attributes: StakedStateOpAttributes,
+        verify_staking: bool,
     ) -> Result<TxAux> {
-        let staked_state = self.get_staked_state(&address)?;
+        let staked_state = self.get_staked_state(name, &address, verify_staking)?;
 
         verify_unjailed(&staked_state).map_err(|e| {
             Error::new(
@@ -279,9 +254,10 @@ where
         from_address: &StakedStateAddress,
         outputs: Vec<TxOut>,
         attributes: TxAttributes,
+        verify_staking: bool,
     ) -> Result<(TxAux, TransactionPending)> {
         let last_block_time = self.get_last_block_time()?;
-        let staked_state = self.get_staked_state(from_address)?;
+        let staked_state = self.get_staked_state(name, from_address, verify_staking)?;
 
         if staked_state.unbonded_from > last_block_time {
             return Err(Error::new(
@@ -348,8 +324,9 @@ where
         enckey: &SecKey,
         address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
+        verify_staking: bool,
     ) -> Result<TxAux> {
-        let staked_state = self.get_staked_state(&address)?;
+        let staked_state = self.get_staked_state(name, &address, verify_staking)?;
 
         if !staked_state.is_jailed() {
             return Err(Error::new(
@@ -394,8 +371,9 @@ where
         from_address: &StakedStateAddress,
         to_address: ExtendedAddr,
         attributes: TxAttributes,
+        verify_staking: bool,
     ) -> Result<(TxAux, TransactionPending)> {
-        let staked_state = self.get_staked_state(from_address)?;
+        let staked_state = self.get_staked_state(name, from_address, verify_staking)?;
 
         verify_unjailed(&staked_state).map_err(|e| {
             Error::new(
@@ -432,6 +410,7 @@ where
             from_address,
             outputs,
             attributes,
+            verify_staking,
         )
     }
 
@@ -442,8 +421,9 @@ where
         staking_account_address: StakedStateAddress,
         attributes: StakedStateOpAttributes,
         node_metadata: CouncilNode,
+        verify_staking: bool,
     ) -> Result<TxAux> {
-        let staked_state = self.get_staked_state(&staking_account_address)?;
+        let staked_state = self.get_staked_state(name, &staking_account_address, verify_staking)?;
 
         verify_unjailed(&staked_state).map_err(|e| {
             Error::new(
@@ -481,8 +461,63 @@ where
     }
 
     #[inline]
-    fn get_staked_state(&self, address: &StakedStateAddress) -> Result<StakedState> {
-        self.get_staked_state_account(address)
+    fn get_staked_state(
+        &self,
+        name: &str,
+        address: &StakedStateAddress,
+        verify: bool,
+    ) -> Result<StakedState> {
+        let mstaking = if verify {
+            let sync_state = self.wallet_client.get_sync_state(name)?;
+            let rsp = self.client.query(
+                "staking",
+                address.as_ref(),
+                Some(sync_state.last_block_height.into()),
+                true,
+            )?;
+            let mstaking = <Option<StakedState>>::decode(&mut rsp.bytes().as_slice())
+                .err_kind(ErrorKind::DeserializationError, || {
+                    format!("Cannot deserialize staked state for address: {}", address)
+                })?;
+
+            let mbytes = if let Some(proof) = rsp.proof.as_ref() {
+                if let Some(evidence) = proof.ops.first() {
+                    Some(evidence.data.as_slice())
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            let mut proof_bytes = mbytes.err_kind(ErrorKind::TendermintRpcError, || {
+                format!("There is no proof for address: {}", address)
+            })?;
+            let proof = SparseMerkleProof::decode(&mut proof_bytes).err_kind(
+                ErrorKind::DeserializationError,
+                || {
+                    format!(
+                        "Cannot deserialize staked state proof for address: {}",
+                        address
+                    )
+                },
+            )?;
+
+            proof
+                .verify(sync_state.staking_root, address, mstaking.as_ref())
+                .err_kind(ErrorKind::VerifyError, || "Verify staking state failed")?;
+
+            mstaking
+        } else {
+            let bytes = self
+                .client
+                .query("staking", address.as_ref(), None, false)?
+                .bytes();
+            <Option<StakedState>>::decode(&mut bytes.as_slice())
+                .err_kind(ErrorKind::DeserializationError, || {
+                    format!("Cannot deserialize staked state for address: {}", address)
+                })?
+        };
+        mstaking.err_kind(ErrorKind::InvalidInput, || "staking not found")
     }
 }
 
@@ -649,7 +684,7 @@ mod tests {
             );
 
             Ok(AbciQuery {
-                value: Some(staked_state.encode()),
+                value: Some(Some(staked_state).encode()),
                 ..Default::default()
             })
         }
@@ -729,7 +764,7 @@ mod tests {
             );
 
             Ok(AbciQuery {
-                value: Some(staked_state.encode()),
+                value: Some(Some(staked_state).encode()),
                 ..Default::default()
             })
         }
@@ -791,6 +826,7 @@ mod tests {
                     transactions,
                     to_staked_account,
                     attributes,
+                    false
                 )
                 .unwrap_err()
                 .kind()
@@ -830,7 +866,7 @@ mod tests {
         let attributes = StakedStateOpAttributes::new(0);
 
         assert!(network_ops_client
-            .create_unbond_stake_transaction(name, &enckey, address, value, attributes)
+            .create_unbond_stake_transaction(name, &enckey, address, value, attributes, false)
             .is_ok());
     }
 
@@ -872,6 +908,7 @@ mod tests {
                 &from_address,
                 vec![TxOut::new(ExtendedAddr::OrTree([0; 32]), Coin::unit())],
                 TxAttributes::new(171),
+                false,
             )
             .unwrap();
 
@@ -931,6 +968,7 @@ mod tests {
                 &from_address,
                 to_address,
                 TxAttributes::new(171),
+                false,
             )
             .unwrap();
 
@@ -997,6 +1035,7 @@ mod tests {
                     ))),
                     vec![TxOut::new(ExtendedAddr::OrTree([0; 32]), Coin::unit())],
                     TxAttributes::new(171),
+                    false
                 )
                 .unwrap_err()
                 .kind()
@@ -1035,6 +1074,7 @@ mod tests {
                     ))),
                     Vec::new(),
                     TxAttributes::new(171),
+                    false
                 )
                 .unwrap_err()
                 .kind()
@@ -1078,6 +1118,7 @@ mod tests {
                 &enckey,
                 from_address,
                 StakedStateOpAttributes::new(171),
+                false,
             )
             .unwrap();
         match transaction {
@@ -1143,6 +1184,7 @@ mod tests {
                 staking_account_address,
                 StakedStateOpAttributes::new(171),
                 node_metadata,
+                false,
             )
             .unwrap();
 

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -39,7 +39,7 @@ pub trait StakingRpc: Send + Sync {
     ) -> Result<String>;
 
     #[rpc(name = "staking_state")]
-    fn state(&self, address: StakedStateAddress) -> Result<StakedState>;
+    fn state(&self, name: String, address: StakedStateAddress) -> Result<StakedState>;
 
     #[rpc(name = "staking_unbondStake")]
     fn unbond_stake(
@@ -144,6 +144,7 @@ where
                 transactions,
                 to_address,
                 attributes,
+                true,
             )
             .map_err(to_rpc_error)?;
 
@@ -230,6 +231,7 @@ where
                 transactions,
                 to_staking_address,
                 attr,
+                true,
             )
             .map_err(to_rpc_error)?;
 
@@ -249,9 +251,9 @@ where
         Ok(hex::encode(transaction.tx_id()))
     }
 
-    fn state(&self, address: StakedStateAddress) -> Result<StakedState> {
+    fn state(&self, name: String, address: StakedStateAddress) -> Result<StakedState> {
         self.ops_client
-            .get_staked_state(&address)
+            .get_staked_state(&name, &address, true)
             .map_err(to_rpc_error)
     }
 
@@ -276,7 +278,14 @@ where
 
         let transaction = self
             .ops_client
-            .create_unbond_stake_transaction(&request.name, &request.enckey, addr, amount, attr)
+            .create_unbond_stake_transaction(
+                &request.name,
+                &request.enckey,
+                addr,
+                amount,
+                attr,
+                true,
+            )
             .map_err(to_rpc_error)?;
 
         self.client
@@ -341,6 +350,7 @@ where
                 &from_address,
                 to_address,
                 attributes,
+                true,
             )
             .map_err(to_rpc_error)?;
 
@@ -373,7 +383,13 @@ where
 
         let transaction = self
             .ops_client
-            .create_unjail_transaction(&request.name, &request.enckey, unjail_address, attributes)
+            .create_unjail_transaction(
+                &request.name,
+                &request.enckey,
+                unjail_address,
+                attributes,
+                true,
+            )
             .map_err(to_rpc_error)?;
 
         self.client
@@ -409,6 +425,7 @@ where
                 staking_account_address,
                 attributes,
                 node_metadata,
+                true,
             )
             .map_err(to_rpc_error)?;
         self.client

--- a/integration-tests/bot/chainrpc.py
+++ b/integration-tests/bot/chainrpc.py
@@ -201,8 +201,8 @@ class Staking(BaseService):
     def deposit_amount(self, to_address, amount, name=DEFAULT_WALLET, enckey=None):
         return self.call('staking_depositAmountStake', [name, enckey or get_enckey()], fix_address(to_address), str(amount))
 
-    def state(self, address):
-        return self.call('staking_state', fix_address(address))
+    def state(self, address, name=DEFAULT_WALLET):
+        return self.call('staking_state', name, fix_address(address))
 
     def unbond(self, address, amount, name=DEFAULT_WALLET, enckey=None):
         return self.call('staking_unbondStake', [name, enckey or get_enckey()], fix_address(address), str(amount))

--- a/integration-tests/multinode/byzantine_test.py
+++ b/integration-tests/multinode/byzantine_test.py
@@ -76,6 +76,7 @@ wait_for_blocktime(rpc, state['validator']['jailed_until'])
 txid = rpc.staking.unjail(bonded_staking)
 print('Wait for unjail transaction', txid)
 wait_for_tx(rpc, txid)
+rpc.wallet.sync()
 
 print('re-join')
 txid = rpc.staking.join(

--- a/integration-tests/multinode/join_test.py
+++ b/integration-tests/multinode/join_test.py
@@ -56,7 +56,7 @@ assert len(rpc.chain.validators()['validators']) == 2
 
 addr = rpc.address.list(enckey=enckey, name='target')[0]
 rpc.wallet.sync(enckey=enckey, name='target')
-state = rpc.staking.state(addr)
+state = rpc.staking.state(addr, name='target')
 punishment = state['last_slash']
 print('punishment', punishment)
 assert punishment['kind'] == 'NonLive'
@@ -97,7 +97,7 @@ rpc.wallet.sync(enckey=enckey, name='target')
 
 assert len(rpc.chain.validators()['validators']) == 2
 
-unbonded_from = rpc.staking.state(addr)['unbonded_from']
+unbonded_from = rpc.staking.state(addr, name='target')['unbonded_from']
 print('Wait until unbonded_from', unbonded_from)
 wait_for_blocktime(rpc, unbonded_from)
 
@@ -127,7 +127,7 @@ print('Wait for transaction', txid)
 wait_for_tx(rpc, txid)
 rpc.wallet.sync(enckey=enckey, name='target')
 
-print('Bonded state:', rpc.staking.state(addr))
+print('Bonded state:', rpc.staking.state(addr, name='target'))
 
 print('Join node0')
 txid = rpc.staking.join(

--- a/integration-tests/multinode/reward_test.py
+++ b/integration-tests/multinode/reward_test.py
@@ -60,7 +60,7 @@ stop_node(supervisor, 'node1')
 
 # jailed and slashed
 slashed = int(last_bonded * 0.2)
-state = rpc.staking.state(bonded_staking2)
+state = rpc.chain.staking(bonded_staking2)
 assert state['validator']['jailed_until'] is not None
 assert int(state['bonded']) == last_bonded - slashed
 
@@ -69,8 +69,8 @@ wait_for_blocktime(rpc, block_time + 10)
 # minted = 6182420000
 minted = monetary_expansion(last_bonded, int(145000000000000000 * 0.99986))
 
-state = rpc.staking.state(bonded_staking2)
+state = rpc.chain.staking(bonded_staking2)
 assert int(state['bonded']) == last_bonded - slashed, 'jailed node don\'t get rewarded'
 
-state = rpc.staking.state(bonded_staking)
+state = rpc.chain.staking(bonded_staking)
 assert int(state['bonded']) == last_bonded + minted + slashed

--- a/integration-tests/pytests/test_pending_tx.py
+++ b/integration-tests/pytests/test_pending_tx.py
@@ -107,7 +107,8 @@ def test_pending_tx(addresses):
 
     # test withdraw tx
     wait_for_tx(rpc, rpc.staking.unbond(staking, 800000000, name=name, enckey=enckey))
-    wait_for_blocktime(rpc, rpc.staking.state(staking)['unbonded_from'])
+    rpc.wallet.sync(name=name, enckey=enckey)
+    wait_for_blocktime(rpc, rpc.staking.state(staking, name=name)['unbonded_from'])
     txid = rpc.staking.withdraw_all_unbonded(staking, transfer1, name=name, enckey=enckey)
     assert rpc.wallet.balance(name=name, enckey=enckey) == {
         'total': '900000000',


### PR DESCRIPTION
Solution:
- Add staking_root in sync state
- Remove the "account" path in favor of the new "staking" path
- Client staking state command add wallet name parameter,
  and verify staking state and proof against the trusted staking_root in sync state
- Need to sync wallet before fetching the new staking state now. (you can still get any staking state without verification by request abci_query API directly)