### PR TITLE
Problem: one cannot optionally disable light client verification (fix…

### DIFF
--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -1168,7 +1168,7 @@ where
         let sync_state = if let Some(sync_state) = mstate {
             sync_state
         } else {
-            get_genesis_sync_state(&self.tendermint_client)?
+            get_genesis_sync_state(&self.tendermint_client, true)?
         };
         Ok(sync_state)
     }


### PR DESCRIPTION
options is)
--disable-light-client-verifcation

CRYPTO_GENESIS_FINGERPRINT check will be skipped,
default options is the same with now. (enabled)
