### PR TITLE
Problem: reading genesis time from tendermint make `dev init` fail(fi…

### DIFF
--- a/ci-scripts/check-docker-app-hash.sh
+++ b/ci-scripts/check-docker-app-hash.sh
@@ -15,7 +15,7 @@ function check_command_exist() {
 
 check_command_exist "jq"
 
-GENERATED_APP_HASH=$(./target/debug/dev-utils genesis generate --genesis_dev_config_path ./docker/config/devnet/dev-conf.json --tendermint_genesis_path ./docker/config/devnet/tendermint/genesis.json | jq -r '.app_hash')
+GENERATED_APP_HASH=$(./target/debug/dev-utils genesis generate --no_evidence_overwrite --no_genesistime_overwrite --genesis_dev_config_path ./docker/config/devnet/dev-conf.json --tendermint_genesis_path ./docker/config/devnet/tendermint/genesis.json | jq -r '.app_hash')
 GENESIS_APP_HASH=$(cat ./docker/config/devnet/tendermint/genesis.json | jq -r '.app_hash')
 echo "Generated app hash: ${GENERATED_APP_HASH}"
 echo "Docker app hash: ${GENESIS_APP_HASH}"

--- a/dev-utils/example-dev-conf.json
+++ b/dev-utils/example-dev-conf.json
@@ -24,6 +24,10 @@
         "base_fee": "1.1",
         "per_byte_fee": "1.25"
     },
+    "evidence": {
+        "max_age_duration": "172800000000000",
+        "max_age_num_blocks": "100000"
+    },
     "council_nodes": {
         "0x3ae55c16800dc4bd0e3397a9d7806fb1f11639de": [
             "test",

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -18,6 +18,7 @@ pub struct GenesisDevConfig {
     pub slashing_config: SlashingParameters,
     pub rewards_config: RewardsParameters,
     pub initial_fee_policy: InitialFeePolicy,
+    pub evidence: Evidence,
     pub council_nodes: BTreeMap<
         RedeemAddress,
         (
@@ -53,6 +54,10 @@ impl GenesisDevConfig {
                 base_fee: "1.1".to_string(),
                 per_byte_fee: "1.25".to_string(),
             },
+            evidence: Evidence {
+                max_age_duration: "5400000000000".into(),
+                max_age_num_blocks: "200".into(),
+            },
             council_nodes: BTreeMap::new(),
         }
     }
@@ -62,4 +67,10 @@ impl GenesisDevConfig {
 pub struct InitialFeePolicy {
     pub base_fee: String,
     pub per_byte_fee: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Evidence {
+    pub max_age_duration: String,
+    pub max_age_num_blocks: String,
 }

--- a/docker/config/devnet/dev-conf.json
+++ b/docker/config/devnet/dev-conf.json
@@ -25,6 +25,10 @@
         "base_fee": "0.0",
         "per_byte_fee": "0.0"
     },
+    "evidence": {
+        "max_age_duration": "172800000000000",
+        "max_age_num_blocks": "100000"
+    },
     "council_nodes": {
         "0x45c1851c2f0dc6138935857b9e23b173185fea15": [
             "node0",

--- a/integration-tests/bot/chainbot.py
+++ b/integration-tests/bot/chainbot.py
@@ -199,6 +199,10 @@ def app_state_cfg(cfg):
             "base_fee": "1.1",
             "per_byte_fee": "1.25"
         },
+        "evidence": {
+            "max_age_duration": "172800000000003",
+            "max_age_num_blocks": "100004"
+        },
         "council_nodes": {
             node['staking'][0]: [
                 node['name'],
@@ -343,7 +347,7 @@ async def fix_genesis(genesis, cfg):
             json.dump(cfg, fp_cfg)
             fp_cfg.flush()
             await run(
-                f'dev-utils genesis generate --in_place --no_backup '
+                f'dev-utils genesis generate --in_place --no_backup --no_genesistime_overwrite --no_evidence_overwrite '
                 f'--genesis_dev_config_path "{fp_cfg.name}" '
                 f'--tendermint_genesis_path "{fp_genesis.name}"'
             )


### PR DESCRIPTION
## why , i make this pr
Genesis time is UTC time , and should be later then keypackage time.
also if it's too distant from current utc time, tendermint will not work correctly.

## how i solved 
1. overwrite genesis time with current utc time,
can be disabled by `--no_genesistime_overwrite` option

2. add evidence parameters to dev.json
