### PR TITLE
Problem: (fix #1437) No multisignature address generation in client-cli

### DIFF
--- a/client-cli/src/command/multisig_command.rs
+++ b/client-cli/src/command/multisig_command.rs
@@ -1,7 +1,9 @@
-use quest::success;
+use quest::{ask, success, text};
+use std::str::FromStr;
 use structopt::StructOpt;
 
-use client_common::{PublicKey, Result};
+use super::address_command::ask_public_key;
+use client_common::{ErrorKind, PublicKey, Result, ResultExt};
 use client_core::types::AddressType;
 use client_core::WalletClient;
 
@@ -36,6 +38,38 @@ pub enum MultiSigCommand {
         )]
         name: String,
     },
+
+    #[structopt(name = "new-address", about = "Create a new MultiSig address")]
+    CreateMultiSigAddress {
+        #[structopt(
+            name = "wallet name",
+            short = "n",
+            long = "name",
+            help = "Name of wallet"
+        )]
+        name: String,
+        #[structopt(
+            name = "public keys",
+            short = "p",
+            long = "public_keys",
+            help = "public keys, included self public key, separated by commas"
+        )]
+        public_keys: Option<String>,
+        #[structopt(
+            name = "self public key",
+            short = "s",
+            long = "self_public_key",
+            help = "self public key"
+        )]
+        self_public_key: Option<String>,
+        #[structopt(
+            name = "number of required signature",
+            short = "r",
+            long = "required_signature",
+            help = "the number of required signature"
+        )]
+        required_signatures: Option<usize>,
+    },
 }
 
 impl MultiSigCommand {
@@ -47,6 +81,18 @@ impl MultiSigCommand {
             MultiSigCommand::ListAddressPublicKeys { name } => {
                 list_address_public_keys(wallet_client, name)
             }
+            MultiSigCommand::CreateMultiSigAddress {
+                name,
+                public_keys,
+                self_public_key,
+                required_signatures,
+            } => new_multisign_address(
+                wallet_client,
+                name,
+                public_keys,
+                self_public_key,
+                required_signatures,
+            ),
         }
     }
 }
@@ -79,4 +125,64 @@ fn list_address_public_keys<T: WalletClient>(wallet_client: T, name: &str) -> Re
     }
 
     Ok(())
+}
+
+fn new_multisign_address<T: WalletClient>(
+    wallet_client: T,
+    name: &str,
+    public_keys: &Option<String>,
+    self_public_key: &Option<String>,
+    required_pubkey: &Option<usize>,
+) -> Result<()> {
+    let enckey = ask_seckey(None)?;
+    let public_keys_str = match public_keys {
+        None => ask_public_keys(None)?,
+        Some(s) => s.clone(),
+    };
+    let pubkeys = public_keys_str
+        .split(',')
+        .map(|s| PublicKey::from_str(s.trim()))
+        .collect::<Result<Vec<_>>>()
+        .chain(|| (ErrorKind::InvalidInput, "Invalid public key"))?;
+
+    let self_public_key = match self_public_key {
+        None => ask_public_key(Some("input self pulblic key: "))?,
+        Some(p) => PublicKey::from_str(p)?,
+    };
+    wallet_client
+        .private_key(name, &enckey, &self_public_key)
+        .chain(|| {
+            (
+                ErrorKind::InvalidInput,
+                "Self public key does not belong to current wallet",
+            )
+        })?;
+    let n = match required_pubkey {
+        None => ask_required_signature()?,
+        Some(n) => *n,
+    };
+    let extended_address =
+        wallet_client.new_multisig_transfer_address(&name, &enckey, pubkeys, self_public_key, n)?;
+
+    let msg = format!("MultiSign address: {}", extended_address.to_string());
+    success(&msg);
+    Ok(())
+}
+
+fn ask_required_signature() -> Result<usize> {
+    ask("how many signatures required: ");
+    let n = text().err_kind(ErrorKind::InvalidInput, || {
+        "Unable to read required signatures number"
+    })?;
+    let n = n
+        .parse::<usize>()
+        .chain(|| (ErrorKind::InvalidInput, "Invalid number"))?;
+    Ok(n)
+}
+
+pub fn ask_public_keys(message: Option<&str>) -> Result<String> {
+    ask(message.unwrap_or("Enter public keys(include self public key, separated by commas): "));
+    let pubkeys_str = text().chain(|| (ErrorKind::InvalidInput, "Invalid input"))?;
+    Ok(pubkeys_str)
+    //    Ok(pubkeys)
 }

