### PR TITLE
Problem: `kvdb` crates not updated to their latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,12 +1951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4ebd0bd29be0f11973e9b3e219005661042a019fd757798c36a47c87852625"
 
 [[package]]
-name = "interleaved-ordered"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
+checksum = "e763b2a9b500ba47948061d1e8bc3b5f03a8a1f067dbcf822a4d2c84d2b54a3a"
 dependencies = [
  "parity-util-mem",
  "smallvec 1.4.0",
@@ -2128,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa954d12cfac958822dfd77aab34f3eec71f103b918c4ab79ab59a36ee594ea"
+checksum = "73027d5e228de6f503b5b7335d530404fc26230a6ae3e09b33ec6e45408509a4"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -2139,12 +2133,11 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f14c3a10c8894d26175e57e9e26032e6d6c49c30cbe2468c5bf5f6b64bb0be"
+checksum = "84384eca250c7ff67877eda5336f28a86586aaee24acb945643590671f6bfce1"
 dependencies = [
  "fs-swap",
- "interleaved-ordered",
  "kvdb",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus",
@@ -3471,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
+checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -52,8 +52,8 @@ quickcheck = "0.9"
 digest = "0.8"
 sha3 = "0.8"
 base64 = "0.11"
-kvdb = "0.5"
-kvdb-memorydb = "0.5"
+kvdb = "0.6"
+kvdb-memorydb = "0.6"
 test-common = { path = "../test-common" }
 
 # TODO: currently not maintained benchmarks

--- a/chain-abci/fuzz/Cargo.toml
+++ b/chain-abci/fuzz/Cargo.toml
@@ -12,8 +12,8 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.3"
 parity-scale-codec = { version = "1.1" }
-kvdb = "0.5"
-kvdb-memorydb = "0.5"
+kvdb = "0.6"
+kvdb-memorydb = "0.6"
 chain-storage = { path = "../../chain-storage" }
 chain-core = { path = "../../chain-core" }
 abci = "0.7"

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 blake3 = "0.3.3"
-kvdb = "0.5"
-kvdb-rocksdb = "0.7"
-kvdb-memorydb = "0.5"
+kvdb = "0.6"
+kvdb-rocksdb = "0.8"
+kvdb-memorydb = "0.6"
 chain-core = { path = "../chain-core" }
 bit-vec = { version = "0.6.1", features = ["serde_no_std"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }

--- a/chain-storage/src/jellyfish.rs
+++ b/chain-storage/src/jellyfish.rs
@@ -207,7 +207,7 @@ pub fn collect_stale_node_indices<S: KeyValueDB>(
     stale_since: BlockHeight,
 ) -> Vec<StaleNodeIndex> {
     storage
-        .iter_from_prefix(COL_TRIE_STALED, &stale_since.value().to_be_bytes())
+        .iter_with_prefix(COL_TRIE_STALED, &stale_since.value().to_be_bytes())
         .map(|(key, _)| decode_stale_node_index(&key).expect("storage corrupted"))
         .collect::<Vec<_>>()
 }

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-kvdb-memorydb = "0.5"
+kvdb-memorydb = "0.6"
 dirs = "2.0.1"
 quest = "0.3"
 secstr = "0.4.0"

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -15,7 +15,7 @@ secstr = { version = "0.4.0", features = ["serde"] }
 lazy_static  = { version = "1.4", features = ["spin_no_std"] }
 signature = "1.0.0-pre.1"
 abci = "0.7"
-kvdb-memorydb = "0.5"
+kvdb-memorydb = "0.6"
 protobuf = "2.7.0"
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }


### PR DESCRIPTION
Solution: Update version of `kvdb` crates to latest. Fixes #1542.