### PR TITLE
Problem: no MLS group creation procedure (WIP #1617)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,6 +2255,7 @@ dependencies = [
  "ring 0.16.13 (git+https://github.com/crypto-com/ring.git?rev=4e1862fb0df9efaf2d2c1ec8cacb1e53104f3daa)",
  "rs-libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -11,6 +11,7 @@ ring = "0.16"
 thiserror = "1.0"
 rustls = "0.17"
 x509-parser = "0.7"
+sha2 = "0.8.1"
 
 ra-client = { path = "../enclave-ra/ra-client" }
 

--- a/chain-tx-enclave-next/mls/src/credential.rs
+++ b/chain-tx-enclave-next/mls/src/credential.rs
@@ -4,7 +4,7 @@ use rustls::internal::msgs::codec::{Codec, Reader};
 use crate::utils;
 
 /// Don't support basic credential, only for parsing.
-#[derive(Debug)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct BasicCredential {
     identity: Vec<u8>,
     sig_schema: u16,
@@ -12,7 +12,7 @@ pub struct BasicCredential {
 }
 
 /// Credential in keypackage
-#[derive(Debug)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Credential {
     /// don't support, only for parsing
     Basic(BasicCredential),

--- a/chain-tx-enclave-next/mls/src/extensions.rs
+++ b/chain-tx-enclave-next/mls/src/extensions.rs
@@ -4,7 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use crate::keypackage::{CipherSuite, ProtocolVersion, Timespec};
 
 /// spec: draft-ietf-mls-protocol.md#key-packages
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, Ord, PartialOrd, Eq)]
 pub enum ExtensionType {
     Invalid = 0,
     SupportedVersions = 1,
@@ -155,7 +155,7 @@ impl MLSExtension for ParentHashExt {
 }
 
 /// Extension entry included in `KeyPackage`
-#[derive(Debug)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ExtensionEntry {
     pub etype: ExtensionType,
     pub data: Vec<u8>,

--- a/chain-tx-enclave-next/mls/src/group.rs
+++ b/chain-tx-enclave-next/mls/src/group.rs
@@ -1,0 +1,189 @@
+use crate::extensions::{self as ext};
+use crate::keypackage::Timespec;
+use crate::keypackage::{self as kp, KeyPackage, OwnedKeyPackage};
+use crate::message::*;
+use crate::tree::*;
+use ra_client::EnclaveCertVerifierConfig;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+
+pub struct EpochSecrets {}
+impl EpochSecrets {
+    pub fn generate_new_epoch_secrets(
+        &self,
+        _commit_secret: Vec<u8>,
+        _updated_group_context: &GroupContext,
+    ) -> Self {
+        todo!()
+    }
+
+    pub fn compute_confirmation(&self, _confirmed_transcript: &[u8]) -> Vec<u8> {
+        todo!()
+    }
+}
+
+/// auxiliary structure to hold group context + tree
+pub struct GroupAux {
+    pub context: GroupContext,
+    pub tree: Tree,
+    pub secrets: EpochSecrets,
+    pub owned_kp: OwnedKeyPackage,
+}
+
+impl GroupAux {
+    fn new(context: GroupContext, tree: Tree, owned_kp: OwnedKeyPackage) -> Self {
+        GroupAux {
+            context,
+            tree,
+            secrets: EpochSecrets {},
+            owned_kp,
+        }
+    }
+
+    fn add_init(&mut self, _kp: &KeyPackage) -> MLSPlaintext {
+        todo!()
+    }
+
+    fn get_confirmed_transcript_hash(&self, _commit: &Commit) -> Vec<u8> {
+        todo!()
+    }
+
+    fn get_signed_commit(&self, _plain: &MLSPlaintextCommon) -> MLSPlaintext {
+        todo!()
+    }
+
+    fn get_welcome_msg(&self) -> Welcome {
+        todo!()
+    }
+
+    fn init_commit(&mut self, add_proposals: &[MLSPlaintext]) -> (MLSPlaintext, Welcome) {
+        let add_proposals_ids: Vec<ProposalId> = vec![]; //todo!();
+        let mut updated_tree = self.tree.clone();
+        updated_tree.update(&add_proposals, &[], &[]);
+        let commit_secret = vec![0; self.tree.cs.hash_len()];
+        let commit = Commit {
+            updates: vec![],
+            removes: vec![],
+            adds: add_proposals_ids,
+            path: None,
+        };
+        let updated_epoch = self.context.epoch + 1;
+        let confirmed_transcript_hash = self.get_confirmed_transcript_hash(&commit);
+        let mut updated_group_context = self.context.clone();
+        updated_group_context.epoch = updated_epoch;
+        updated_group_context.tree_hash = updated_tree.compute_tree_hash();
+        updated_group_context.confirmed_transcript_hash = confirmed_transcript_hash;
+        let epoch_secrets = self
+            .secrets
+            .generate_new_epoch_secrets(commit_secret, &updated_group_context);
+        let confirmation =
+            epoch_secrets.compute_confirmation(&updated_group_context.confirmed_transcript_hash);
+        let sender = Sender {
+            sender_type: SenderType::Member,
+            sender: 0, // FIXME
+        };
+        let commit_content = MLSPlaintextCommon {
+            group_id: self.context.group_id.clone(),
+            epoch: self.context.epoch,
+            sender,
+            content: ContentType::Commit {
+                commit,
+                confirmation,
+            },
+        };
+        (
+            self.get_signed_commit(&commit_content),
+            self.get_welcome_msg(),
+        )
+    }
+
+    pub fn init_group(
+        creator_kp: OwnedKeyPackage,
+        others: &[KeyPackage],
+        ra_config: EnclaveCertVerifierConfig,
+        genesis_time: Timespec,
+    ) -> Result<(Self, Vec<MLSPlaintext>, MLSPlaintext, Welcome), kp::Error> {
+        let mut kps = BTreeSet::new();
+        for kp in others.iter() {
+            if kps.contains(kp) {
+                return Err(kp::Error::DuplicateKeyPackage);
+            } else {
+                kp.verify(ra_config.clone(), genesis_time)?;
+                kps.insert(kp.clone());
+            }
+        }
+        if kps.contains(&creator_kp.keypackage) {
+            Err(kp::Error::DuplicateKeyPackage)
+        } else {
+            creator_kp.keypackage.verify(ra_config, genesis_time)?;
+            let (context, tree) = GroupContext::init(creator_kp.keypackage.clone())?;
+            let mut group = GroupAux::new(context, tree, creator_kp);
+            let add_proposals: Vec<MLSPlaintext> =
+                others.iter().map(|kp| group.add_init(kp)).collect();
+            let (commit, welcome) = group.init_commit(&add_proposals);
+            Ok((group, add_proposals, commit, welcome))
+        }
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[repr(u16)]
+#[derive(Clone)]
+pub enum CipherSuite {
+    MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 = 2,
+}
+
+impl CipherSuite {
+    /// TODO: use generic array?
+    pub fn hash(&self, data: &[u8]) -> Vec<u8> {
+        match self {
+            CipherSuite::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 => Sha256::digest(data).to_vec(),
+        }
+    }
+
+    pub fn hash_len(&self) -> usize {
+        match self {
+            CipherSuite::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 => 32,
+        }
+    }
+}
+
+const TDBE_GROUP_ID: &[u8] = b"Crypto.com Chain Council Node Transaction Data Bootstrap Enclave";
+
+/// spec: draft-ietf-mls-protocol.md#group-state
+#[derive(Clone)]
+pub struct GroupContext {
+    /// 0..255 bytes -- application-defined id
+    pub group_id: Vec<u8>,
+    /// version of the group key
+    /// (incremented by 1 for each Commit message
+    /// that is processed)
+    pub epoch: u64,
+    /// commitment to the contents of the
+    /// group's ratchet tree and the credentials
+    /// for the members of the group
+    /// 0..255
+    pub tree_hash: Vec<u8>,
+    /// field contains a running hash over
+    /// the messages that led to this state.
+    /// 0..255
+    pub confirmed_transcript_hash: Vec<u8>,
+    pub extensions: Vec<ext::ExtensionEntry>,
+}
+
+impl GroupContext {
+    pub fn init(creator_kp: KeyPackage) -> Result<(Self, Tree), kp::Error> {
+        let extensions = creator_kp.payload.extensions.clone();
+        let tree = Tree::init(creator_kp)?;
+        Ok((
+            GroupContext {
+                group_id: TDBE_GROUP_ID.to_vec(),
+                epoch: 0,
+                tree_hash: tree.compute_tree_hash(),
+                confirmed_transcript_hash: vec![],
+                extensions,
+            },
+            tree,
+        ))
+    }
+}

--- a/chain-tx-enclave-next/mls/src/key.rs
+++ b/chain-tx-enclave-next/mls/src/key.rs
@@ -9,7 +9,7 @@ use ring::{
 use rustls::internal::msgs::codec::{Codec, Reader};
 
 /// p-256 public key
-#[derive(Debug)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct PublicKey(Vec<u8>);
 
 impl PublicKey {

--- a/chain-tx-enclave-next/mls/src/keypackage.rs
+++ b/chain-tx-enclave-next/mls/src/keypackage.rs
@@ -23,7 +23,7 @@ pub const MLS10_128_DHKEMP256_AES128GCM_SHA256_P256: CipherSuite = 2;
 pub const CREDENTIAL_TYPE_X509: u8 = 1;
 
 /// spec: draft-ietf-mls-protocol.md#key-packages
-#[derive(Debug)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct KeyPackagePayload {
     pub version: ProtocolVersion,
     pub cipher_suite: CipherSuite,
@@ -121,7 +121,7 @@ impl KeyPackagePayload {
 
 /// Key package, only send `(payload, signature)` to other nodes.
 /// spec: draft-ietf-mls-protocol.md#key-packages
-#[derive(Debug)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct KeyPackage {
     pub payload: KeyPackagePayload,
     pub signature: Vec<u8>,
@@ -222,6 +222,8 @@ pub enum Error {
     UnsupportedCipherSuite(CipherSuite),
     #[error("init key and credential public key don't match")]
     InitKeyDontMatch,
+    #[error("duplicate key package")]
+    DuplicateKeyPackage,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/chain-tx-enclave-next/mls/src/lib.rs
+++ b/chain-tx-enclave-next/mls/src/lib.rs
@@ -1,8 +1,11 @@
-//! This crate implements [mls protocol](https://github.com/mlswg/mls-protocol/blob/bb3a3de94cc75e91dee62d24f702fb2b1b5d1182/draft-ietf-mls-protocol.md)
+//! This crate implements [mls protocol](https://github.com/mlswg/mls-protocol/blob/8264f452c27354ac043d289a893b4bec80c1d556/draft-ietf-mls-protocol.md)
 pub mod credential;
 pub mod extensions;
+pub mod group;
 pub mod key;
 pub mod keypackage;
+pub mod message;
+pub mod tree;
 pub mod utils;
 
 pub use keypackage::{KeyPackage, OwnedKeyPackage};

--- a/chain-tx-enclave-next/mls/src/message.rs
+++ b/chain-tx-enclave-next/mls/src/message.rs
@@ -1,0 +1,145 @@
+use crate::key::PublicKey;
+use crate::keypackage::{CipherSuite, KeyPackage, ProtocolVersion};
+
+/// spec: draft-ietf-mls-protocol.md#Add
+pub struct Add {
+    key_package: KeyPackage,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Update
+/// FIXME
+#[allow(dead_code)]
+pub struct Update {
+    key_package: KeyPackage,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Remove
+/// FIXME
+#[allow(dead_code)]
+pub struct Remove {
+    removed: u32,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Proposal
+/// #[repr(u8)]
+pub enum Proposal {
+    // Invalid = 0,
+    Add(Add),       // = 1,
+    Update(Update), // = 2,
+    Remove(Remove), // = 3,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Message-Framing
+/// + draft-ietf-mls-protocol.md#MContent-Signing-and-Encryption
+pub struct MLSPlaintextCommon {
+    /// 0..255 bytes -- application-defined id
+    pub group_id: Vec<u8>,
+    /// version of the group key
+    /// (incremented by 1 for each Commit message
+    /// that is processed)
+    pub epoch: u64,
+    pub sender: Sender,
+    pub content: ContentType,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Message-Framing
+pub struct MLSPlaintext {
+    pub content: MLSPlaintextCommon,
+    /// 0..2^16-1
+    pub signature: Vec<u8>,
+}
+
+impl MLSPlaintext {
+    pub fn get_add_keypackage(&self) -> Option<KeyPackage> {
+        match &self.content.content {
+            ContentType::Proposal(Proposal::Add(Add { key_package })) => Some(key_package.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// 0..255 -- hash of the MLSPlaintext in which the Proposal was sent
+/// spec: draft-ietf-mls-protocol.md#Commit
+pub type ProposalId = Vec<u8>;
+
+/// spec: draft-ietf-mls-protocol.md#Commit
+pub struct Commit {
+    /// 0..2^16-1
+    pub updates: Vec<ProposalId>,
+    /// 0..2^16-1
+    pub removes: Vec<ProposalId>,
+    /// 0..2^16-1
+    pub adds: Vec<ProposalId>,
+    /// 0..2^16-1
+    /// "path field of a Commit message MUST be populated if the Commit covers at least one Update or Remove proposal"
+    /// "path field MUST also be populated if the Commit covers no proposals at all (i.e., if all three proposal vectors are empty)."
+    pub path: Option<DirectPath>,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Welcoming-New-Members
+pub struct Welcome {
+    pub version: ProtocolVersion,
+    pub cipher_suite: CipherSuite,
+    /// 0..2^32-1
+    pub secrets: Vec<EncryptedGroupSecrets>,
+    /// 0..2^32-1
+    pub encrypted_group_info: Vec<u8>,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Welcoming-New-Members
+pub struct EncryptedGroupSecrets {
+    pub encrypted_group_secrets: HPKECiphertext,
+    pub key_package_hash: Vec<u8>,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Direct-Paths
+pub struct HPKECiphertext {
+    /// 0..2^16-1
+    pub kem_output: Vec<u8>,
+    /// 0..2^16-1
+    pub ciphertext: Vec<u8>,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Direct-Paths
+pub struct DirectPathNode {
+    pub public_key: PublicKey,
+    /// 0..0..2^32-1>
+    pub encrypted_path_secret: Vec<HPKECiphertext>,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Direct-Paths
+pub struct DirectPath {
+    pub leaf_key_package: KeyPackage,
+    /// 0..0..2^16-1>
+    pub nodes: Vec<DirectPathNode>,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Message-Framing
+/// #[repr(u8)]
+#[allow(clippy::large_enum_variant)]
+pub enum ContentType {
+    Application {
+        // <0..2^32-1>
+        application_data: Vec<u8>,
+    }, //= 1,
+    Proposal(Proposal), //= 2,
+    Commit {
+        commit: Commit,
+        // 0..255
+        confirmation: Vec<u8>,
+    }, //= 3,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Message-Framing
+#[repr(u8)]
+pub enum SenderType {
+    Member = 1,
+    Preconfigured = 2,
+    NewMember = 3,
+}
+
+/// spec: draft-ietf-mls-protocol.md#Message-Framing
+pub struct Sender {
+    pub sender_type: SenderType,
+    pub sender: u32,
+}

--- a/chain-tx-enclave-next/mls/src/tree.rs
+++ b/chain-tx-enclave-next/mls/src/tree.rs
@@ -1,0 +1,399 @@
+use crate::group::*;
+use crate::key::PublicKey;
+use crate::keypackage::{self as kp, KeyPackage, MLS10_128_DHKEMP256_AES128GCM_SHA256_P256};
+use crate::message::*;
+use crate::utils::{decode_option, encode_option, encode_vec_u32, read_vec_u32};
+use rustls::internal::msgs::codec::{self, Codec, Reader};
+
+#[derive(Debug, Clone)]
+/// spec: draft-ietf-mls-protocol.md#tree-hashes
+pub struct ParentNode {
+    pub public_key: PublicKey,
+    // 0..2^32-1
+    pub unmerged_leaves: Vec<u32>,
+    // 0..255
+    pub parent_hash: Vec<u8>,
+}
+
+impl Codec for ParentNode {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.public_key.encode(bytes);
+        encode_vec_u32(bytes, &self.unmerged_leaves);
+        codec::encode_vec_u8(bytes, &self.parent_hash);
+    }
+
+    fn read(r: &mut Reader) -> Option<Self> {
+        let public_key = PublicKey::read(r)?;
+        let unmerged_leaves = read_vec_u32(r)?;
+        let parent_hash = codec::read_vec_u8(r)?;
+        Some(Self {
+            public_key,
+            unmerged_leaves,
+            parent_hash,
+        })
+    }
+}
+
+/// spec: draft-ietf-mls-protocol.md#tree-hashes
+#[derive(Clone)]
+pub enum Node {
+    Leaf(Option<KeyPackage>),
+    Parent(Option<ParentNode>),
+}
+
+impl Node {
+    pub fn is_leaf(&self) -> bool {
+        matches!(self, Node::Leaf(_))
+    }
+
+    pub fn is_empty_leaf(&self) -> bool {
+        matches!(self, Node::Leaf(None))
+    }
+}
+
+#[derive(Debug)]
+/// spec: draft-ietf-mls-protocol.md#tree-hashes
+pub struct ParentNodeHashInput {
+    pub node_index: u32,
+    pub parent_node: Option<ParentNode>,
+    pub left_hash: Vec<u8>,
+    pub right_hash: Vec<u8>,
+}
+
+impl Codec for ParentNodeHashInput {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.node_index.encode(bytes);
+        encode_option(bytes, &self.parent_node);
+        codec::encode_vec_u8(bytes, &self.left_hash);
+        codec::encode_vec_u8(bytes, &self.right_hash);
+    }
+
+    fn read(r: &mut Reader) -> Option<Self> {
+        let node_index = u32::read(r)?;
+        let parent_node: Option<ParentNode> = decode_option(r)?;
+        let left_hash = codec::read_vec_u8(r)?;
+        let right_hash = codec::read_vec_u8(r)?;
+
+        Some(Self {
+            node_index,
+            parent_node,
+            left_hash,
+            right_hash,
+        })
+    }
+}
+
+#[derive(Debug)]
+/// spec: draft-ietf-mls-protocol.md#tree-hashes
+pub struct LeafNodeHashInput {
+    pub node_index: u32,
+    pub key_package: Option<KeyPackage>,
+}
+
+impl Codec for LeafNodeHashInput {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.node_index.encode(bytes);
+        encode_option(bytes, &self.key_package);
+    }
+
+    fn read(r: &mut Reader) -> Option<Self> {
+        let node_index = u32::read(r)?;
+        let key_package: Option<KeyPackage> = decode_option(r)?;
+
+        Some(Self {
+            node_index,
+            key_package,
+        })
+    }
+}
+
+/// spec: draft-ietf-mls-protocol.md#tree-math
+/// TODO: https://github.com/mlswg/mls-protocol/pull/327/files
+#[derive(Clone)]
+pub struct Tree {
+    pub nodes: Vec<Node>,
+    pub cs: CipherSuite,
+}
+
+/// The level of a node in the tree.  Leaves are level 0, their
+/// parents are level 1, etc.  If a node's children are at different
+/// level, then its level is the max level of its children plus one.
+#[inline]
+fn level(x: usize) -> usize {
+    if (x & 0x01) == 0 {
+        return 0;
+    }
+    let mut k = 0;
+    while ((x >> k) & 0x01) == 1 {
+        k += 1;
+    }
+    k
+}
+
+/// The number of nodes needed to represent a tree with n leaves
+#[inline]
+fn node_width(n: usize) -> usize {
+    2 * (n - 1) + 1
+}
+
+/// The left child of an intermediate node.  Note that because the
+/// tree is left-balanced, there is no dependency on the size of the
+/// tree.  The child of a leaf node is itself.
+#[inline]
+fn left(x: usize) -> usize {
+    let k = level(x);
+    if k == 0 {
+        return x;
+    }
+    x ^ (0x01 << (k - 1))
+}
+
+/// The right child of an intermediate node.  Depends on the size of
+/// the tree because the straightforward calculation can take you
+/// beyond the edge of the tree.  The child of a leaf node is itself.
+#[inline]
+fn right(x: usize, n: usize) -> usize {
+    let k = level(x);
+    if k == 0 {
+        return x;
+    }
+    let mut r = x ^ (0x03 << (k - 1));
+    while r >= node_width(n) {
+        r = left(r);
+    }
+    r
+}
+
+/// The index of the root node of a tree with n leaves
+#[inline]
+fn root(n: usize) -> usize {
+    let w = node_width(n);
+    (1usize << log2(w)) - 1
+}
+
+/// The largest power of 2 less than n.  Equivalent to:
+///  int(math.floor(math.log(x, 2)))
+#[inline]
+fn log2(x: usize) -> usize {
+    if x == 0 {
+        return 0;
+    }
+
+    let mut k = 0;
+    while (x >> k) > 0 {
+        k += 1
+    }
+    k - 1
+}
+
+/// The immediate parent of a node.  May be beyond the right edge of
+/// the tree.
+#[inline]
+fn parent_step(x: usize) -> usize {
+    let k = level(x);
+    let b = (x >> (k + 1)) & 0x01;
+    (x | (1 << k)) ^ (b << (k + 1))
+}
+
+/// The parent of a node.  As with the right child calculation, have
+/// to walk back until the parent is within the range of the tree.
+#[inline]
+fn parent(x: usize, n: usize) -> usize {
+    if x == root(n) {
+        return x;
+    }
+    let mut p = parent_step(x);
+    while p >= node_width(n) {
+        p = parent_step(p)
+    }
+    p
+}
+
+/// The direct path of a node, ordered from the root
+/// down, including the root
+#[inline]
+fn direct_path(node_pos: usize, n: usize) -> Vec<usize> {
+    let mut d = Vec::new();
+    let mut p = parent(node_pos, n);
+    let r = root(n);
+    while p != r {
+        d.push(p);
+        p = parent(p, n);
+    }
+    if node_pos != r {
+        d.push(r);
+    }
+    d
+}
+
+impl Tree {
+    fn get_free_leaf_or_extend(&mut self) -> usize {
+        match self.nodes.iter().position(|n| n.is_empty_leaf()) {
+            Some(i) => i,
+            None => {
+                self.nodes.push(Node::Parent(None));
+                self.nodes.push(Node::Leaf(None));
+                self.nodes.len() - 1
+            }
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        add_proposals: &[MLSPlaintext],
+        update_proposals: &[MLSPlaintext],
+        remove_proposals: &[MLSPlaintext],
+    ) {
+        for _update in update_proposals.iter() {
+            // FIXME
+        }
+        for _remove in remove_proposals.iter() {
+            // FIXME
+        }
+        for add in add_proposals.iter() {
+            // position to add
+            // "If necessary, extend the tree to the right until it has at least index + 1 leaves"
+            let position = self.get_free_leaf_or_extend();
+            let leafs = self.leaf_len();
+            let dirpath = direct_path(position, leafs);
+            for d in dirpath.iter() {
+                let node = &mut self.nodes[*d];
+                if let Node::Parent(Some(ref mut np)) = node {
+                    // "For each non-blank intermediate node along the
+                    // path from the leaf at position index to the root,
+                    // add index to the unmerged_leaves list for the node."
+                    let du32 = *d as u32;
+                    if !np.unmerged_leaves.contains(&du32) {
+                        np.unmerged_leaves.push(du32);
+                    }
+                }
+            }
+            // "Set the leaf node in the tree at position index to a new node containing the public key
+            // from the KeyPackage in the Add, as well as the credential under which the KeyPackage was signed"
+            let leaf_node = Node::Leaf(add.get_add_keypackage());
+            self.nodes[position] = leaf_node;
+        }
+    }
+
+    fn node_hash(&self, index: usize) -> Vec<u8> {
+        let node = &self.nodes[index];
+        match node {
+            Node::Leaf(kp) => {
+                let mut inp = Vec::new();
+                LeafNodeHashInput {
+                    node_index: index as u32,
+                    key_package: kp.clone(),
+                }
+                .encode(&mut inp);
+                self.cs.hash(&inp)
+            }
+            Node::Parent(pn) => {
+                let left_index = left(index);
+                let left_hash = self.node_hash(left_index);
+                let right_index = right(index, self.nodes.len());
+                let right_hash = self.node_hash(right_index);
+                let mut inp = Vec::new();
+                ParentNodeHashInput {
+                    node_index: index as u32,
+                    parent_node: pn.clone(),
+                    left_hash,
+                    right_hash,
+                }
+                .encode(&mut inp);
+                self.cs.hash(&inp)
+            }
+        }
+    }
+
+    fn leaf_len(&self) -> usize {
+        self.nodes.iter().filter(|n| n.is_leaf()).count()
+    }
+
+    pub fn compute_tree_hash(&self) -> Vec<u8> {
+        let root_index = root(self.leaf_len());
+        self.node_hash(root_index)
+    }
+
+    pub fn init(creator_kp: KeyPackage) -> Result<Self, kp::Error> {
+        let cs = match creator_kp.payload.cipher_suite {
+            MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 => {
+                Ok(CipherSuite::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256)
+            }
+            _ => Err(kp::Error::UnsupportedCipherSuite(
+                creator_kp.payload.cipher_suite,
+            )),
+        }?;
+        Ok(Self {
+            nodes: vec![Node::Leaf(Some(creator_kp))],
+            cs,
+        })
+    }
+}
+
+mod test {
+
+    #[test]
+    fn test_tree_math() {
+        use super::{direct_path, left, level, log2, parent, right, root};
+        // Precomputed answers for the tree on eleven elements
+        // adapted from https://github.com/cisco/go-mls/blob/master/tree-math_test.go
+        let a_root = vec![
+            0x00, 0x01, 0x03, 0x03, 0x07, 0x07, 0x07, 0x07, 0x0f, 0x0f, 0x0f,
+        ];
+        let a_log2 = vec![
+            0x00, 0x00, 0x01, 0x01, 0x02, 0x02, 0x02, 0x02, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
+            0x03, 0x03, 0x04, 0x04, 0x04, 0x04, 0x04,
+        ];
+        let a_level = vec![
+            0x00, 0x01, 0x00, 0x02, 0x00, 0x01, 0x00, 0x03, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01,
+            0x00, 0x04, 0x00, 0x01, 0x00, 0x02, 0x00,
+        ];
+        let a_left = vec![
+            0x00, 0x00, 0x02, 0x01, 0x04, 0x04, 0x06, 0x03, 0x08, 0x08, 0x0a, 0x09, 0x0c, 0x0c,
+            0x0e, 0x07, 0x10, 0x10, 0x12, 0x11, 0x14,
+        ];
+        let a_right = vec![
+            0x00, 0x02, 0x02, 0x05, 0x04, 0x06, 0x06, 0x0b, 0x08, 0x0a, 0x0a, 0x0d, 0x0c, 0x0e,
+            0x0e, 0x13, 0x10, 0x12, 0x12, 0x14, 0x14,
+        ];
+        let a_parent = vec![
+            0x01, 0x03, 0x01, 0x07, 0x05, 0x03, 0x05, 0x0f, 0x09, 0x0b, 0x09, 0x07, 0x0d, 0x0b,
+            0x0d, 0x0f, 0x11, 0x13, 0x11, 0x0f, 0x13,
+        ];
+        let a_dirpath = [
+            vec![0x01, 0x03, 0x07, 0x0f],
+            vec![0x03, 0x07, 0x0f],
+            vec![0x01, 0x03, 0x07, 0x0f],
+            vec![0x07, 0x0f],
+            vec![0x05, 0x03, 0x07, 0x0f],
+            vec![0x03, 0x07, 0x0f],
+            vec![0x05, 0x03, 0x07, 0x0f],
+            vec![0x0f],
+            vec![0x09, 0x0b, 0x07, 0x0f],
+            vec![0x0b, 0x07, 0x0f],
+            vec![0x09, 0x0b, 0x07, 0x0f],
+            vec![0x07, 0x0f],
+            vec![0x0d, 0x0b, 0x07, 0x0f],
+            vec![0x0b, 0x07, 0x0f],
+            vec![0x0d, 0x0b, 0x07, 0x0f],
+            vec![],
+            vec![0x11, 0x13, 0x0f],
+            vec![0x13, 0x0f],
+            vec![0x11, 0x13, 0x0f],
+            vec![0x0f],
+            vec![0x13, 0x0f],
+        ];
+        let a_n = 0x0b;
+        for n in 1..a_n {
+            assert_eq!(root(n), a_root[n - 1])
+        }
+        for i in 0x00..0x14 {
+            assert_eq!(a_log2[i], log2(i));
+            assert_eq!(a_level[i], level(i));
+            assert_eq!(a_left[i], left(i));
+            assert_eq!(a_right[i], right(i, a_n));
+            assert_eq!(a_parent[i], parent(i, a_n));
+            assert_eq!(a_dirpath[i], direct_path(i, a_n));
+        }
+    }
+}


### PR DESCRIPTION
Solution:
- added basic data types + serialization helpers
- tree math + tests: https://github.com/mlswg/mls-protocol/blob/master/draft-ietf-mls-protocol.md#tree-math-tree-math
- creator group initilizations + some skeleton code

NOTE / WIP: As this turns out to be quite large, it may be better to split this over more PRs.
What's still missing:
- plaintext msg signing -- creation of add proposal messages
- secret derivations, ecnryptions... -- creation of commit and welcome messages
- welcome message processing / group creation from it
(and more tests)