--- a/client-core/src/service/root_hash_service.rs
+++ b/client-core/src/service/root_hash_service.rs
@@ -103,7 +103,7 @@ where
 
     /// Returns MultiSig address from storage with the given root_hash
     /// decrypted with enckey
-    fn get_multi_sig_address_from_root_hash(
+    pub fn get_multi_sig_address_from_root_hash(
         &self,
         name: &str,
         root_hash: &H256,

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -24,7 +24,8 @@ use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::TxAux;
 use client_common::tendermint::types::BroadcastTxResponse;
 use client_common::{
-    PrivateKey, PrivateKeyAction, PublicKey, Result, SecKey, Transaction, TransactionInfo,
+    MultiSigAddress, PrivateKey, PrivateKeyAction, PublicKey, Result, SecKey, Transaction,
+    TransactionInfo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -242,6 +243,9 @@ pub trait WalletClient: Send + Sync {
         self_public_key: PublicKey,
         m: usize,
     ) -> Result<ExtendedAddr>;
+
+    /// get the multisig addresses
+    fn get_multisig_addresses(&self, name: &str, enckey: &SecKey) -> Result<Vec<MultiSigAddress>>;
 
     /// Generates inclusion proof for set of public keys in multi-sig address
     fn generate_proof(

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -30,8 +30,8 @@ use client_common::tendermint::types::Time;
 use client_common::tendermint::types::{AbciQueryExt, BlockResults, BroadcastTxResponse};
 use client_common::tendermint::{Client, UnauthorizedClient};
 use client_common::{
-    seckey::derive_enckey, Error, ErrorKind, PrivateKey, PrivateKeyAction, PublicKey, Result,
-    ResultExt, SecKey, SignedTransaction, Storage, Transaction, TransactionInfo,
+    seckey::derive_enckey, Error, ErrorKind, MultiSigAddress, PrivateKey, PrivateKeyAction,
+    PublicKey, Result, ResultExt, SecKey, SignedTransaction, Storage, Transaction, TransactionInfo,
 };
 use indexmap::IndexSet;
 use parity_scale_codec::Encode;
@@ -742,6 +742,17 @@ where
         self.wallet_service.add_root_hash(name, enckey, root_hash)?;
 
         Ok(multi_sig_address.into())
+    }
+
+    fn get_multisig_addresses(&self, name: &str, enckey: &SecKey) -> Result<Vec<MultiSigAddress>> {
+        let root_hashes = self.wallet_service.root_hashes(name, enckey)?;
+        root_hashes
+            .iter()
+            .map(|hash| {
+                self.root_hash_service
+                    .get_multi_sig_address_from_root_hash(name, hash, enckey)
+            })
+            .collect::<Result<Vec<MultiSigAddress>>>()
     }
 
     fn generate_proof(


### PR DESCRIPTION
* add command `new-address` in `client-cli multisig`
* classify the transfer addresses in client-cli print out, it looks like:

```
Address: dcro18cae94afx0qxjm3cvayyavxu9vnvuqrlexxhgqyt3vyumfm2spnq0f5kcf
MultiSig Address: dcro1w489pglfzv9lam9r6e656tmdu28sxhtgk6psfcw7rghhhfcx2qkq7qk9mr(3/4)
```