### PR TITLE
Problem (Fix #1621): Can't deposit into other's new staking address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 ### Improvements
 ### Bug Fixes
 
+*May 20, 2020*
+
+This release contains a hotfix for client-cli deposit transaction issue.
+
+## V0.5.3
+
+### Bug Fixes
+
+- *client* [1652](https://github.com/crypto-com/chain/pull/1625): Add staking address check and double confirmation in
+  client-cli for deposit transaction, remove the restriction in client-rpc.
+
 *May 7, 2020*
 
 This release contains a hotfix for client-cli sync issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "client-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.5.0",
@@ -597,7 +597,7 @@ dependencies = [
  "cli-table 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-common 0.5.0",
  "client-core 0.5.0",
- "client-network 0.5.0",
+ "client-network 0.5.3",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "client-network"
-version = "0.5.0"
+version = "0.5.3"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain-core 0.5.0",
@@ -720,7 +720,7 @@ dependencies = [
  "chain-core 0.5.0",
  "client-common 0.5.0",
  "client-core 0.5.0",
- "client-network 0.5.0",
+ "client-network 0.5.3",
  "client-rpc-core 0.5.0",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -738,7 +738,7 @@ dependencies = [
  "chain-core 0.5.0",
  "client-common 0.5.0",
  "client-core 0.5.0",
- "client-network 0.5.0",
+ "client-network 0.5.3",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -837,7 +837,7 @@ dependencies = [
  "chain-core 0.5.0",
  "client-common 0.5.0",
  "client-core 0.5.0",
- "client-network 0.5.0",
+ "client-network 0.5.3",
  "client-rpc-core 0.5.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1050,7 +1050,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "client-common 0.5.0",
  "client-core 0.5.0",
- "client-network 0.5.0",
+ "client-network 0.5.3",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-cli"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 build = "build.rs"

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-network"
-version = "0.5.0"
+version = "0.5.3"
 authors = ["Devashish Dixit <devashish@crypto.com>"]
 edition = "2018"
 

--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -12,7 +12,7 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
-use client_common::{Result, SecKey};
+use client_common::{ErrorKind, Result, ResultExt, SecKey};
 use client_core::types::TransactionPending;
 
 /// Interface for performing network operations on Crypto.com Chain
@@ -91,5 +91,16 @@ pub trait NetworkOpsClient: Send + Sync {
         name: &str,
         address: &StakedStateAddress,
         verify: bool,
-    ) -> Result<StakedState>;
+    ) -> Result<StakedState> {
+        self.get_staking(name, address, verify)?
+            .err_kind(ErrorKind::InvalidInput, || "staking not found")
+    }
+
+    /// Returns staked stake corresponding to given address
+    fn get_staking(
+        &self,
+        name: &str,
+        address: &StakedStateAddress,
+        verify: bool,
+    ) -> Result<Option<StakedState>>;
 }

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-rpc-core"
-version = "0.5.0"
+version = "0.5.3"
 authors = ["Crypto.com <chain@crypto.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Solution:
- Remove the restriction from client network ops code
- Add check and double confirmation in client-cli