### PR TITLE
Problem (Fix #1038): no total supply sanity checks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,7 @@ steps:
   commands:
   - export CARGO_HOME=$PWD/drone/cargo
   - export CARGO_TARGET_DIR=$PWD/drone/target
+  - export CRYPTO_CHAIN_ENABLE_SANITY_CHECKS=1
   - cargo test
 
 - name: integration-tests
@@ -38,6 +39,7 @@ steps:
   commands:
   - export CARGO_TARGET_DIR=$PWD/drone/target
   - export PYTHON_VENV_DIR=$PWD/drone/venv
+  - export CRYPTO_CHAIN_ENABLE_SANITY_CHECKS=1
   - LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service
   - ./integration-tests/run.sh
 
@@ -56,6 +58,7 @@ steps:
   commands:
   - export CARGO_TARGET_DIR=$PWD/drone/target
   - export PYTHON_VENV_DIR=$PWD/drone/venv
+  - export CRYPTO_CHAIN_ENABLE_SANITY_CHECKS=1
   - LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service
   - ./integration-tests/run_multinode.sh
 
@@ -128,6 +131,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 9a1fa3521f6d925ed079f7953dd0b2d721e207895928a04119659a9f99fe7de2
+hmac: fbabf3a62adcb7697a34675624f62c408eda1197524bbab22a904694cb3c2fc8
 
 ...

--- a/chain-abci/fuzz/fuzz_targets/abci_cycle.rs
+++ b/chain-abci/fuzz/fuzz_targets/abci_cycle.rs
@@ -1,17 +1,15 @@
 #![no_main]
 use abci::Application;
-use abci::{Request, Request_oneof_value, RequestInitChain, PubKey, ValidatorUpdate};
-use chain_core::state::tendermint::{
-    TendermintValidatorPubKey, TendermintVotePower,
-};
-use chain_core::init::coin::Coin;
+use abci::{PubKey, Request, RequestInitChain, Request_oneof_value, ValidatorUpdate};
 use chain_abci::app::check_validators;
 use chain_abci::app::*;
 use chain_abci::enclave_bridge::mock::MockClient;
 use chain_core::common::MerkleTree;
 use chain_core::compute_app_hash;
+use chain_core::init::coin::Coin;
 use chain_core::init::config::InitConfig;
 use chain_core::init::config::NetworkParameters;
+use chain_core::state::tendermint::{TendermintValidatorPubKey, TendermintVotePower};
 use chain_storage::{Storage, NUM_COLUMNS};
 use kvdb::KeyValueDB;
 use kvdb_memorydb::create;
@@ -106,6 +104,7 @@ fn init_request() -> RequestInitChain {
 }
 
 fuzz_target!(|data: &[u8]| {
+    std::env::set_var("CRYPTO_CHAIN_ENABLE_SANITY_CHECKS", "1");
     let stuff: Result<Vec<Vec<u8>>, _> = Vec::decode(&mut data.to_owned().as_slice());
 
     let mut messages = Vec::<Request>::new();

--- a/chain-abci/src/app/macros.rs
+++ b/chain-abci/src/app/macros.rs
@@ -51,3 +51,18 @@ macro_rules! kv_store {
         )
     };
 }
+
+macro_rules! kv_getter {
+    ($app:expr) => {
+        chain_storage::buffer::BufferStoreGetter::new(&$app.storage, &$app.kv_buffer)
+    };
+    ($app:expr, $buffer_type:expr) => {
+        chain_storage::buffer::BufferStoreGetter::new(
+            &$app.storage,
+            match $buffer_type {
+                crate::app::app_init::BufferType::Consensus => &$app.kv_buffer,
+                crate::app::app_init::BufferType::Mempool => &$app.mempool_kv_buffer,
+            },
+        )
+    };
+}

--- a/chain-abci/src/main.rs
+++ b/chain-abci/src/main.rs
@@ -3,14 +3,13 @@ use std::fs::File;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use chain_abci::app::ChainNodeApp;
+use chain_abci::app::{sanity_check_enabled, ChainNodeApp};
 #[cfg(any(feature = "mock-enclave", not(target_os = "linux")))]
 use chain_abci::enclave_bridge::mock::MockClient;
 #[cfg(all(not(feature = "mock-enclave"), target_os = "linux"))]
 use chain_abci::enclave_bridge::real::TxValidationApp;
 use chain_core::init::network::{get_network, get_network_id, init_chain_id};
 use chain_storage::{Storage, StorageConfig, StorageType};
-#[cfg(any(feature = "mock-enclave", not(target_os = "linux")))]
 use log::warn;
 use serde::Deserialize;
 use std::io::BufReader;
@@ -173,6 +172,9 @@ fn main() {
         get_network_id()
     );
     let tx_validator = get_enclave_proxy();
+    if sanity_check_enabled() {
+        warn!("Enabled sanity checks");
+    }
 
     let host = config.host.parse().expect("invalid host");
     let addr = SocketAddr::new(host, config.port);

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -218,6 +218,7 @@ fn get_dummy_app_state(app_hash: H256) -> ChainNodeState {
         genesis_time: 0,
         staking_table: StakingTable::default(),
         staking_version: 0,
+        utxo_coins: Coin::zero(),
         top_level: ChainState {
             account_root: [0u8; 32],
             rewards_pool: RewardsPoolState::new(0, params.get_rewards_monetary_expansion_tau()),

--- a/chain-core/src/init/coin.rs
+++ b/chain-core/src/init/coin.rs
@@ -314,11 +314,8 @@ impl Encode for Coin {
 impl EncodeLike<u64> for Coin {}
 
 /// helper for summing coins in some iterable structure
-pub fn sum_coins<I>(coin_iter: I) -> CoinResult
-where
-    I: Iterator<Item = Coin>,
-{
-    coin_iter.fold(Coin::new(0), |acc, ref c| acc.and_then(|v| v + *c))
+pub fn sum_coins(mut coins: impl Iterator<Item = Coin>) -> Result<Coin, CoinError> {
+    coins.try_fold(Coin::zero(), |acc, coin| acc + coin)
 }
 
 #[cfg(test)]

--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -50,7 +50,11 @@ use client_core::cipher::mock::MockAbciTransactionObfuscation;
 #[cfg(not(feature = "mock-enclave"))]
 use client_core::cipher::DefaultTransactionObfuscation;
 
+#[cfg(not(feature = "mock-enclave"))]
 type AppTransactionCipher = DefaultTransactionObfuscation;
+#[cfg(feature = "mock-enclave")]
+type AppTransactionCipher = MockAbciTransactionObfuscation<WebsocketRpcClient>;
+
 type AppTxBuilder = DefaultWalletTransactionBuilder<SledStorage, LinearFee, AppTransactionCipher>;
 type AppWalletClient = DefaultWalletClient<SledStorage, WebsocketRpcClient, AppTxBuilder>;
 


### PR DESCRIPTION
Solution:
- Record utxo coins
- Do the check at the end of commit events.
- Optimize `sum_coins` to use `try_fold`
  ```
  utxo = withdraw - deposit - utxo transfer fee
  utxo + staking + reward_pool = initial distribution + minted
  minted <= expansion_cap
  initial distribution + expansion_cap = max supply
  ```