### PR TITLE
Problem (Fix #1664): fuzzer crashes because of missing keypackage field in its default genesis

### DIFF
--- a/chain-abci/fuzz/fuzz_targets/abci_cycle.rs
+++ b/chain-abci/fuzz/fuzz_targets/abci_cycle.rs
@@ -75,7 +75,7 @@ const TEST_GENESIS: &str = "{
           \"value\": \"MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=\"
         },
         {
-          \"cert\": \"RklYTUU=\"
+          \"keypackage\": \"RklYTUU=\"
         }
       ]
     }


### PR DESCRIPTION
Solution:
- Rename cert -> keypackage
