### PR TITLE
Problem (#1483): client rpc setup code is duplicated between server and c-api

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -26,7 +26,9 @@ use client_common::{ErrorKind, Result, ResultExt, SecKey, Storage};
 use client_core::signer::WalletSignerManager;
 use client_core::transaction_builder::DefaultWalletTransactionBuilder;
 use client_core::types::BalanceChange;
-use client_core::wallet::syncer::{ObfuscationSyncerConfig, ProgressReport, WalletSyncer};
+use client_core::wallet::syncer::{
+    ObfuscationSyncerConfig, ProgressReport, SyncerOptions, WalletSyncer,
+};
 use client_core::wallet::{DefaultWalletClient, WalletClient};
 use client_core::TransactionObfuscation;
 use client_network::network_ops::{DefaultNetworkOpsClient, NetworkOpsClient};
@@ -390,10 +392,12 @@ impl Command {
                     storage.clone(),
                     tendermint_client,
                     tx_obfuscation,
-                    !*disable_fast_forward,
-                    !*disable_address_recovery,
-                    *batch_size,
-                    *block_height_ensure,
+                    SyncerOptions {
+                        enable_fast_forward: !*disable_fast_forward,
+                        enable_address_recovery: !*disable_address_recovery,
+                        batch_size: *batch_size,
+                        block_height_ensure: *block_height_ensure,
+                    },
                 );
                 Self::resync(config, name.clone(), enckey, *force, storage)
             }

