### PR TITLE
Problem: no MLS group creation procedure (fixes #1617)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ dependencies = [
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -18,6 +18,7 @@ hpke = "0.1.3"
 aead = "0.2.0"
 rand = "0.7"
 ra-client = { path = "../enclave-ra/ra-client" }
+subtle = "2.2.3"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/chain-tx-enclave-next/mls/src/tree.rs
+++ b/chain-tx-enclave-next/mls/src/tree.rs
@@ -158,9 +158,9 @@ pub struct Tree {
     pub my_pos: usize,
 }
 
-/// The level of a node in the tree.  Leaves are level 0, their
-/// parents are level 1, etc.  If a node's children are at different
-/// level, then its level is the max level of its children plus one.
+/// The level of a node in the tree. Leaves are level 0, their parents are
+/// level 1, etc. If a node's children are at different levels, then its
+/// level is the max level of its children plus one.
 #[inline]
 fn level(x: usize) -> usize {
     if (x & 0x01) == 0 {
@@ -214,7 +214,7 @@ fn root(n: usize) -> usize {
     (1usize << log2(w)) - 1
 }
 
-/// The largest power of 2 less than n.  Equivalent to:
+/// The exponent of the largest power of 2 less than x. Equivalent to:
 ///  int(math.floor(math.log(x, 2)))
 #[inline]
 fn log2(x: usize) -> usize {


### PR DESCRIPTION
Solution: confirmation is derived from the updated secrets
+ constant time equality is used for comparing the confirmation mac
--
NOTE: some things aren't done yet or broken, e.g. tree integrity checking
a follow up issues are created: https://github.com/crypto-com/chain/issues/1703

