### PR TITLE
Problem: (fix #1585)cargo kcov occasionally crashing on test_dev_config_file

### DIFF
--- a/dev-utils/src/commands/genesis_command.rs
+++ b/dev-utils/src/commands/genesis_command.rs
@@ -386,11 +386,9 @@ mod test {
 
     #[test]
     fn test_dev_config_file() {
-        let file = PathBuf::from("./example-dev-conf.json");
-        let genesis_dev_config_string =
-            fs::read_to_string(file).expect("can not find example-dev-config file");
+        let genesis_dev_config_str = include_str!("../../example-dev-conf.json");
         let genesis_dev_config: std::result::Result<GenesisDevConfig, _> =
-            serde_json::from_str(&genesis_dev_config_string);
+            serde_json::from_str(genesis_dev_config_str);
         assert!(genesis_dev_config.is_ok());
     }
 }


### PR DESCRIPTION
solution: use `include_str!` instead of reading from the file.