--- a/client-rpc/src/handler.rs
+++ b/client-rpc/src/handler.rs
@@ -1,0 +1,182 @@
+use jsonrpc_core::IoHandler;
+
+use chain_core::tx::fee::LinearFee;
+use client_common::storage::SledStorage;
+use client_common::tendermint::{types::GenesisExt, Client, WebsocketRpcClient};
+use client_common::Result;
+use client_core::cipher::TransactionObfuscation;
+use client_core::cipher::{mock::MockAbciTransactionObfuscation, DefaultTransactionObfuscation};
+use client_core::service::HwKeyService;
+use client_core::signer::WalletSignerManager;
+use client_core::transaction_builder::DefaultWalletTransactionBuilder;
+use client_core::wallet::syncer::{ObfuscationSyncerConfig, SyncerOptions};
+use client_core::wallet::DefaultWalletClient;
+use client_network::network_ops::DefaultNetworkOpsClient;
+
+use crate::rpc::{
+    multisig_rpc::{MultiSigRpc, MultiSigRpcImpl},
+    staking_rpc::{StakingRpc, StakingRpcImpl},
+    sync_rpc::{CBindingCore, SyncRpc, SyncRpcImpl},
+    transaction_rpc::{TransactionRpc, TransactionRpcImpl},
+    wallet_rpc::{WalletRpc, WalletRpcImpl},
+};
+
+type AppWalletClient<O> = DefaultWalletClient<
+    SledStorage,
+    WebsocketRpcClient,
+    DefaultWalletTransactionBuilder<SledStorage, LinearFee, O>,
+>;
+type AppOpsClient<O> =
+    DefaultNetworkOpsClient<AppWalletClient<O>, SledStorage, WebsocketRpcClient, LinearFee, O>;
+type AppSyncerConfig<O> = ObfuscationSyncerConfig<SledStorage, WebsocketRpcClient, O>;
+
+#[derive(Clone)]
+pub struct RpcHandler {
+    pub io: IoHandler,
+}
+
+impl RpcHandler {
+    fn new_impl<O, F>(
+        storage_dir: &str,
+        websocket_url: &str,
+        network_id: u8,
+        sync_options: SyncerOptions,
+        progress_callback: Option<CBindingCore>,
+        get_obfuscator: F,
+    ) -> Result<Self>
+    where
+        O: TransactionObfuscation + 'static,
+        F: Fn(&WebsocketRpcClient) -> Result<O>,
+    {
+        let mut io = IoHandler::new();
+        let storage = SledStorage::new(&storage_dir)?;
+        let tendermint_client = WebsocketRpcClient::new(&websocket_url)?;
+        let fee_policy = tendermint_client.genesis()?.fee_policy();
+        let obfuscator: O = get_obfuscator(&tendermint_client)?;
+
+        let wallet_client = make_wallet_client(
+            storage.clone(),
+            tendermint_client.clone(),
+            fee_policy,
+            obfuscator.clone(),
+        )?;
+        let ops_client = make_ops_client(
+            storage.clone(),
+            tendermint_client.clone(),
+            fee_policy,
+            obfuscator.clone(),
+        )?;
+        let syncer_config = AppSyncerConfig::new(
+            storage.clone(),
+            tendermint_client.clone(),
+            obfuscator.clone(),
+            sync_options,
+        );
+
+        let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
+        let transaction_rpc = TransactionRpcImpl::new(network_id);
+        let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
+
+        let sync_wallet_client =
+            make_wallet_client(storage, tendermint_client, fee_policy, obfuscator)?;
+
+        let sync_rpc = SyncRpcImpl::new(syncer_config, progress_callback, sync_wallet_client);
+        let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
+
+        io.extend_with(multisig_rpc.to_delegate());
+        io.extend_with(transaction_rpc.to_delegate());
+        io.extend_with(staking_rpc.to_delegate());
+        io.extend_with(sync_rpc.to_delegate());
+        io.extend_with(wallet_rpc.to_delegate());
+
+        Ok(RpcHandler { io })
+    }
+
+    pub fn new(
+        storage_dir: &str,
+        websocket_url: &str,
+        network_id: u8,
+        sync_options: SyncerOptions,
+        progress_callback: Option<CBindingCore>,
+    ) -> Result<Self> {
+        Self::new_impl(
+            storage_dir,
+            websocket_url,
+            network_id,
+            sync_options,
+            progress_callback,
+            get_tx_query,
+        )
+    }
+
+    pub fn new_mock(
+        storage_dir: &str,
+        websocket_url: &str,
+        network_id: u8,
+        sync_options: SyncerOptions,
+        progress_callback: Option<CBindingCore>,
+    ) -> Result<Self> {
+        Self::new_impl(
+            storage_dir,
+            websocket_url,
+            network_id,
+            sync_options,
+            progress_callback,
+            get_tx_query_mock,
+        )
+    }
+
+    pub fn handle(&self, req: &str) -> Option<String> {
+        self.io.handle_request_sync(req)
+    }
+}
+
+fn get_tx_query(tendermint_client: &WebsocketRpcClient) -> Result<impl TransactionObfuscation> {
+    DefaultTransactionObfuscation::from_tx_query(tendermint_client)
+}
+
+fn get_tx_query_mock(
+    tendermint_client: &WebsocketRpcClient,
+) -> Result<impl TransactionObfuscation> {
+    MockAbciTransactionObfuscation::from_tx_query(tendermint_client)
+}
+
+fn make_wallet_client<O: TransactionObfuscation>(
+    storage: SledStorage,
+    tendermint_client: WebsocketRpcClient,
+    fee_policy: LinearFee,
+    obfuscator: O,
+) -> Result<AppWalletClient<O>> {
+    let hw_key_service = HwKeyService::default();
+    let signer_manager = WalletSignerManager::new(storage.clone(), hw_key_service.clone());
+    Ok(DefaultWalletClient::new(
+        storage,
+        tendermint_client,
+        DefaultWalletTransactionBuilder::new(signer_manager, fee_policy, obfuscator),
+        Some(50),
+        hw_key_service,
+    ))
+}
+
+fn make_ops_client<O: TransactionObfuscation>(
+    storage: SledStorage,
+    tendermint_client: WebsocketRpcClient,
+    fee_policy: LinearFee,
+    obfuscator: O,
+) -> Result<AppOpsClient<O>> {
+    let hw_key_service = HwKeyService::default();
+    let signer_manager = WalletSignerManager::new(storage.clone(), hw_key_service);
+    let wallet_client = make_wallet_client(
+        storage,
+        tendermint_client.clone(),
+        fee_policy,
+        obfuscator.clone(),
+    )?;
+    Ok(DefaultNetworkOpsClient::new(
+        wallet_client,
+        signer_manager,
+        tendermint_client,
+        fee_policy,
+        obfuscator,
+    ))
+}

