### PR TITLE
Problem: lvi hardening not enabled

### DIFF
--- a/chain-tx-enclave/common.mk
+++ b/chain-tx-enclave/common.mk
@@ -11,6 +11,110 @@ SGX_MODE ?= SW
 SGX_ARCH ?= x64
 SGX_DEBUG ?= 1
 
+# turn on stack protector for SDK
+COMMON_FLAGS += -fstack-protector
+
+ifdef DEBUG
+    COMMON_FLAGS += -O0 -g -DDEBUG -UNDEBUG
+else
+    COMMON_FLAGS += -O2 -D_FORTIFY_SOURCE=2 -UDEBUG -DNDEBUG
+endif
+
+# turn on compiler warnings as much as possible
+COMMON_FLAGS += -Wall -Wextra -Winit-self -Wpointer-arith -Wreturn-type \
+		-Waddress -Wsequence-point -Wformat-security \
+		-Wmissing-include-dirs -Wfloat-equal -Wundef -Wshadow \
+		-Wcast-align -Wconversion -Wredundant-decls
+# additional warnings flags for C
+CFLAGS += -Wjump-misses-init -Wstrict-prototypes -Wunsuffixed-float-constants
+
+# additional warnings flags for C++
+CXXFLAGS += -Wnon-virtual-dtor
+
+# for static_assert()
+CXXFLAGS += -std=c++0x
+
+ifeq ($(ARCH), x86)
+COMMON_FLAGS += -DITT_ARCH_IA32
+else
+COMMON_FLAGS += -DITT_ARCH_IA64
+endif
+
+CFLAGS   += $(COMMON_FLAGS)
+CXXFLAGS += $(COMMON_FLAGS)
+
+# Enable the security flags
+COMMON_LDFLAGS := -Wl,-z,relro,-z,now,-z,noexecstack
+
+MITIGATION-CVE-2020-0551 ?= LOAD
+
+# mitigation options
+MITIGATION_INDIRECT ?= 0
+MITIGATION_RET ?= 0
+MITIGATION_C ?= 0
+MITIGATION_ASM ?= 0
+MITIGATION_AFTERLOAD ?= 0
+MITIGATION_LIB_PATH :=
+
+ifeq ($(MITIGATION-CVE-2020-0551), LOAD)
+    MITIGATION_C := 1
+    MITIGATION_ASM := 1
+    MITIGATION_INDIRECT := 1
+    MITIGATION_RET := 1
+    MITIGATION_AFTERLOAD := 1
+    MITIGATION_LIB_PATH := cve_2020_0551_load
+else ifeq ($(MITIGATION-CVE-2020-0551), CF)
+    MITIGATION_C := 1
+    MITIGATION_ASM := 1
+    MITIGATION_INDIRECT := 1
+    MITIGATION_RET := 1
+    MITIGATION_AFTERLOAD := 0
+    MITIGATION_LIB_PATH := cve_2020_0551_cf
+endif
+
+MITIGATION_CFLAGS :=
+MITIGATION_ASFLAGS :=
+ifeq ($(MITIGATION_C), 1)
+ifeq ($(MITIGATION_INDIRECT), 1)
+    MITIGATION_CFLAGS += -mindirect-branch-register
+endif
+ifeq ($(MITIGATION_RET), 1)
+    MITIGATION_CFLAGS += -mfunction-return=thunk-extern
+endif
+endif
+
+ifeq ($(MITIGATION_ASM), 1)
+    MITIGATION_ASFLAGS += -fno-plt
+ifeq ($(MITIGATION_AFTERLOAD), 1)
+    MITIGATION_ASFLAGS += -Wa,-mlfence-after-load=yes
+else
+    MITIGATION_ASFLAGS += -Wa,-mlfence-before-indirect-branch=register
+endif
+ifeq ($(MITIGATION_RET), 1)
+    MITIGATION_ASFLAGS += -Wa,-mlfence-before-ret=not
+endif
+endif
+
+MITIGATION_CFLAGS += $(MITIGATION_ASFLAGS)
+
+# Compiler and linker options for an Enclave
+#
+# We are using '--export-dynamic' so that `g_global_data_sim' etc.
+# will be exported to dynamic symbol table.
+#
+# When `pie' is enabled, the linker (both BFD and Gold) under Ubuntu 14.04
+# will hide all symbols from dynamic symbol table even if they are marked
+# as `global' in the LD version script.
+ENCLAVE_CFLAGS   = -ffreestanding -nostdinc -fvisibility=hidden -fpie -fno-strict-overflow -fno-delete-null-pointer-checks
+ENCLAVE_CXXFLAGS = $(ENCLAVE_CFLAGS) -nostdinc++
+ENCLAVE_LDFLAGS  = $(COMMON_LDFLAGS) -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
+                   -Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
+                   -Wl,--gc-sections \
+                   -Wl,--defsym,__ImageBase=0
+
+ENCLAVE_CFLAGS += $(MITIGATION_CFLAGS)
+ENCLAVE_ASFLAGS = $(MITIGATION_ASFLAGS)
+
 ifeq ($(shell getconf LONG_BIT), 32)
 	SGX_ARCH := x86
 else ifeq ($(findstring -m32, $(CXXFLAGS)), -m32)
@@ -60,11 +164,8 @@ RustEnclave_Link_Flags := -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfi
 	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
 	-Wl,--start-group -lsgx_tcxx -lsgx_tstdc -l$(Service_Library_Name) -l$(Crypto_Library_Name) \
    	$(Enclave_Static_Lib) -Wl,--end-group \
