### PR TITLE
Problem: hotfix (0.5.1) release not documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Changelog
 
 *Unreleased*
-## v0.5.1 or v0.6.0 
+## v0.5.2 or v0.6.0 
 ### Breaking changes
 ### Features
 ### Improvements
 ### Bug Fixes
+
+*May 4, 2020*
+
+This release contains a hotfix for version reporting of chain-abci.
+
+## v0.5.1
+### Bug Fixes
+- *chain-abci* [1528](https://github.com/crypto-com/chain/pull/1528): correct app version returned on the first startup 
 
 *May 2, 2020*
 

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-abci"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Crypto.com <chain@crypto.com>"]
 description = "Pre-alpha version prototype of Crypto.com Chain node (Tendermint ABCI application)"
 readme = "README.md"


### PR DESCRIPTION
Solution: updated chain-abci ver + changelog

--
hot fix needed as restarting nodes may fail as observed by @lezzokafka @allthatjazzleo 