--- a/client-rpc/src/lib.rs
+++ b/client-rpc/src/lib.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
+pub mod handler;
 pub mod rpc;
+
+pub use handler::RpcHandler;
 
 pub fn to_rpc_error<E: ToString + Debug>(error: E) -> jsonrpc_core::Error {
     log::error!("{:?}", error);

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [lib]
 name = "cro_clib"
-crate-type =["staticlib"]
+crate-type = ["staticlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cro-clib/chain.h
+++ b/cro-clib/chain.h
@@ -19,6 +19,8 @@ typedef struct CroJsonRpc CroJsonRpc;
 
 typedef struct CroTx CroTx;
 
+typedef struct Option_ProgressCallback Option_ProgressCallback;
+
 typedef struct CroResult {
   int result;
 } CroResult;
@@ -30,12 +32,6 @@ typedef CroFee *CroFeePtr;
 typedef CroHDWallet *CroHDWalletPtr;
 
 typedef CroJsonRpc *CroJsonRpcPtr;
-
-/**
- * current, start, end, userdata
- * return: 1: continue, 0: stop
- */
-typedef int32_t (*ProgressCallback)(uint64_t, uint64_t, uint64_t, const void*);
 
 typedef CroTx *CroTxPtr;
 
@@ -140,7 +136,20 @@ CroResult cro_create_jsonrpc(CroJsonRpcPtr *rpc_out,
                              const char *storage_dir_user,
                              const char *websocket_url_user,
                              uint8_t network_id,
-                             ProgressCallback progress_callback);
+                             Option_ProgressCallback progress_callback);
+
+/**
+ * mock mode, only use for testing
+ *
+ * # Safety
+ *
+ * Should not be called with null pointers.
+ */
+CroResult cro_create_mock_jsonrpc(CroJsonRpcPtr *rpc_out,
+                                  const char *storage_dir_user,
+                                  const char *websocket_url_user,
+                                  uint8_t network_id,
+                                  Option_ProgressCallback progress_callback);
 
 /**
  * create staking address from bip44 hdwallet
@@ -336,8 +345,24 @@ CroResult cro_jsonrpc_call(const char *storage_dir,
                            const char *request,
                            char *buf,
                            uintptr_t buf_size,
-                           ProgressCallback progress_callback,
+                           Option_ProgressCallback progress_callback,
                            const void *user_data);
+
+/**
+ * mock mode, only use for testing
+ *
+ * # Safety
+ *
+ * Should not be called with null pointers.
+ */
+CroResult cro_jsonrpc_call_mock(const char *storage_dir,
+                                const char *websocket_url,
+                                uint8_t network_id,
+                                const char *request,
+                                char *buf,
+                                uintptr_t buf_size,
+                                Option_ProgressCallback progress_callback,
+                                const void *user_data);
 
 /**
  * # Safety

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -1,109 +1,20 @@
-use jsonrpc_core::IoHandler;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
+use std::sync::Arc;
+use std::sync::Mutex;
 
-use chain_core::tx::fee::LinearFee;
-use client_common::storage::SledStorage;
-use client_common::tendermint::{types::GenesisExt, Client, WebsocketRpcClient};
-use client_common::{ErrorKind, Result, ResultExt};
-use client_core::cipher::DefaultTransactionObfuscation;
-use client_core::service::HwKeyService;
-use client_core::signer::WalletSignerManager;
-use client_core::transaction_builder::DefaultWalletTransactionBuilder;
-use client_core::wallet::syncer::ObfuscationSyncerConfig;
-use client_core::wallet::DefaultWalletClient;
-use client_network::network_ops::DefaultNetworkOpsClient;
-use client_rpc_core::rpc::{
-    multisig_rpc::{MultiSigRpc, MultiSigRpcImpl},
-    staking_rpc::{StakingRpc, StakingRpcImpl},
-    sync_rpc::{CBindingCallback, CBindingCore, SyncRpc, SyncRpcImpl},
-    transaction_rpc::{TransactionRpc, TransactionRpcImpl},
-    wallet_rpc::{WalletRpc, WalletRpcImpl},
+use client_common::Result;
+use client_core::wallet::syncer::SyncerOptions;
+use client_rpc_core::{
+    rpc::sync_rpc::{CBindingCallback, CBindingCore},
+    RpcHandler,
 };
 
 use crate::types::get_string;
 use crate::types::CroResult;
 use crate::types::ProgressCallback;
 use crate::types::{CroJsonRpc, CroJsonRpcPtr};
-
-type AppTransactionCipher = DefaultTransactionObfuscation;
-
-type AppTxBuilder = DefaultWalletTransactionBuilder<SledStorage, LinearFee, AppTransactionCipher>;
-type AppWalletClient = DefaultWalletClient<SledStorage, WebsocketRpcClient, AppTxBuilder>;
-type AppOpsClient = DefaultNetworkOpsClient<
-    AppWalletClient,
-    SledStorage,
-    WebsocketRpcClient,
-    LinearFee,
-    AppTransactionCipher,
->;
-type AppSyncerConfig =
-    ObfuscationSyncerConfig<SledStorage, WebsocketRpcClient, AppTransactionCipher>;
-
-/// normal
-fn get_tx_query(tendermint_client: WebsocketRpcClient) -> Result<DefaultTransactionObfuscation> {
-    DefaultTransactionObfuscation::from_tx_query(&tendermint_client)
-}
-
-fn make_wallet_client(
-    storage: SledStorage,
-    tendermint_client: WebsocketRpcClient,
-) -> Result<AppWalletClient> {
-    let hw_key_service = HwKeyService::default();
-    let signer_manager = WalletSignerManager::new(storage.clone(), hw_key_service.clone());
-    let transaction_cipher = get_tx_query(tendermint_client.clone())?;
-    let transaction_builder = DefaultWalletTransactionBuilder::new(
-        signer_manager,
-        tendermint_client.genesis().unwrap().fee_policy(),
-        transaction_cipher,
-    );
-    Ok(DefaultWalletClient::new(
-        storage,
-        tendermint_client,
-        transaction_builder,
-        Some(50),
-        hw_key_service,
-    ))
-}
-
-fn make_ops_client(
-    storage: SledStorage,
-    tendermint_client: WebsocketRpcClient,
-) -> Result<AppOpsClient> {
-    let hw_key_service = HwKeyService::default();
-    let transaction_cipher = get_tx_query(tendermint_client.clone())?;
-    let signer_manager = WalletSignerManager::new(storage.clone(), hw_key_service);
-    let fee_algorithm = tendermint_client.genesis().unwrap().fee_policy();
-    let wallet_client = make_wallet_client(storage, tendermint_client.clone())?;
-    Ok(DefaultNetworkOpsClient::new(
-        wallet_client,
-        signer_manager,
-        tendermint_client,
-        fee_algorithm,
-        transaction_cipher,
-    ))
-}
-
-fn make_syncer_config(
-    storage: SledStorage,
-    tendermint_client: WebsocketRpcClient,
-) -> Result<AppSyncerConfig> {
-    let transaction_cipher = get_tx_query(tendermint_client.clone())?;
-
-    Ok(AppSyncerConfig::new(
-        storage,
-        tendermint_client,
-        transaction_cipher,
-        true,
-        true,
-        50,
-        50,
-    ))
-}
-
-use std::sync::Arc;
-use std::sync::Mutex;
 
 #[derive(Clone)]
 struct CBindingData {
@@ -134,49 +45,6 @@ impl CBindingCallback for CBindingData {
     }
 }
 
-fn do_jsonrpc_call(
-    storage_dir: &str,
-    websocket_url: &str,
-    network_id: u8,
-    json_request: &str,
-    progress_callback: ProgressCallback,
-    user_data: *const std::ffi::c_void,
-) -> Result<String> {
-    let mut io = IoHandler::new();
-    let storage = SledStorage::new(storage_dir)?;
-    let tendermint_client = WebsocketRpcClient::new(websocket_url)?;
-    let wallet_client = make_wallet_client(storage.clone(), tendermint_client.clone())?;
-    let ops_client = make_ops_client(storage.clone(), tendermint_client.clone())?;
-    let syncer_config = make_syncer_config(storage.clone(), tendermint_client.clone())?;
-
-    let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
-    let transaction_rpc = TransactionRpcImpl::new(network_id);
-    let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
-    let cbindingcallback = CBindingCore {
-        data: Arc::new(Mutex::new(CBindingData {
-            progress_callback,
-            // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
-            user_data: user_data as u64,
-        })),
-    };
-    let sync_wallet_client = make_wallet_client(storage, tendermint_client)?;
-
-    let sync_rpc = SyncRpcImpl::new(syncer_config, Some(cbindingcallback), sync_wallet_client);
-    let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
-
-    io.extend_with(multisig_rpc.to_delegate());
-    io.extend_with(transaction_rpc.to_delegate());
-    io.extend_with(staking_rpc.to_delegate());
-    io.extend_with(sync_rpc.to_delegate());
-    io.extend_with(wallet_rpc.to_delegate());
-
-    // let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
-    io.handle_request_sync(json_request)
-        .err_kind(ErrorKind::InvalidInput, || {
-            "stateful command execute failed"
-        })
-}
-
 /// # Safety
 ///
 /// Should not be called with null pointers.
@@ -201,24 +69,66 @@ pub unsafe extern "C" fn cro_jsonrpc_call(
     request: *const c_char,
     buf: *mut c_char,
     buf_size: usize,
-    progress_callback: ProgressCallback,
+    progress_callback: Option<ProgressCallback>,
     user_data: *const std::ffi::c_void,
 ) -> CroResult {
-    let res = do_jsonrpc_call(
-        CStr::from_ptr(storage_dir)
-            .to_str()
-            .expect("storage_dir should be utf-8"),
-        CStr::from_ptr(websocket_url)
-            .to_str()
-            .expect("storage_dir should be utf-8"),
+    let res = create_rpc(
+        storage_dir,
+        websocket_url,
         network_id,
-        CStr::from_ptr(request)
-            .to_str()
-            .expect("storage_dir should be utf-8"),
         progress_callback,
-        // SAFETY-WARNING, DO NOT use this inside rust, just pass back to c-side
         user_data,
-    );
+        false,
+    )
+    .map(|rpc| {
+        let json_request = get_string(request);
+        rpc.handler.handle(&json_request).unwrap_or_default()
+    });
+    match res {
+        Err(e) => {
+            libc::strncpy(
+                buf,
+                CString::new(e.to_string()).unwrap().into_raw(),
+                buf_size,
+            );
+            CroResult::fail()
+        }
+        Ok(s) => {
+            libc::strncpy(buf, CString::new(s).unwrap().into_raw(), buf_size);
+            CroResult::success()
+        }
+    }
+}
+
+/// mock mode, only use for testing
+///
+/// # Safety
+///
+/// Should not be called with null pointers.
+#[cfg(debug_assertions)]
+#[no_mangle]
+pub unsafe extern "C" fn cro_jsonrpc_call_mock(
+    storage_dir: *const c_char,
+    websocket_url: *const c_char,
+    network_id: u8,
+    request: *const c_char,
+    buf: *mut c_char,
+    buf_size: usize,
+    progress_callback: Option<ProgressCallback>,
+    user_data: *const std::ffi::c_void,
+) -> CroResult {
+    let res = create_rpc(
+        storage_dir,
+        websocket_url,
+        network_id,
+        progress_callback,
+        user_data,
+        true,
+    )
+    .map(|rpc| {
+        let json_request = get_string(request);
+        rpc.handler.handle(&json_request).unwrap_or_default()
+    });
     match res {
         Err(e) => {
             libc::strncpy(
@@ -258,53 +168,56 @@ pub unsafe extern "C" fn cro_create_jsonrpc(
     storage_dir_user: *const c_char,
     websocket_url_user: *const c_char,
     network_id: u8,
-    progress_callback: ProgressCallback,
+    progress_callback: Option<ProgressCallback>,
 ) -> CroResult {
-    let storage_dir = get_string(storage_dir_user);
-    let websocket_url = get_string(websocket_url_user);
-
-    let mut io = IoHandler::new();
-    let storage = SledStorage::new(&storage_dir).unwrap();
-    let tendermint_client = WebsocketRpcClient::new(&websocket_url).unwrap();
-    let wallet_client = make_wallet_client(storage.clone(), tendermint_client.clone()).unwrap();
-    let ops_client = make_ops_client(storage.clone(), tendermint_client.clone()).unwrap();
-    let syncer_config = make_syncer_config(storage.clone(), tendermint_client.clone()).unwrap();
-
-    let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
-    let transaction_rpc = TransactionRpcImpl::new(network_id);
-    let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
-
-    let cbindingcallback = CBindingCore {
-        data: Arc::new(Mutex::new(CBindingData {
-            progress_callback,
-            user_data: 0 as u64,
-        })),
-    };
-
-    let sync_wallet_client =
-        make_wallet_client(storage, tendermint_client).expect("get sync wallet clinet");
-
-    let sync_rpc = SyncRpcImpl::new(
-        syncer_config,
-        Some(cbindingcallback.clone()),
-        sync_wallet_client,
+    let mrpc = create_rpc(
+        storage_dir_user,
+        websocket_url_user,
+        network_id,
+        progress_callback,
+        ptr::null(),
+        false,
     );
-    let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
+    match mrpc {
+        Ok(rpc) => {
+            let rpc_box = Box::new(rpc);
+            ptr::write(rpc_out, Box::into_raw(rpc_box));
+            CroResult::success()
+        }
+        _ => CroResult::fail(),
+    }
+}
 
-    io.extend_with(multisig_rpc.to_delegate());
-    io.extend_with(transaction_rpc.to_delegate());
-    io.extend_with(staking_rpc.to_delegate());
-    io.extend_with(sync_rpc.to_delegate());
-    io.extend_with(wallet_rpc.to_delegate());
-
-    let rpc = CroJsonRpc {
-        handler: io,
-        binding: cbindingcallback,
-    };
-    let rpc_box = Box::new(rpc);
-    ptr::write(rpc_out, Box::into_raw(rpc_box));
-
-    CroResult::success()
+/// mock mode, only use for testing
+///
+/// # Safety
+///
+/// Should not be called with null pointers.
+#[cfg(debug_assertions)]
+#[no_mangle]
+pub unsafe extern "C" fn cro_create_mock_jsonrpc(
+    rpc_out: *mut CroJsonRpcPtr,
+    storage_dir_user: *const c_char,
+    websocket_url_user: *const c_char,
+    network_id: u8,
+    progress_callback: Option<ProgressCallback>,
+) -> CroResult {
+    let mrpc = create_rpc(
+        storage_dir_user,
+        websocket_url_user,
+        network_id,
+        progress_callback,
+        ptr::null(),
+        true,
+    );
+    match mrpc {
+        Ok(rpc) => {
+            let rpc_box = Box::new(rpc);
+            ptr::write(rpc_out, Box::into_raw(rpc_box));
+            CroResult::success()
+        }
+        _ => CroResult::fail(),
+    }
 }
 
 /// request: json rpc request
@@ -326,31 +239,14 @@ pub unsafe extern "C" fn cro_run_jsonrpc(
     let rpc = rpc_ptr.as_mut().expect("get wallet");
     let json_request = get_string(request);
 
-    {
-        let mut user = (*rpc).binding.data.lock().expect("get cbinding callback");
+    if let Some(binding) = &(*rpc).binding {
+        let mut user = binding.data.lock().expect("get cbinding callback");
         user.set_user(user_data as u64);
     }
 
-    let io = &rpc.handler;
-    let res = io
-        .handle_request_sync(&json_request)
-        .err_kind(ErrorKind::InvalidInput, || {
-            "stateful command execute failed"
-        });
-    match res {
-        Err(e) => {
-            libc::strncpy(
-                buf,
-                CString::new(e.to_string()).unwrap().into_raw(),
-                buf_size,
-            );
-            CroResult::fail()
-        }
-        Ok(s) => {
-            libc::strncpy(buf, CString::new(s).unwrap().into_raw(), buf_size);
-            CroResult::success()
-        }
-    }
+    let s = rpc.handler.handle(&json_request).unwrap_or_default();
+    libc::strncpy(buf, CString::new(s).unwrap().into_raw(), buf_size);
+    CroResult::success()
 }
 
 /// destroy json-rpc context
@@ -360,4 +256,50 @@ pub unsafe extern "C" fn cro_run_jsonrpc(
 pub unsafe extern "C" fn cro_destroy_jsonrpc(rpc: CroJsonRpcPtr) -> CroResult {
     Box::from_raw(rpc);
     CroResult::success()
+}
+
+unsafe fn create_rpc(
+    storage_dir: *const c_char,
+    websocket_url: *const c_char,
+    network_id: u8,
+    progress_callback: Option<ProgressCallback>,
+    user_data: *const std::ffi::c_void,
+    mock: bool,
+) -> Result<CroJsonRpc> {
+    let storage_dir = get_string(storage_dir);
+    let websocket_url = get_string(websocket_url);
+    let cbindingcallback = progress_callback.map(|progress_callback| CBindingCore {
+        data: Arc::new(Mutex::new(CBindingData {
+            progress_callback,
+            user_data: user_data as u64,
+        })),
+    });
+    let options = SyncerOptions {
+        enable_fast_forward: true,
+        enable_address_recovery: true,
+        batch_size: 50,
+        block_height_ensure: 50,
+    };
+    let handler = if mock {
+        RpcHandler::new_mock(
+            &storage_dir,
+            &websocket_url,
+            network_id,
+            options,
+            cbindingcallback.clone(),
+        )?
+    } else {
+        RpcHandler::new(
+            &storage_dir,
+            &websocket_url,
+            network_id,
+            options,
+            cbindingcallback.clone(),
+        )?
+    };
+
+    Ok(CroJsonRpc {
+        handler,
+        binding: cbindingcallback,
+    })
 }

--- a/cro-clib/src/types.rs
+++ b/cro-clib/src/types.rs
@@ -4,12 +4,10 @@ use chain_core::tx::fee::{LinearFee, Milli};
 use client_common::{PrivateKey, PublicKey};
 use client_core::transaction_builder::WitnessedUTxO;
 use client_core::HDSeed;
-use client_rpc_core::rpc::sync_rpc::CBindingCore;
+use client_rpc_core::{rpc::sync_rpc::CBindingCore, RpcHandler};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
-
-use jsonrpc_core::IoHandler;
 
 pub type CroHDWalletPtr = *mut CroHDWallet;
 pub type CroAddressPtr = *mut CroAddress;
@@ -107,7 +105,7 @@ pub type ProgressCallback = extern "C" fn(u64, u64, u64, *const std::ffi::c_void
 
 #[derive(Clone)]
 pub struct CroJsonRpc {
-    pub handler: IoHandler,
-    pub binding: CBindingCore,
+    pub handler: RpcHandler,
+    pub binding: Option<CBindingCore>,
 }
 pub type CroJsonRpcPtr = *mut CroJsonRpc;

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -29,5 +29,10 @@ else
     cargo build $CARGO_ARGS --features mock-enclave --manifest-path client-cli/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enclave --manifest-path dev-utils/Cargo.toml
     cargo build $CARGO_ARGS --features mock-enclave --manifest-path chain-abci/Cargo.toml
-    cargo build $CARGO_ARGS --manifest-path cro-clib/Cargo.toml
 fi
+
+echo "Build dynamic cro-clib"
+cargo install cargo-crate-type
+cargo crate-type -f cro-clib/Cargo.toml dynamic
+cargo build $CARGO_ARGS -p cro-clib
+cargo crate-type -f cro-clib/Cargo.toml static


### PR DESCRIPTION
Solution:
- consolidate the client-rpc setup code
- cro-clib add mock mode api when build in debug
- build cro-clib as cdylib, can be used directly by other language.
- make callback parameter in c api optional