-	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
-	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
-	-Wl,--defsym,__ImageBase=0 \
-	-Wl,--gc-sections \
-	-Wl,--version-script=enclave/Enclave.lds
+	-Wl,--version-script=enclave/Enclave.lds \
+	$(ENCLAVE_LDFLAGS)
 
 .PHONY: all
 all: $(Enclave_Signed_Lib)

--- a/chain-tx-enclave/tx-query/enclave/build.rs
+++ b/chain-tx-enclave/tx-query/enclave/build.rs
@@ -23,17 +23,51 @@ fn main() {
         .status()
         .unwrap();
 
-    cc::Build::new()
+    let mut build = cc::Build::new();
+
+    build
         .file("Enclave_t.c")
         .include("../../rust-sgx-sdk/common/inc")
         .include("../../rust-sgx-sdk/edl")
         .include(&format!("{}/include", sdk_dir))
         .include(&format!("{}/include/tlibc", sdk_dir))
-        .flag("-nostdinc")
-        .flag("-fvisibility=hidden")
-        .flag("-fpie")
+        .opt_level(2)
         .flag("-fstack-protector")
-        .compile("enclave.a");
+        .flag("-ffreestanding")
+        .flag("-fpie")
+        .flag("-fno-strict-overflow")
+        .flag("-fno-delete-null-pointer-checks")
+        .flag("-fvisibility=hidden");
+
+    let mitigation_cflags1 = "-mindirect-branch-register";
+    let mitigation_cflags2 = "-mfunction-return=thunk-extern";
+    let mitigation_asflags = "-fno-plt";
+    let mitigation_loadflags1 = "-Wa,-mlfence-after-load=yes";
+    let mitigation_loadflags2 = "-Wa,-mlfence-before-ret=not";
+    let mitigation_cfflags1 = "-Wa,-mlfence-before-indirect-branch=register";
+    let mitigation_cfflags2 = "-Wa,-mlfence-before-ret=not";
+    let mitigation = env::var("MITIGATION_CVE_2020_0551").unwrap_or("LOAD".to_owned());
+    match mitigation.as_ref() {
+        "LOAD" => {
+            build
+                .flag(mitigation_cflags1)
+                .flag(mitigation_cflags2)
+                .flag(mitigation_asflags)
+                .flag(mitigation_loadflags1)
+                .flag(mitigation_loadflags2);
+        }
+        "CF" => {
+            build
+                .flag(mitigation_cflags1)
+                .flag(mitigation_cflags2)
+                .flag(mitigation_asflags)
+                .flag(mitigation_cfflags1)
+                .flag(mitigation_cfflags2);
+        }
+        _ => {}
+    }
+
+    build.compile("enclave.a");
 
     println!("cargo:rerun-if-changed=Enclave.edl");
 }

--- a/chain-tx-enclave/tx-validation/enclave/build.rs
+++ b/chain-tx-enclave/tx-validation/enclave/build.rs
@@ -22,18 +22,51 @@ fn main() {
         ])
         .status()
         .unwrap();
+    let mut build = cc::Build::new();
 
-    cc::Build::new()
+    build
         .file("Enclave_t.c")
         .include("../../rust-sgx-sdk/common/inc")
         .include("../../rust-sgx-sdk/edl")
         .include(&format!("{}/include", sdk_dir))
         .include(&format!("{}/include/tlibc", sdk_dir))
-        .flag("-nostdinc")
-        .flag("-fvisibility=hidden")
-        .flag("-fpie")
+        .opt_level(2)
         .flag("-fstack-protector")
-        .compile("enclave.a");
+        .flag("-ffreestanding")
+        .flag("-fpie")
+        .flag("-fno-strict-overflow")
+        .flag("-fno-delete-null-pointer-checks")
+        .flag("-fvisibility=hidden");
+
+    let mitigation_cflags1 = "-mindirect-branch-register";
+    let mitigation_cflags2 = "-mfunction-return=thunk-extern";
+    let mitigation_asflags = "-fno-plt";
+    let mitigation_loadflags1 = "-Wa,-mlfence-after-load=yes";
+    let mitigation_loadflags2 = "-Wa,-mlfence-before-ret=not";
+    let mitigation_cfflags1 = "-Wa,-mlfence-before-indirect-branch=register";
+    let mitigation_cfflags2 = "-Wa,-mlfence-before-ret=not";
+    let mitigation = env::var("MITIGATION_CVE_2020_0551").unwrap_or("LOAD".to_owned());
+    match mitigation.as_ref() {
+        "LOAD" => {
+            build
+                .flag(mitigation_cflags1)
+                .flag(mitigation_cflags2)
+                .flag(mitigation_asflags)
+                .flag(mitigation_loadflags1)
+                .flag(mitigation_loadflags2);
+        }
+        "CF" => {
+            build
+                .flag(mitigation_cflags1)
+                .flag(mitigation_cflags2)
+                .flag(mitigation_asflags)
+                .flag(mitigation_cfflags1)
+                .flag(mitigation_cfflags2);
+        }
+        _ => {}
+    }
+
+    build.compile("enclave.a");
 
     println!("cargo:rerun-if-changed=Enclave.edl");
 }


### PR DESCRIPTION
Solution: updated Makefile + build.rs flags
Note that this covers the Intel SDK-related C code.
For Rust code, there's a pending PR to update LLVM
https://github.com/rust-lang/llvm-project/pull/58/commits/88008b8cd7b5e165a830f33b7d946b8bd3ec2a51#diff-c9b310226bd6dbea006b9c172ffed354R2331
