### PR TITLE
Problem: No way to create mutually attested enclave-to-enclave TLS connections

### DIFF
--- a/chain-tx-enclave/enclave-ra/ra-enclave/src/lib.rs
+++ b/chain-tx-enclave/enclave-ra/ra-enclave/src/lib.rs
@@ -16,7 +16,8 @@
 //! let context = EnclaveRaContext::new(&config).unwrap();
 //! let certificate = context.get_certificate().unwrap();
 //!
-//! let tls_server_config: ServerConfig = certificate.try_into().unwrap();
+//! let mut server_config = ServerConfig::new(NoClientAuth::new());
+//! certificate.configure_server_config(&mut server_config).unwrap();
 //!
 //! // This `server_config` can now be used to create a `rustls::Stream`.
 //! ```

--- a/client-core/src/cipher/default.rs
+++ b/client-core/src/cipher/default.rs
@@ -55,7 +55,7 @@ fn get_tls_config() -> Result<Arc<rustls::ClientConfig>> {
             "Cannot initialize enclave certificate verifier",
         )
     })?;
-    Ok(Arc::new(verifier.into()))
+    Ok(Arc::new(verifier.into_client_config()))
 }
 
 /// Implementation of transaction obfuscation which directly talks to transaction decryption query and encryption enclaves


### PR DESCRIPTION
Solution: Added constructs for creating attested enclave-to-enclave TLS connections

- `EnclaveCertVerifier` now implements `ClientCertVerifier`
- Added some utility functions for creating `rustls::ServerConfig` and `rustls::ClientConfig`

Related to #1549.