### PR TITLE
Problem (Fix #1699): mock mode multinode integration tests fails

### DIFF
--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -21,3 +21,6 @@ env_logger="0.7.1"
 log ="0.4.8"
 zeroize = "1.1"
 parity-scale-codec = "1.3"
+
+[features]
+mock-enclave = []

--- a/client-rpc/server/Cargo.toml
+++ b/client-rpc/server/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Crypto.com <chain@crypto.com>"]
 edition = "2018"
 
 [features]
-mock-enclave = []
-default = []
+mock-enclave = ["client-rpc-core/mock-enclave"]
 
 [dependencies]
 client-rpc-core = { path = ".." }

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -478,6 +478,8 @@ fn get_node_metadata(
     let keypackage = base64::decode(keypackage)
         .err_kind(ErrorKind::InvalidInput, || "invalid base64")
         .map_err(to_rpc_error)?;
+
+    #[cfg(not(feature = "mock-enclave"))]
     verify_keypackage(&keypackage).map_err(to_rpc_error)?;
 
     Ok(CouncilNode {

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 name = "cro_clib"
 crate-type = ["staticlib"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+mock-enclave = ["client-rpc-core/mock-enclave"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"]}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -56,7 +56,11 @@ else
 fi
 
 echo "Build dynamic cro-clib"
-cargo install cargo-crate-type
-cargo crate-type -f cro-clib/Cargo.toml dynamic
-cargo build $CARGO_ARGS -p cro-clib
-cargo crate-type -f cro-clib/Cargo.toml static
+sed -i.bak -E "s/crate-type = \[\".+\"\]/crate-type = \[\"cdylib\"\]/" cro-clib/Cargo.toml
+if [ $BUILD_MODE == "sgx" ]; then
+    cargo build $CARGO_ARGS -p cro-clib
+else
+    cargo build $CARGO_ARGS --features mock-enclave --manifest-path cro-clib/Cargo.toml
+fi
+sed -i.bak -E "s/crate-type = \[\".+\"\]/crate-type = \[\"staticlib\"\]/" cro-clib/Cargo.toml
+rm cro-clib/Cargo.toml.bak

--- a/integration-tests/bot/chainbot.py
+++ b/integration-tests/bot/chainbot.py
@@ -275,7 +275,9 @@ def tasks_ini(node_cfgs, app_hash, root_path, cfg):
         'supervisorctl': {
             'serverurl': 'unix://%(here)s/supervisor.sock',
         },
-        'program:ra-sp-server': {
+    }
+    if not cfg.get('mock_mode'):
+        ini['program:ra-sp-server'] = {
             'command': f'ra-sp-server --quote-type Unlinkable --ias-key {os.environ["IAS_API_KEY"]} --spid {os.environ["SPID"]}',
             'stdout_logfile': '%(here)s/logs/ra-sp-server.log',
             'autostart': 'true',
@@ -284,8 +286,7 @@ def tasks_ini(node_cfgs, app_hash, root_path, cfg):
             'priority': '10',
             'startsecs': '3',
             'startretries': '10',
-        },
-    }
+        }
 
     for node in node_cfgs:
         prgs = programs(node, app_hash, root_path, cfg)

--- a/integration-tests/bot/chainrpc.py
+++ b/integration-tests/bot/chainrpc.py
@@ -75,6 +75,7 @@ class Client:
             network_id=network_id,
             mock_mode=mock_mode
         )
+        self.mock_mode = mock_mode
 
     def call(self, method, *args, **kwargs):
         params = None
@@ -266,8 +267,10 @@ class Staking:
         return self.client.call('wallet_broadcastSignedTransferTx', [name, enckey or get_enckey()], signed_tx)
 
     def gen_keypackage(self, path=MLS_ENCLAVE_PATH):
-        print('mls path', path)
-        return self.client.call('staking_genKeyPackage', path)
+        if self.client.mock_mode:
+            return ''
+        else:
+            return self.client.call('staking_genKeyPackage', path)
 
 
 class MultiSig:


### PR DESCRIPTION
Solution:
- in mock mode, provide empty key package, client and abci don't verify
