### PR TITLE
Problem:(fix #1649) no graceful close in client-cli after sync

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -384,9 +384,10 @@ impl Command {
                 disable_address_recovery,
                 block_height_ensure,
             } => {
+                let enckey = ask_seckey(None)?;
                 let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
                 let tx_obfuscation = get_tx_query(tendermint_client.clone())?;
-                let enckey = ask_seckey(None)?;
+
                 let storage = SledStorage::new(storage_path())?;
                 let config = ObfuscationSyncerConfig::new(
                     storage.clone(),
@@ -399,7 +400,8 @@ impl Command {
                         block_height_ensure: *block_height_ensure,
                     },
                 );
-                Self::resync(config, name.clone(), enckey, *force, storage)
+                Self::resync(config, name.clone(), enckey, *force, storage)?;
+                Ok(())
             }
             Command::MultiSig { multisig_command } => {
                 let storage = SledStorage::new(storage_path())?;
@@ -691,6 +693,7 @@ fn print_sync_warning() {
 
 fn get_wallet_client(storage: SledStorage) -> Result<AppWalletClient> {
     let tendermint_client = WebsocketRpcClient::new(&tendermint_url())?;
+
     let hw_key_service = HwKeyService::default();
 
     let signer_manager = WalletSignerManager::new(storage.clone(), hw_key_service.clone());

--- a/client-common/src/tendermint/rpc_client/async_rpc_client.rs
+++ b/client-common/src/tendermint/rpc_client/async_rpc_client.rs
@@ -23,9 +23,10 @@ use tokio::{
 };
 use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
+/// websocket writer
 pub type WebSocketWriter = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
+/// websocket reader
 pub type WebSocketReader = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
-
 use super::{
     types::{ConnectionState, JsonRpcRequest, JsonRpcResponse},
     websocket_rpc_loop,
@@ -40,7 +41,8 @@ const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 #[derive(Clone)]
 pub struct AsyncRpcClient {
     connection_state: Arc<Mutex<ConnectionState>>,
-    websocket_writer: Arc<Mutex<WebSocketWriter>>,
+    /// websocket
+    pub websocket_writer: Arc<Mutex<WebSocketWriter>>,
     channel_map: Arc<Mutex<HashMap<String, Sender<JsonRpcResponse>>>>,
     unique_id: Arc<AtomicUsize>,
 }


### PR DESCRIPTION
- send `close` websocket message before shutting down websocket
- to fix two `EOF` errors per syncing
