### PR TITLE
Problem: Remote attestation does not verify enclave measurement and svn information

### DIFF
--- a/chain-tx-enclave/enclave-ra/ra-client/src/config.rs
+++ b/chain-tx-enclave/enclave-ra/ra-client/src/config.rs
@@ -7,4 +7,17 @@ pub struct EnclaveCertVerifierConfig<'a> {
     pub valid_enclave_quote_statuses: Cow<'a, [Cow<'a, str>]>,
     /// Duration for which an attestation report will be considered as valid (in secs)
     pub report_validity_secs: u32,
+    /// Information about the enclave that'll be verifier if present
+    pub enclave_info: Option<EnclaveInfo>,
+}
+
+pub struct EnclaveInfo {
+    /// 256-bit hash of enclave author's public key
+    pub mr_signer: [u8; 32],
+    /// 256-bit hash that identifies the code and initial data in enclave
+    pub mr_enclave: Option<[u8; 32]>,
+    /// CPU security version number
+    pub cpu_svn: [u8; 16],
+    /// Security version number provided by enclave author
+    pub isv_svn: u16,
 }

--- a/chain-tx-enclave/enclave-ra/ra-client/src/lib.rs
+++ b/chain-tx-enclave/enclave-ra/ra-client/src/lib.rs
@@ -21,4 +21,7 @@
 mod config;
 mod verifier;
 
-pub use self::{config::EnclaveCertVerifierConfig, verifier::EnclaveCertVerifier};
+pub use self::{
+    config::{EnclaveCertVerifierConfig, EnclaveInfo},
+    verifier::EnclaveCertVerifier,
+};

--- a/client-core/src/cipher/default.rs
+++ b/client-core/src/cipher/default.rs
@@ -48,6 +48,7 @@ fn get_tls_config() -> Result<Arc<rustls::ClientConfig>> {
         signing_ca_cert_pem: IAS_CERT.into(),
         valid_enclave_quote_statuses: vec!["OK".into()].into(),
         report_validity_secs: 86400,
+        enclave_info: None, // TODO: Get enclave details from command line or env variables?
     };
     let verifier = EnclaveCertVerifier::new(verifier_config).chain(|| {
         (


### PR DESCRIPTION
Solution: Added optional verification of enclave measurement and svn info if `enclave_info` is provided in verifier config.

Fixes #1622.