### PR TITLE
Problem (Fix #1483): client-rpc process is not necessary for python integration tests

### DIFF
--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -275,7 +275,7 @@ unsafe fn create_rpc(
         })),
     });
     let options = SyncerOptions {
-        enable_fast_forward: true,
+        enable_fast_forward: false,
         enable_address_recovery: true,
         batch_size: 50,
         block_height_ensure: 50,

--- a/integration-tests/bot/chainbinding.py
+++ b/integration-tests/bot/chainbinding.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import os
+import sys
+import ctypes
+
+from decouple import config
+
+target_dir = config('CARGO_TARGET_DIR', os.path.join(os.path.dirname(__file__), '../../target'))
+build_profile = config('BUILD_PROFILE', 'debug')
+ext = 'dylib' if sys.platform == 'darwin' else 'so'
+dll = ctypes.cdll.LoadLibrary(os.path.join(target_dir, '%s/libcro_clib.%s' % (build_profile, ext)))
+
+dll.cro_jsonrpc_call.argtypes = dll.cro_jsonrpc_call_mock.argtypes = [
+    ctypes.c_char_p,  # storage_dir
+    ctypes.c_char_p,  # websocket_url
+    ctypes.c_char,    # network id
+    ctypes.c_char_p,  # request
+    ctypes.c_char_p,  # buf
+    ctypes.c_size_t,  # buf_size
+    ctypes.c_void_p,  # progress callback
+    ctypes.c_void_p,  # user_data
+]
+dll.cro_jsonrpc_call.restype = dll.cro_jsonrpc_call_mock.restype = ctypes.c_int
+
+dll.cro_create_jsonrpc.argtypes = dll.cro_create_mock_jsonrpc.argtypes = [
+    ctypes.POINTER(ctypes.c_void_p),  # rpc_out
+    ctypes.c_char_p,                  # storage_dir
+    ctypes.c_char_p,                  # websocket_url
+    ctypes.c_char,                    # network_id
+    ctypes.c_void_p,                  # progress callback
+]
+dll.cro_create_jsonrpc.restype = dll.cro_create_mock_jsonrpc.restype = ctypes.c_int
+
+dll.cro_run_jsonrpc.argtypes = [
+    ctypes.c_void_p,  # jsonrpc
+    ctypes.c_char_p,  # request
+    ctypes.c_char_p,  # buf
+    ctypes.c_size_t,  # buf_size
+    ctypes.c_void_p,  # user_data
+]
+dll.cro_run_jsonrpc.restype = ctypes.c_int
+
+dll.cro_destroy_jsonrpc.argtypes = [
+    ctypes.c_void_p,  # jsonrpc
+]
+dll.cro_destroy_jsonrpc.restype = ctypes.c_int
+
+
+class RpcBinding:
+    def __init__(self, storage, tendermint_ws, network_id=0xab, mock_mode=False):
+        create_jsonrpc = dll.cro_create_mock_jsonrpc if mock_mode else dll.cro_create_jsonrpc
+        self._p = ctypes.c_void_p()
+        retcode = create_jsonrpc(ctypes.byref(self._p), storage.encode(), tendermint_ws.encode(), network_id, None)
+        assert retcode == 0, 'create jsonrpc failed'
+
+    def __del__(self):
+        dll.cro_destroy_jsonrpc(self._p)
+
+    def call(self, req):
+        rsp = ctypes.create_string_buffer(10240)
+        retcode = dll.cro_run_jsonrpc(self._p, req.encode(), rsp, len(rsp), None)
+        assert retcode == 0, rsp.value
+        return rsp.value
+
+
+if __name__ == '__main__':
+    import fire
+    fire.Fire(RpcBinding)

--- a/integration-tests/bot/chainrpc.py
+++ b/integration-tests/bot/chainrpc.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
+import sys
 import getpass
 import logging
 import base64
 import binascii
+import json
 
-import fire
 from jsonrpcclient import request
 from decouple import config
+
+from chainbinding import RpcBinding
 
 DEBUG_LEVEL = config('HTTP_DEBUG_LEVEL', 0, cast=int)
 if DEBUG_LEVEL:
@@ -58,27 +61,46 @@ def fix_address_hex(addr):
         return addr
 
 
-class BaseService:
-    def __init__(self, base_port=None):
-        self.base_port = base_port if base_port is not None else config('BASE_PORT', 26650, cast=int)
-        self.client_rpc_url = 'http://127.0.0.1:%d' % (self.base_port + 9)
-        self.chain_rpc_url = 'http://127.0.0.1:%d' % (self.base_port + 7)
+class Client:
+    def __init__(self, tendermint_port, wallet_directory, network_id, mock_mode):
+        self.binding = RpcBinding(
+            wallet_directory,
+            'ws://127.0.0.1:%d/websocket' % tendermint_port,
+            network_id=network_id,
+            mock_mode=mock_mode
+        )
 
     def call(self, method, *args, **kwargs):
-        rsp = request(self.client_rpc_url, method, *args, **kwargs)
-        return rsp.data.result
+        params = None
+        if args and kwargs:
+            params = list(args)
+            params.append(kwargs)
+        elif args:
+            params = list(args)
+        elif kwargs:
+            params = kwargs
+        req = {
+            'jsonrpc': '2.0',
+            'id': '0',
+            'method': method,
+            'params': params
+        }
+        rsp = json.loads(self.binding.call(json.dumps(req)))
+        if 'result' in rsp:
+            return rsp['result']
+        else:
+            print(rsp['error'], file=sys.stderr)
 
-    def call_chain(self, method, *args, **kwargs):
-        rsp = request(self.chain_rpc_url, method, *args, **kwargs)
-        return rsp.data.result
 
+class Address:
+    def __init__(self, client):
+        self.client = client
 
-class Address(BaseService):
     def list(self, name=DEFAULT_WALLET, type='staking', enckey=None):
         '''list addresses
         :param name: Name of the wallet. [default: Default]
         :params type: [staking|transfer]'''
-        return self.call('wallet_listStakingAddresses' if type == 'staking' else 'wallet_listTransferAddresses', [name, enckey or get_enckey()])
+        return self.client.call('wallet_listStakingAddresses' if type == 'staking' else 'wallet_listTransferAddresses', [name, enckey or get_enckey()])
 
     def create(self, name=DEFAULT_WALLET, type='staking', enckey=None):
         '''Create address
@@ -86,7 +108,7 @@ class Address(BaseService):
         :param type: Type of address. [staking|transfer]'''
         type = type.lower()
         assert type in ('staking', 'transfer'), 'invalid type'
-        return self.call(
+        return self.client.call(
             'wallet_createStakingAddress'
             if type == 'staking'
             else 'wallet_createTransferAddress',
@@ -99,137 +121,146 @@ class Address(BaseService):
         :param public_key: Public key of the address'''
         type = type.lower()
         assert type in ('staking', 'transfer'), 'invalid type'
-        return self.call(
+        return self.client.call(
             'wallet_createWatchStakingAddress'
             if type == 'staking'
             else 'wallet_createWatchTransferAddress',
             [name, enckey or get_enckey()], public_key)
 
 
-class Wallet(BaseService):
+class Wallet:
+    def __init__(self, client):
+        self.client = client
+
     def enckey(self, name=DEFAULT_WALLET):
         '''Get encryption key of wallet
         :param name: Name of the wallet. [default: Default]'''
-        return self.call('wallet_getEncKey', [name, get_passphrase()])
+        return self.client.call('wallet_getEncKey', [name, get_passphrase()])
 
     def balance(self, name=DEFAULT_WALLET, enckey=None):
         '''Get balance of wallet
         :param name: Name of the wallet. [default: Default]'''
-        return self.call('wallet_balance', [name, enckey or get_enckey()])
+        return self.client.call('wallet_balance', [name, enckey or get_enckey()])
 
     def list(self):
-        return self.call('wallet_list')
+        return self.client.call('wallet_list')
 
     def utxo(self, name=DEFAULT_WALLET, enckey=None):
         '''Get UTxO of wallet
         :param name: Name of the wallet. [default: Default]'''
-        return self.call('wallet_listUTxO', [name, enckey or get_enckey()])
+        return self.client.call('wallet_listUTxO', [name, enckey or get_enckey()])
 
     def create(self, name=DEFAULT_WALLET, type='Basic', passphrase=None):
         '''create wallet
         :param name: Name of the wallet. [defualt: Default]
         :param type: Type of the wallet. [Basic|HD] [default: Basic]
         '''
-        return self.call('wallet_create', [name, passphrase or get_passphrase()], type)
+        return self.client.call('wallet_create', [name, passphrase or get_passphrase()], type)
 
     def restore(self, mnemonics, name=DEFAULT_WALLET, passphrase=None):
         '''restore wallet
         :param name: Name of the wallet. [defualt: Default]
         :param mnemonics: mnemonics words
         '''
-        return self.call('wallet_restore', [name, passphrase or get_passphrase()], mnemonics)
+        return self.client.call('wallet_restore', [name, passphrase or get_passphrase()], mnemonics)
 
     def restore_basic(self, private_view_key, name=DEFAULT_WALLET, passphrase=None):
         '''restore wallet
         :param name: Name of the wallet. [defualt: Default]
         :param private_view_key: hex encoded private view key
         '''
-        return self.call('wallet_restoreBasic', [name, passphrase or get_passphrase()], private_view_key)
+        return self.client.call('wallet_restoreBasic', [name, passphrase or get_passphrase()], private_view_key)
 
     def delete(self, name=DEFAULT_WALLET, passphrase=None):
-        return self.call('wallet_delete', [name, passphrase or get_passphrase()])
+        return self.client.call('wallet_delete', [name, passphrase or get_passphrase()])
 
     def view_key(self, name=DEFAULT_WALLET, private=False, enckey=None):
-        return self.call(
+        return self.client.call(
             'wallet_getViewKey',
             [name, enckey or get_enckey()], private
         )
 
     def list_pubkey(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('wallet_listPublicKeys', [name, enckey or get_enckey()])
+        return self.client.call('wallet_listPublicKeys', [name, enckey or get_enckey()])
 
     def transactions(self, name=DEFAULT_WALLET, offset=0, limit=100, reversed=False, enckey=None):
-        return self.call('wallet_transactions', [name, enckey or get_enckey()], offset, limit, reversed)
+        return self.client.call('wallet_transactions', [name, enckey or get_enckey()], offset, limit, reversed)
 
     def send(self, to_address, amount, name=DEFAULT_WALLET, view_keys=None, enckey=None):
-        return self.call(
+        return self.client.call(
             'wallet_sendToAddress',
             [name, enckey or get_enckey()],
             to_address, str(amount), view_keys or [])
 
     def sync(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync', [name, enckey or get_enckey()],{"blocking":True, "reset":False, "do_loop":False})
+        return self.client.call('sync', [name, enckey or get_enckey()],{"blocking":True, "reset":False, "do_loop":False})
 
     def sync_all(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync', [name, enckey or get_enckey()],{"blocking":True, "reset":True, "do_loop":False})
+        return self.client.call('sync', [name, enckey or get_enckey()],{"blocking":True, "reset":True, "do_loop":False})
 
     def sync_unlock(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync', [name, enckey or get_enckey()],{"blocking":False, "reset":False, "do_loop":True})
+        return self.client.call('sync', [name, enckey or get_enckey()],{"blocking":False, "reset":False, "do_loop":True})
 
     def sync_stop(self, name=DEFAULT_WALLET, enckey=None):
-        return self.call('sync_stop', [name, enckey or get_enckey()])
+        return self.client.call('sync_stop', [name, enckey or get_enckey()])
 
     def build_raw_transfer_tx(self, to_address, amount, name=DEFAULT_WALLET,  enckey=None, viewkeys=[]):
         """
         build a raw transfer tx on watch-only wallet
         :return: unsigned raw transaction info encoded in base64 string
         """
-        return self.call('wallet_buildRawTransferTransaction', [name, enckey or get_enckey()], to_address, str(amount), viewkeys)
+        return self.client.call('wallet_buildRawTransferTransaction', [name, enckey or get_enckey()], to_address, str(amount), viewkeys)
 
     def broadcast_signed_transfer_tx(self, signed_tx, name=DEFAULT_WALLET, enckey=None):
         """
         send a transfer tx signed by offline wallet
         :return:
         """
-        return self.call('wallet_broadcastSignedTransferTransaction', [name, enckey or get_enckey()], signed_tx)
+        return self.client.call('wallet_broadcastSignedTransferTransaction', [name, enckey or get_enckey()], signed_tx)
 
 
-class Staking(BaseService):
+class Staking:
+    def __init__(self, client):
+        self.client = client
+
     def deposit(self, to_address, inputs, name=DEFAULT_WALLET, enckey=None):
-        return self.call('staking_depositStake', [name, enckey or get_enckey()], fix_address(to_address), inputs)
+        return self.client.call('staking_depositStake', [name, enckey or get_enckey()], fix_address(to_address), inputs)
 
     def deposit_amount(self, to_address, amount, name=DEFAULT_WALLET, enckey=None):
-        return self.call('staking_depositAmountStake', [name, enckey or get_enckey()], fix_address(to_address), str(amount))
+        return self.client.call('staking_depositAmountStake', [name, enckey or get_enckey()], fix_address(to_address), str(amount))
 
     def state(self, address, name=DEFAULT_WALLET):
-        return self.call('staking_state', name, fix_address(address))
+        return self.client.call('staking_state', name, fix_address(address))
 
     def unbond(self, address, amount, name=DEFAULT_WALLET, enckey=None):
-        return self.call('staking_unbondStake', [name, enckey or get_enckey()], fix_address(address), str(amount))
+        return self.client.call('staking_unbondStake', [name, enckey or get_enckey()], fix_address(address), str(amount))
 
     def withdraw_all_unbonded(self, from_address, to_address, view_keys=None, name=DEFAULT_WALLET, enckey=None):
-        return self.call(
+        return self.client.call(
             'staking_withdrawAllUnbondedStake',
             [name, enckey or get_enckey()],
             fix_address(from_address), to_address, view_keys or []
         )
 
     def unjail(self, address, name=DEFAULT_WALLET, enckey=None):
-        return self.call('staking_unjail', [name, enckey or get_enckey()], fix_address(address))
+        return self.client.call('staking_unjail', [name, enckey or get_enckey()], fix_address(address))
 
     def join(self, node_name, node_pubkey, node_staking_address, name=DEFAULT_WALLET, enckey=None):
-        return self.call('staking_validatorNodeJoin', [name, enckey or get_enckey()], node_name, node_pubkey,  fix_address(node_staking_address))
+        return self.client.call('staking_validatorNodeJoin', [name, enckey or get_enckey()], node_name, node_pubkey,  fix_address(node_staking_address))
 
     def build_raw_transfer_tx(self, to_address, amount, name=DEFAULT_WALLET,  enckey=None, viewkeys=[]):
-        return self.call('wallet_buildRawTransferTx', [name, enckey or get_enckey()], to_address, amount, viewkeys)
+        return self.client.call('wallet_buildRawTransferTx', [name, enckey or get_enckey()], to_address, amount, viewkeys)
 
     def broadcast_raw_transfer_tx(self, signed_tx, name=DEFAULT_WALLET, enckey=None):
-        return self.call('wallet_broadcastSignedTransferTx', [name, enckey or get_enckey()], signed_tx)
+        return self.client.call('wallet_broadcastSignedTransferTx', [name, enckey or get_enckey()], signed_tx)
 
 
-class MultiSig(BaseService):
+class MultiSig:
+    def __init__(self, client):
+        self.client = client
+
     def create_address(self, public_keys, self_public_key, required_signatures, name=DEFAULT_WALLET, enckey=None):
-        return self.call(
+        return self.client.call(
             'multiSig_createAddress',
             [name, enckey or get_enckey()],
             public_keys,
@@ -237,7 +268,7 @@ class MultiSig(BaseService):
             required_signatures)
 
     def new_session(self, message, signer_public_keys, self_public_key, name=DEFAULT_WALLET, enckey=None):
-        return self.call(
+        return self.client.call(
             'multiSig_newSession',
             [name, enckey or get_enckey()],
             message,
@@ -245,35 +276,42 @@ class MultiSig(BaseService):
             self_public_key)
 
     def nonce_commitment(self, session_id, passphrase):
-        return self.call('multiSig_nonceCommitment', session_id, passphrase)
+        return self.client.call('multiSig_nonceCommitment', session_id, passphrase)
 
     def add_nonce_commitment(self, session_id, passphrase, nonce_commitment, public_key):
-        return self.call('multiSig_addNonceCommitment', session_id, passphrase, nonce_commitment, public_key)
+        return self.client.call('multiSig_addNonceCommitment', session_id, passphrase, nonce_commitment, public_key)
 
     def nonce(self, session_id, passphrase):
-        return self.call('multiSig_nonce', session_id, passphrase)
+        return self.client.call('multiSig_nonce', session_id, passphrase)
 
     def add_nonce(self, session_id, passphrase, nonce, public_key):
-        return self.call('multiSig_addNonce', session_id, passphrase, nonce, public_key)
+        return self.client.call('multiSig_addNonce', session_id, passphrase, nonce, public_key)
 
     def partial_signature(self, session_id, passphrase):
-        return self.call('multiSig_partialSign', session_id, passphrase)
+        return self.client.call('multiSig_partialSign', session_id, passphrase)
 
     def add_partial_signature(self, session_id, passphrase, partial_signature, public_key):
-        return self.call('multiSig_addPartialSignature', session_id, passphrase, partial_signature, public_key)
+        return self.client.call('multiSig_addPartialSignature', session_id, passphrase, partial_signature, public_key)
 
     def signature(self, session_id, passphrase):
-        return self.call('multiSig_signature', session_id, passphrase)
+        return self.client.call('multiSig_signature', session_id, passphrase)
 
     def broadcast_with_signature(self, session_id, unsigned_transaction, name=DEFAULT_WALLET, enckey=None):
-        return self.call(
+        return self.client.call(
             'multiSig_broadcastWithSignature',
             [name, enckey or get_enckey()],
             session_id,
             unsigned_transaction)
 
 
-class Blockchain(BaseService):
+class Blockchain:
+    def __init__(self, tendermint_port):
+        self.tendermint_http = 'http://127.0.0.1:%d' % tendermint_port
+
+    def call_chain(self, method, *args, **kwargs):
+        rsp = request(self.tendermint_http, method, *args, **kwargs)
+        return rsp.data.result
+
     def status(self):
         return self.call_chain('status')
 
@@ -358,16 +396,24 @@ class Blockchain(BaseService):
 
 
 class RPC:
-    def __init__(self, base_port=None):
-        self.wallet = Wallet(base_port)
-        self.staking = Staking(base_port)
-        self.address = Address(base_port)
-        self.multisig = MultiSig(base_port)
-        self.chain = Blockchain(base_port)
+    def __init__(self, wallet_directory=None, tendermint_rpc_port=None, network_id=0xab, mock_mode=None):
+        if wallet_directory is None:
+            wallet_directory = config('WALLET_DIRECTORY')
+        if tendermint_rpc_port is None:
+            tendermint_rpc_port = config('TENDERMINT_RPC_PORT', 26657)
+        if mock_mode is None:
+            mock_mode = config('BUILD_MODE', 'sgx') == 'mock'
+        client = Client(tendermint_rpc_port, wallet_directory, network_id, mock_mode)
+        self.wallet = Wallet(client)
+        self.staking = Staking(client)
+        self.address = Address(client)
+        self.multisig = MultiSig(client)
+        self.chain = Blockchain(tendermint_rpc_port)
 
     def raw_tx(self, inputs, outputs, view_keys):
-        return self.call('transaction_createRaw', inputs, outputs, view_keys)
+        return self.wallet.call('transaction_createRaw', inputs, outputs, view_keys)
 
 
 if __name__ == '__main__':
-    fire.Fire(RPC())
+    import fire
+    fire.Fire(RPC)

--- a/integration-tests/bot/setup.py
+++ b/integration-tests/bot/setup.py
@@ -25,5 +25,6 @@ setup(
         'chainbot.py',
         'chainrpc.py',
         'chaincodec.py',
+        'chainbinding.py',
     ]
 )

--- a/integration-tests/multinode/byzantine_test.py
+++ b/integration-tests/multinode/byzantine_test.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import os
-from chainrpc import RPC
 from chainbot import SigningKey
-from common import UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, wait_for_blocks, stop_node, wait_for_tx, wait_for_blocktime
+from common import get_rpc, UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, wait_for_blocks, stop_node, wait_for_tx, wait_for_blocktime
 
 '''
 - 3 nodes
@@ -15,11 +14,10 @@ from common import UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, w
 
 # keep these values same as jail_cluster.json
 VALIDATOR_SEED = '3d96c3c476e463bdcd751c9bf1715b7da37229ac00be33f34496797ca892b68a'
-BASE_PORT = int(os.environ.get('BASE_PORT', 25560))
-TARGET_PORT = BASE_PORT + 2 * 10
 
+BASE_PORT = int(os.environ.get('BASE_PORT', 26650))
 supervisor = UnixStreamXMLRPCClient('data/supervisor.sock')
-rpc = RPC(BASE_PORT)
+rpc = get_rpc()
 
 # stop node1
 print('Stop node1')
@@ -57,7 +55,7 @@ assert len(rpc.chain.validators()['validators']) == 2
 
 # start node1
 supervisor.supervisor.startProcessGroup('node1')
-wait_for_port(BASE_PORT + 10 + 9)
+wait_for_port(BASE_PORT + 10 + 7)
 
 wait_for_blocks(rpc, 13)
 rpc.wallet.sync()

--- a/integration-tests/multinode/common.py
+++ b/integration-tests/multinode/common.py
@@ -1,9 +1,11 @@
+import os
 import time
 from datetime import datetime
 import http.client
 import socket
 import xmlrpc.client
 import iso8601
+import weakref
 
 
 def wait_for_port(port, host='127.0.0.1', timeout=40.0):
@@ -69,6 +71,22 @@ def wait_for_blocktime(rpc, t):
         print('block_time:', block_time)
         if block_time > t:
             break
+
+
+_rpc_cache = weakref.WeakValueDictionary()
+
+
+def get_rpc(i=0):
+    rpc = _rpc_cache.get(i)
+    if rpc is None:
+        from chainrpc import RPC
+        base_port = int(os.environ.get('BASE_PORT', 26650))
+        rpc = RPC(
+            os.path.join(os.path.dirname(__file__), '../data/node%d/wallet' % i),
+            base_port + 7
+        )
+        _rpc_cache[i] = rpc
+    return rpc
 
 
 class UnixStreamHTTPConnection(http.client.HTTPConnection):

--- a/integration-tests/multinode/join_test.py
+++ b/integration-tests/multinode/join_test.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import os
-from chainrpc import RPC
 from chainbot import SigningKey
-from common import UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, wait_for_blocks, wait_for_tx, stop_node, wait_for_blocktime
+from common import get_rpc, UnixStreamXMLRPCClient, wait_for_validators, wait_for_port, wait_for_blocks, wait_for_tx, stop_node, wait_for_blocktime
 
 '''
 three node, 1/3 voting power each.
@@ -34,11 +33,11 @@ TARGET_NODE_MNEMONIC = 'symptom labor zone shrug chicken bargain hood define tor
 TARGET_NODE_VALIDATOR_SEED = '5c1b9c06ae7485cd0f9d75819f964db3b1306ebd397f5bbdc1dd386a32b7c1c0'
 MISSED_BLOCK_THRESHOLD = 5
 JAIL_DURATION = 10
-BASE_PORT = int(os.environ.get('BASE_PORT', 25560))
+BASE_PORT = int(os.environ.get('BASE_PORT', 26650))
 TARGET_PORT = BASE_PORT + 2 * 10
 
 supervisor = UnixStreamXMLRPCClient('data/supervisor.sock')
-rpc = RPC(BASE_PORT)
+rpc = get_rpc()
 
 # wait for 3 validators online
 print('Wait for 3 validators online')
@@ -64,7 +63,7 @@ print('slash amount', punishment['amount'])
 
 print('Starting', TARGET_NODE)
 supervisor.supervisor.startProcessGroup(TARGET_NODE)
-wait_for_port(TARGET_PORT + 9)
+wait_for_port(TARGET_PORT + 7)
 print('Started', TARGET_NODE)
 
 jailed_until = state['validator']['jailed_until']

--- a/integration-tests/multinode/multitx_test.py
+++ b/integration-tests/multinode/multitx_test.py
@@ -1,8 +1,7 @@
 import os
 import time
-from chainrpc import RPC
 from common import (
-    UnixStreamXMLRPCClient, wait_for_validators, stop_node,
+    get_rpc, UnixStreamXMLRPCClient, wait_for_validators, stop_node,
     wait_for_tx, latest_block_height
 )
 
@@ -19,9 +18,8 @@ Procedure:
 '''
 
 
-BASE_PORT = int(os.environ.get('BASE_PORT', 25560))
 supervisor = UnixStreamXMLRPCClient('data/supervisor.sock')
-rpc = RPC(BASE_PORT)
+rpc = get_rpc()
 
 print('Wait for 2 validators online')
 wait_for_validators(rpc, 2)

--- a/integration-tests/multinode/reward_test.py
+++ b/integration-tests/multinode/reward_test.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import os
 import math
-from chainrpc import RPC
-from common import UnixStreamXMLRPCClient, wait_for_blocks, stop_node, wait_for_blocktime, wait_for_port, latest_block_time
+from common import get_rpc, UnixStreamXMLRPCClient, wait_for_blocks, stop_node, wait_for_blocktime, wait_for_port, latest_block_time
 
 '''
 wait for first reward distribution (the second block)
@@ -25,12 +24,12 @@ def monetary_expansion(S, tau):
     return N - N % 10000
 
 
-BASE_PORT = int(os.environ.get('BASE_PORT', 25560))
+BASE_PORT = int(os.environ.get('BASE_PORT', 26650))
 supervisor = UnixStreamXMLRPCClient('data/supervisor.sock')
-wait_for_port(BASE_PORT + 20 + 9)
+wait_for_port(BASE_PORT + 20 + 7)
 
-rpc = RPC(BASE_PORT)
-rpc2 = RPC(BASE_PORT + 20)
+rpc = get_rpc()
+rpc2 = get_rpc(2)
 init_bonded = 90000000000000000
 
 os.environ['ENCKEY'] = rpc.wallet.enckey()

--- a/integration-tests/pytests/common.py
+++ b/integration-tests/pytests/common.py
@@ -1,6 +1,8 @@
+import os
 from datetime import datetime
 import time
 import iso8601
+import weakref
 
 
 def wait_for_tx(rpc, txid, timeout=10):
@@ -21,3 +23,19 @@ def wait_for_blocktime(rpc, t):
         print('block_time:', block_time)
         if block_time > t:
             break
+
+
+_rpc_cache = weakref.WeakValueDictionary()
+
+
+def get_rpc(i=0):
+    rpc = _rpc_cache.get(i)
+    if rpc is None:
+        from chainrpc import RPC
+        base_port = int(os.environ.get('BASE_PORT', 26650))
+        rpc = RPC(
+            os.path.join(os.path.dirname(__file__), '../data/node%d/wallet' % i),
+            base_port + 7
+        )
+        _rpc_cache[i] = rpc
+    return rpc

--- a/integration-tests/pytests/conftest.py
+++ b/integration-tests/pytests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import time
 import pytest
-from chainrpc import RPC
+from .common import get_rpc
 
 
 def pytest_configure(config):
@@ -23,7 +23,7 @@ class TestAddresses:
 
 @pytest.fixture
 def addresses():
-    rpc = RPC()
+    rpc = get_rpc()
     enckey = rpc.wallet.enckey()
     os.environ['ENCKEY'] = enckey
     rpc.wallet.sync()

--- a/integration-tests/pytests/test_pending_tx.py
+++ b/integration-tests/pytests/test_pending_tx.py
@@ -1,10 +1,9 @@
 from uuid import uuid1
 
 import pytest
-from chainrpc import RPC
-from .common import wait_for_tx, wait_for_blocktime
+from .common import wait_for_tx, wait_for_blocktime, get_rpc
 
-rpc = RPC()
+rpc = get_rpc()
 
 
 @pytest.mark.zerofee

--- a/integration-tests/pytests/test_small.py
+++ b/integration-tests/pytests/test_small.py
@@ -1,8 +1,7 @@
 import pytest
-from chainrpc import RPC
-from .common import wait_for_tx
+from .common import wait_for_tx, get_rpc
 
-rpc = RPC()
+rpc = get_rpc()
 
 
 @pytest.mark.withfee

--- a/integration-tests/pytests/test_wallet_offline.py
+++ b/integration-tests/pytests/test_wallet_offline.py
@@ -4,13 +4,10 @@ import pexpect
 import os
 import tempfile
 import pytest
-from chainrpc import RPC
-from .common import wait_for_tx, wait_for_blocktime
-
-rpc = RPC()
+from .common import wait_for_tx, get_rpc
 
 PASSWD = "123456"
-rpc = RPC()
+rpc = get_rpc()
 
 # TODO:it strange that python can not read client-cli output, so deadcode the information
 # ./client-cli wallet auth-token -n ${wallet_name}
@@ -172,7 +169,5 @@ def test_wallet_offline():
     assert balance_receiver["total"] == "50"
 
 
-
 if __name__ == "__main__":
-    test_offline_wallet()
-
+    test_wallet_offline()

--- a/integration-tests/pytests/test_watch_only_wallet.py
+++ b/integration-tests/pytests/test_watch_only_wallet.py
@@ -1,9 +1,7 @@
-import time
-from chainrpc import RPC
 from uuid import uuid1
-from .common import wait_for_tx
+from .common import wait_for_tx, get_rpc
 
-rpc = RPC()
+rpc = get_rpc()
 
 
 def test_watch_only_wallet(addresses):

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -50,7 +50,9 @@ function wait_http() {
 function runtest() {
     echo "Preparing... $1"
     LOWERED_TYPE=`echo $1 | tr "[:upper:]" "[:lower:]"`
-    chainbot.py prepare ${LOWERED_TYPE}_cluster.json --base_port $BASE_PORT $CHAINBOT_ARGS
+    chainbot.py prepare ${LOWERED_TYPE}_cluster.json --base_port $BASE_PORT --start_client_rpc $CHAINBOT_ARGS
+    export CRYPTO_GENESIS_HASH=`python -c "import json; print(json.load(open('data/info.json'))['genesis_hash'])"`
+    echo "genesis hash: $CRYPTO_GENESIS_HASH"
 
     echo "Startup..."
     supervisord -n -c data/tasks.ini &
@@ -64,6 +66,8 @@ function runtest() {
         TEST_ONLY=$1 npm run test
         RETCODE=$?
         popd
+
+        supervisorctl -c data/tasks.ini stop node0:client-rpc-node0
 
         if [ $RETCODE -eq 0 ]; then
 			if [ $1 == "WITH_FEE" ]; then

--- a/integration-tests/run_multinode.sh
+++ b/integration-tests/run_multinode.sh
@@ -27,7 +27,7 @@ fi
 # environment variables for integration tests
 export PASSPHRASE=123456
 export BASE_PORT=${BASE_PORT:-26650}
-export CLIENT_RPC_PORT=$(($BASE_PORT + 9))
+export TENDERMINT_RPC_PORT=$(($BASE_PORT + 7))
 
 function wait_http() {
     echo "Wait for http port $1"
@@ -47,11 +47,13 @@ function wait_http() {
 function runtest() {
     echo "Preparing... $1"
     chainbot.py prepare multinode/$1_cluster.json --base_port $BASE_PORT $CHAINBOT_ARGS
+    export CRYPTO_GENESIS_HASH=`python -c "import json; print(json.load(open('data/info.json'))['genesis_hash'])"`
+    echo "genesis hash: $CRYPTO_GENESIS_HASH"
 
     echo "Startup..."
     supervisord -n -c data/tasks.ini &
-    if ! wait_http $CLIENT_RPC_PORT; then
-        echo 'client-rpc of first node still not ready, giveup.'
+    if ! wait_http $TENDERMINT_RPC_PORT; then
+        echo 'tendermint of first node still not ready, giveup.'
         RETCODE=1
     else
         set +e


### PR DESCRIPTION
Solution:
- python call the rpc shared library directly
- chainbot don't start client-rpc by default,
  but integration tests still starts client-rpc for type script tests.

fast forward is disabled by default through c API, because it's problematic in zero-fee test env.
Opened an issue to configure it through c API: #1627 