### PR TITLE
Problem: enclave-utils doesn't zero-out intermediate gcm parts

### DIFF
--- a/chain-tx-enclave-next/enclave-utils/Cargo.toml
+++ b/chain-tx-enclave-next/enclave-utils/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 sgx-isa = "0.3"
-aes-gcm = "0.5.0"
+aes-gcm = { version = "0.5.0", features = ["zeroize"] }
 aead = "0.2"
 zeroize = "1.1"
 rand = "0.7"


### PR DESCRIPTION
Solution: enabled zeroize feature on aes-gcm

