### PR TITLE
Problem: `tx-query-next` does not create a new certificate after old one is expired.

### DIFF
--- a/chain-tx-enclave/tx-query-next/enclave-app/Cargo.toml
+++ b/chain-tx-enclave/tx-query-next/enclave-app/Cargo.toml
@@ -20,5 +20,5 @@ enclave-protocol = { path = "../../../enclave-protocol", features = ["edp"] }
 enclave-utils = { path = "../../enclave-utils", features = ["sgxstd"] }
 ra-enclave = { path = "../../enclave-ra/ra-enclave" }
 
-[patch.crates-io]
-ring = { git = "https://github.com/crypto-com/ring.git", rev = "4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa" }
+# [patch.crates-io]
+# ring = { git = "https://github.com/crypto-com/ring.git", rev = "4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa" }

--- a/chain-tx-enclave/tx-query-next/enclave-app/src/handler/decryption_request.rs
+++ b/chain-tx-enclave/tx-query-next/enclave-app/src/handler/decryption_request.rs
@@ -25,9 +25,9 @@ pub fn get_random_challenge() -> H256 {
 }
 
 pub fn verify_decryption_request(decryption_request: &DecryptionRequest, challenge: H256) -> bool {
-    !decryption_request
+    decryption_request
         .verify(&Secp256k1::verification_only(), challenge)
-        .is_err()
+        .is_ok()
 }
 
 pub fn handle_decryption_request(

--- a/chain-tx-enclave/tx-query-next/enclave-app/src/handler/encryption_request.rs
+++ b/chain-tx-enclave/tx-query-next/enclave-app/src/handler/encryption_request.rs
@@ -13,6 +13,7 @@ use enclave_protocol::{
 };
 use enclave_utils::SealedData;
 
+#[allow(clippy::boxed_local)]
 pub fn handle_encryption_request(
     encryption_request: Box<EncryptionRequest>,
     request_len: usize,


### PR DESCRIPTION
Solution:
- Moved the code to set TLS certificate inside of individual connection threads.
- Some `clippy` fixes.