### PR TITLE
Problem (Fix #1645): 0.2.* time crate fails to compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,7 +2859,6 @@ dependencies = [
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/chain-tx-enclave/enclave-ra/ra-client/Cargo.toml
+++ b/chain-tx-enclave/enclave-ra/ra-client/Cargo.toml
@@ -16,6 +16,5 @@ serde_json = "1.0"
 thiserror = "1.0"
 webpki = "0.21"
 x509-parser = "0.7"
-time = "0.1"
 
 ra-common = { path = "../ra-common" }


### PR DESCRIPTION
Solution:
- Remove time dependency
- Only handle the seconds part of time when checking certificate validity
  for simplicity