### PR TITLE
Problem (Fix #1520): `missed_block_threshold <= block_signing_window`not checked in init chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@
 
 ### Features
 
-- *chain-abci* [1458](https://github.com/crypto-com/chain/pull/1458): new abci_query path "sealed", query sealed log of transaction id.
+- *chain-abci* [1458](https://github.com/crypto-com/chain/pull/1458): new abci_query path "sealed", query sealed log of
+  transaction id
 
 ### Improvements
+
+- *chain-abci* [1521](https://github.com/crypto-com/chain/pull/1521): add network parameter validation rule:
+  `missed_block_threshold <= block_signing_window`
 
 ### Bug Fixes
 

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -1114,3 +1114,12 @@ fn query_should_return_proof_for_committed_tx() {
     }
     assert_eq!(proof.ops[1].data, txid_hash(&qresp.value));
 }
+
+#[test]
+#[should_panic]
+fn check_invalid_punishment_config() {
+    ChainEnv::new_with_customizer(Coin::max(), Coin::zero(), 2, |parameters| {
+        parameters.jailing_config.missed_block_threshold = 720;
+        parameters.jailing_config.block_signing_window = 360;
+    });
+}

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -38,6 +38,8 @@ pub enum DistributionError {
     /// problems with reward configuration
     /// TODO: embed the error type?
     InvalidRewardsParamter(&'static str),
+    /// Invalid punishment configuration parameter
+    InvalidPunishmentParamter,
 }
 
 impl fmt::Display for DistributionError {
@@ -73,6 +75,9 @@ impl fmt::Display for DistributionError {
             },
             DistributionError::InvalidRewardsParamter(err) => {
                 write!(f, "Invalid rewards parameters: {}", err)
+            }
+            DistributionError::InvalidPunishmentParamter => {
+                write!(f, "Invalid punishment parameters")
             }
         }
     }
@@ -183,6 +188,10 @@ impl InitConfig {
         &self,
         genesis_time: Timespec,
     ) -> Result<GenesisState, DistributionError> {
+        let jailing_config = &self.network_params.jailing_config;
+        if jailing_config.missed_block_threshold > jailing_config.block_signing_window {
+            return Err(DistributionError::InvalidPunishmentParamter);
+        }
         self.network_params
             .rewards_config
             .validate()


### PR DESCRIPTION
Solution:
- Add validation
