### PR TITLE
Problem: Cannot compile chain code with latest version of bit-vec (0.6.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,9 +288,9 @@ checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bit-vec"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 dependencies = [
  "serde",
 ]
@@ -477,7 +477,7 @@ version = "0.5.1"
 dependencies = [
  "abci",
  "base64 0.11.0",
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "byteorder",
  "cc",
  "chain-core",
@@ -540,7 +540,7 @@ name = "chain-storage"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "blake3",
  "chain-core",
  "criterion",
@@ -557,7 +557,7 @@ dependencies = [
 name = "chain-tx-filter"
 version = "0.5.0"
 dependencies = [
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "chain-core",
  "ethbloom",
  "hex 0.4.2",
@@ -711,7 +711,7 @@ version = "0.5.0"
 dependencies = [
  "base58",
  "base64 0.11.0",
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "byteorder",
  "chain-core",
  "chain-storage",
@@ -4746,7 +4746,7 @@ name = "tx-query-enclave"
 version = "0.5.0"
 dependencies = [
  "base64 0.10.1",
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "cc",
  "chain-core",
  "chrono 0.4.11 (git+https://github.com/mesalock-linux/chrono-sgx)",
@@ -5227,7 +5227,7 @@ name = "yasna"
 version = "0.3.1"
 source = "git+https://github.com/mesalock-linux/yasna.rs-sgx#e28d16ecb426975d10ab792179e4d4f473ab872d"
 dependencies = [
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "chrono 0.4.11 (git+https://github.com/mesalock-linux/chrono-sgx)",
  "num-bigint 0.2.5",
  "sgx_tstd",
@@ -5239,7 +5239,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a563d10ead87e2d798e357d44f40f495ad70bcee4d5c0d3f77a5b1b7376645d9"
 dependencies = [
- "bit-vec 0.6.1",
+ "bit-vec 0.6.2",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.6",
 ]

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -21,7 +21,7 @@ enclave-protocol = { path = "../enclave-protocol" }
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
 log = "0.4.8"
 env_logger = "0.7.1"
-bit-vec = { version = "0.6.1", features = ["serde_no_std"] }
+bit-vec = { version = "0.6.2", features = ["serde_no_std"] }
 byteorder = "1.3.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -12,7 +12,7 @@ kvdb = "0.6"
 kvdb-rocksdb = "0.8"
 kvdb-memorydb = "0.6"
 chain-core = { path = "../chain-core" }
-bit-vec = { version = "0.6.1", features = ["serde_no_std"] }
+bit-vec = { version = "0.6.2", features = ["serde_no_std"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 integer-encoding = "1.1.5"
 anyhow = "1.0"

--- a/chain-tx-enclave/tx-query/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-query/enclave/Cargo.toml
@@ -31,7 +31,7 @@ webpki      = { git = "https://github.com/mesalock-linux/webpki", branch = "mesa
 base64      = { git = "https://github.com/mesalock-linux/rust-base64-sgx", features = ["mesalock_sgx"] }
 yasna       = { git = "https://github.com/mesalock-linux/yasna.rs-sgx", features = ["bit-vec", "num-bigint", "chrono"] }
 num-bigint  = { git = "https://github.com/mesalock-linux/num-bigint-sgx", features = ["mesalock_sgx"] }
-bit-vec     = { version = "0.6.1", default-features = false}
+bit-vec     = { version = "0.6.2", default-features = false}
 httparse    = { version = "1.3.2", default-features = false }
 itertools   = { version = "0.9", default-features = false, features = []}
 rustls      = { git = "https://github.com/mesalock-linux/rustls", branch = "mesalock_sgx" }

--- a/chain-tx-filter/src/filter.rs
+++ b/chain-tx-filter/src/filter.rs
@@ -72,19 +72,19 @@ impl Bloom {
 
     /// Adds the other bloom filter to the current one
     pub fn add(&mut self, other: &Bloom) {
-        self.0.union(&other.0);
+        self.0.or(&other.0);
     }
 
     /// Set respective bits in the bloom with the array
     pub fn set(&mut self, arr: &[u8]) {
-        self.0.union(&single_set(arr));
+        self.0.or(&single_set(arr));
     }
 
     /// Check that an array is in the bloom
     pub fn check(&self, arr: &[u8]) -> bool {
         let s1 = single_set(arr);
         let mut s2 = s1.clone();
-        s2.intersect(&self.0);
+        s2.and(&self.0);
 
         s2 == s1
     }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -27,7 +27,7 @@ base64 = "0.11"
 webpki = "0.21"
 rustls =  { version = "0.17", features = ["dangerous_configuration"] }
 yasna = { version = "0.3.1", features = ["bit-vec", "num-bigint", "chrono"], optional = true }
-bit-vec = "0.6.1"
+bit-vec = "0.6.2"
 num-bigint = "0.2.5"
 serde_json = "1.0.52"
 uuid = { version = "0.8.1", features = ["v4"] }


### PR DESCRIPTION
Solution: Removed calls to deprecated functions. Fixes #1554.