### PR TITLE
Problem: TLS 1.3 may not be used

### DIFF
--- a/chain-tx-enclave-next/enclave-ra/ra-client/src/verifier.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-client/src/verifier.rs
@@ -232,12 +232,15 @@ impl EnclaveCertVerifier {
     pub fn into_client_config(self) -> ClientConfig {
         let mut config = ClientConfig::new();
         config.dangerous().set_certificate_verifier(Arc::new(self));
+        config.versions = vec![rustls::ProtocolVersion::TLSv1_3];
         config
     }
 
     /// Converts enclave certificate verifier into server config expected by `rustls`
     pub fn into_server_config(self) -> ServerConfig {
-        ServerConfig::new(Arc::new(self))
+        let mut server_config = ServerConfig::new(Arc::new(self));
+        server_config.versions = vec![rustls::ProtocolVersion::TLSv1_3];
+        server_config
     }
 }
 

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module.rs
@@ -59,6 +59,7 @@ pub fn entry() -> std::io::Result<()> {
                 certificate
                     .configure_server_config(&mut tls_server_config)
                     .expect("Unable to create TLS server config");
+                tls_server_config.versions = vec![rustls::ProtocolVersion::TLSv1_3];
 
                 let tls_server_config = Arc::new(tls_server_config);
 


### PR DESCRIPTION
Solution: Explicitly add supported TLS version to 1.3 in client and server configs. Fixes #1709.