### PR TITLE
Problem: (fix #1658) no api for `minimum unbonded time` in client-rpc

### DIFF
--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -2,7 +2,6 @@
 mod default_network_ops_client;
 
 pub use self::default_network_ops_client::DefaultNetworkOpsClient;
-
 use chain_core::init::coin::Coin;
 use chain_core::state::account::{
     CouncilNode, StakedState, StakedStateAddress, StakedStateOpAttributes,
@@ -12,6 +11,7 @@ use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use chain_core::tx::TxAux;
+use client_common::tendermint::types::{Genesis, StatusResponse};
 use client_common::{ErrorKind, Result, ResultExt, SecKey};
 use client_core::types::TransactionPending;
 
@@ -103,4 +103,10 @@ pub trait NetworkOpsClient: Send + Sync {
         address: &StakedStateAddress,
         verify: bool,
     ) -> Result<Option<StakedState>>;
+
+    /// Return genesis of tendermint
+    fn get_genesis(&self) -> Result<Genesis>;
+
+    /// Return status response
+    fn get_status(&self) -> Result<StatusResponse>;
 }

--- a/client-rpc/src/handler.rs
+++ b/client-rpc/src/handler.rs
@@ -14,6 +14,7 @@ use client_core::wallet::DefaultWalletClient;
 use client_network::network_ops::DefaultNetworkOpsClient;
 
 use crate::rpc::{
+    info_rpc::{InfoRpc, InfoRpcImpl},
     multisig_rpc::{MultiSigRpc, MultiSigRpcImpl},
     staking_rpc::{StakingRpc, StakingRpcImpl},
     sync_rpc::{CBindingCore, SyncRpc, SyncRpcImpl},
@@ -75,7 +76,9 @@ impl RpcHandler {
 
         let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
         let transaction_rpc = TransactionRpcImpl::new(network_id);
-        let staking_rpc = StakingRpcImpl::new(wallet_client.clone(), ops_client, network_id);
+        let staking_rpc =
+            StakingRpcImpl::new(wallet_client.clone(), ops_client.clone(), network_id);
+        let info_rpc = InfoRpcImpl::new(ops_client);
 
         let sync_wallet_client =
             make_wallet_client(storage, tendermint_client, fee_policy, obfuscator)?;
@@ -88,6 +91,7 @@ impl RpcHandler {
         io.extend_with(staking_rpc.to_delegate());
         io.extend_with(sync_rpc.to_delegate());
         io.extend_with(wallet_rpc.to_delegate());
+        io.extend_with(info_rpc.to_delegate());
 
         Ok(RpcHandler { io })
     }

--- a/client-rpc/src/rpc.rs
+++ b/client-rpc/src/rpc.rs
@@ -1,3 +1,4 @@
+pub mod info_rpc;
 pub mod multisig_rpc;
 pub mod staking_rpc;
 pub mod sync_rpc;

--- a/client-rpc/src/rpc/info_rpc.rs
+++ b/client-rpc/src/rpc/info_rpc.rs
@@ -1,0 +1,42 @@
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+
+use crate::to_rpc_error;
+use client_common::tendermint::types::{Genesis, StatusResponse};
+use client_network::NetworkOpsClient;
+
+#[rpc(server)]
+pub trait InfoRpc: Send + Sync {
+    #[rpc(name = "genesis")]
+    fn genesis(&self) -> Result<Genesis>;
+    #[rpc(name = "status")]
+    fn status(&self) -> Result<StatusResponse>;
+}
+
+pub struct InfoRpcImpl<N>
+where
+    N: NetworkOpsClient,
+{
+    ops_client: N,
+}
+
+impl<N> InfoRpcImpl<N>
+where
+    N: NetworkOpsClient,
+{
+    pub fn new(ops_client: N) -> Self {
+        InfoRpcImpl { ops_client }
+    }
+}
+
+impl<N> InfoRpc for InfoRpcImpl<N>
+where
+    N: NetworkOpsClient + 'static,
+{
+    fn genesis(&self) -> Result<Genesis> {
+        self.ops_client.get_genesis().map_err(to_rpc_error)
+    }
+    fn status(&self) -> Result<StatusResponse> {
+        self.ops_client.get_status().map_err(to_rpc_error)
+    }
+}


### PR DESCRIPTION
to display unbonded time in sample wallet client.
use evidence,max_age_duration in genesis(which is nano seconds)
added genesis, status api to client-rpc, which uses tendermint rpc (26657 port)
also when withdrawal fails by unbonded time, also returns remaining time for withdrawal