### PR TITLE
Problem (Fix #1518): reward multi-node integration test fails on TM 0.33.3/4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -e; \
     apt-get install -y libzmq3-dev libssl1.1 libprotobuf10 libsgx-launch libsgx-urts libsgx-epid libsgx-quote-ex; \
     rm -rf /var/lib/apt/lists/*
 # only for chain-test -- for some reason, multi-node integration tests fail
-COPY --from=tendermint/tendermint:v0.33.2 /usr/bin/tendermint /usr/bin/tendermint
+COPY --from=tendermint/tendermint:v0.33.4 /usr/bin/tendermint /usr/bin/tendermint
 
 FROM baiduxlab/sgx-rust:1804-1.1.2 AS BUILDER_BASE
 LABEL maintainer="blockchain@crypto.com"
@@ -38,7 +38,7 @@ RUN set -e; \
       clang; \
     rm -rf /var/lib/apt/lists/*
 # only for chain-test -- for some reason, multi-node integration tests fail
-COPY --from=tendermint/tendermint:v0.33.2 /usr/bin/tendermint /usr/bin/tendermint
+COPY --from=tendermint/tendermint:v0.33.4 /usr/bin/tendermint /usr/bin/tendermint
 
 FROM BUILDER_BASE AS TEST
 LABEL maintainer="blockchain@crypto.com"

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ endif
 
 IMAGE                  = crypto-chain
 IMAGE_RUST             = cryptocom/chain
-IMAGE_TENDERMINT       = tendermint/tendermint:v0.33.3
+IMAGE_TENDERMINT       = tendermint/tendermint:v0.33.4
 DOCKER_FILE            = docker/Dockerfile
 DOCKER_FILE_RELEASE    = docker/Dockerfile.release
 ITEMS_START            = sgx-query chain-abci tendermint client-rpc

--- a/integration-tests/multinode/reward_test.py
+++ b/integration-tests/multinode/reward_test.py
@@ -49,28 +49,34 @@ enckey2 = rpc2.wallet.enckey()
 bonded_staking2 = rpc2.address.list(enckey=enckey2)[0]
 
 state = rpc.chain.staking(bonded_staking2, height=2)
-assert int(state['bonded']) == init_bonded + minted // 2
-
+bonded_rewarded = init_bonded + minted // 2
 last_bonded = int(state['bonded'])
 block_time = latest_block_time(rpc)
 
-# wait for byzantine fault detected
-wait_for_blocks(rpc, 5)
-stop_node(supervisor, 'node1')
+if last_bonded == bonded_rewarded:
+    # wait for it to get jailed and slashed later
+    wait_for_blocks(rpc, 5)
 
-# jailed and slashed
-slashed = int(last_bonded * 0.2)
-state = rpc.chain.staking(bonded_staking2)
+    # jailed and slashed
+    slashed = int(last_bonded * 0.2)
+    state = rpc.chain.staking(bonded_staking2)
+    assert int(state['bonded']) == last_bonded - slashed, 'incorrect bonded: %s' % state['bonded']
+    last_bonded = int(state['bonded'])
+else:
+    # already jailed
+    slashed = int(init_bonded * 0.2)
+    assert last_bonded == bonded_rewarded - slashed, 'incorrect bonded: %s' % last_bonded
+
 assert state['validator']['jailed_until'] is not None
-assert int(state['bonded']) == last_bonded - slashed
+stop_node(supervisor, 'node1')
 
 # wait for reward period, for second reward distribution
 wait_for_blocktime(rpc, block_time + 10)
 # minted = 6182420000
-minted = monetary_expansion(last_bonded, int(145000000000000000 * 0.99986))
+minted = monetary_expansion(bonded_rewarded, int(145000000000000000 * 0.99986))
 
 state = rpc.chain.staking(bonded_staking2)
-assert int(state['bonded']) == last_bonded - slashed, 'jailed node don\'t get rewarded'
+assert int(state['bonded']) == last_bonded, 'jailed node don\'t get rewarded'
 
 state = rpc.chain.staking(bonded_staking)
-assert int(state['bonded']) == last_bonded + minted + slashed
+assert int(state['bonded']) == bonded_rewarded + minted + slashed


### PR DESCRIPTION
Solution:
- Make reward integration tests more stable
- Also upgrade the tendermint version in Dockerfile and Makefile