### PR TITLE
Problem: edp related crates conflicts with hacks for old enclave code

### DIFF
--- a/architecture-docs/adr-002.md
+++ b/architecture-docs/adr-002.md
@@ -3,6 +3,7 @@
 ## Changelog
 * 10-03-2020: Initial Draft
 * 11-03-2020: Decision based on Slack discussion
+* 19-05-2020: Use standalone directory for edp codes
 
 ## Context
 The prototype enclave code in Rust has been developed using Apache Teaclave SGX SDK, which wraps Intel SDK
@@ -36,6 +37,9 @@ The code will be progressively moved to EDP across different PRs:
 * runner with zMQ to replace tx-query: the usercall extension will bridge the zMQ connection requests and replies
 * other implementation work: "transaction bootstrapping enclave" work may begin with enclave-to-enclave connections leveraging the above
 * port tx-validation: add a runner to chain-abci that will load tx-validation's sgxs and relay the the requests
+* put the edp enclave crates in standalone directory `chain-tx-enclave-next`, to prevent conflicts with some hacks for old enclave
+  codes.
+  After tx-validation and tx-query ported, remove the `chain-tx-enclave` directory, and rename `chain-tx-enclave-next` to `chain-tx-enclave`.
 
 ## Status
 


### PR DESCRIPTION
Solution:
- Put edp related crates in a standalone directory