### PR TITLE
Problem: `dev-utils` cannot generate `genesis.json` for testnet

### DIFF
--- a/dev-utils/src/commands/init_command.rs
+++ b/dev-utils/src/commands/init_command.rs
@@ -214,6 +214,7 @@ impl InitCommand {
                 .duration_since(Time::unix_epoch())
                 .unwrap()
                 .as_secs(),
+            &None,
         )
         .unwrap();
         self.app_hash = result.0;


### PR DESCRIPTION
Solution: Added a new option in genesis generation command (`unbonded_address`). If `unbonded_address` is provided, all other staking addresses will be marked as `Bonded` except for the one provided in `unbonded_address`, which will be marked as `UnbondedFromGenesis`. If `unbonded_address` is not provided, everything will work the same.