### PR TITLE
Problem: no way for mls member to prove invalid ciphertext (fixes #1797)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "elliptic-curve"
+version = "0.4.0"
+source = "git+https://github.com/nickray/elliptic-curves.git?rev=336eb4eb8500c42e3d47deffb1490b8e49afd948#336eb4eb8500c42e3d47deffb1490b8e49afd948"
+dependencies = [
+ "generic-array 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "enclave-macro"
 version = "0.5.0"
 dependencies = [
@@ -1579,6 +1588,15 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2344,6 +2362,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hpke 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "p256 0.3.0 (git+https://github.com/nickray/elliptic-curves.git?rev=336eb4eb8500c42e3d47deffb1490b8e49afd948)",
  "ra-client 0.5.0",
  "ra-enclave 0.5.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2355,6 +2374,7 @@ dependencies = [
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-parser 0.8.0-beta1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2584,6 +2604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elliptic-curve 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "p256"
+version = "0.3.0"
+source = "git+https://github.com/nickray/elliptic-curves.git?rev=336eb4eb8500c42e3d47deffb1490b8e49afd948#336eb4eb8500c42e3d47deffb1490b8e49afd948"
+dependencies = [
+ "elliptic-curve 0.4.0 (git+https://github.com/nickray/elliptic-curves.git?rev=336eb4eb8500c42e3d47deffb1490b8e49afd948)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5152,6 +5181,7 @@ dependencies = [
 "checksum ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum elliptic-curve 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
+"checksum elliptic-curve 0.4.0 (git+https://github.com/nickray/elliptic-curves.git?rev=336eb4eb8500c42e3d47deffb1490b8e49afd948)" = "<none>"
 "checksum enclave-runner 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30403bc2e2fd0d46290ab89c44ca8ed0c4bc3d0f5b2d699231a1c75a7cef2e0d"
 "checksum encoding_rs 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -5186,6 +5216,7 @@ dependencies = [
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcd 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c7cd301bf2ab11ae4e5bdfd79c221d97a25e46c089144a62ee9d09cb32d2b92"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum generic-array 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
@@ -5288,6 +5319,7 @@ dependencies = [
 "checksum owning_ref 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 "checksum p256 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "812a058a5afc96a52a8ab6e250325d025254ff030ff737dc5b62576e4e604c42"
 "checksum p256 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86640e33ca638ec215c74de317696bbca5daa7d52cf55b905bd20a6bd2cfd133"
+"checksum p256 0.3.0 (git+https://github.com/nickray/elliptic-curves.git?rev=336eb4eb8500c42e3d47deffb1490b8e49afd948)" = "<none>"
 "checksum p384 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3aee0d9bdeedaea6cdd47f9281a9f8e1037d3037088b70e2af13c64ce65608ec"
 "checksum parity-scale-codec 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a74f02beb35d47e0706155c9eac554b50c671e0d868fe8296bcdf44a9a4847bf"
 "checksum parity-scale-codec-derive 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"

--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -20,6 +20,8 @@ rand = "0.7"
 chrono="0.4.11"
 ra-client = { path = "../enclave-ra/ra-client" }
 subtle = "2.2.3"
+p256 = { git = "https://github.com/nickray/elliptic-curves.git", rev = "336eb4eb8500c42e3d47deffb1490b8e49afd948", features = ["expose-arithmetic", "zeroize"] }
+zeroize = "1.1"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/chain-tx-enclave-next/mls/src/extras/dleq.rs
+++ b/chain-tx-enclave-next/mls/src/extras/dleq.rs
@@ -1,0 +1,342 @@
+use crate::key::{HPKEPrivateKey, HPKEPublicKey};
+use hpke::kex::{Marshallable, Unmarshallable};
+///! Highly experimental implementation of (honest-verifier) NIZK proof
+///! of discrete logarithm equality.
+///!
+///! ref: https://www.chaum.com/publications/Wallet_Databases.pdf
+///! ref: https://blog.cloudflare.com/privacy-pass-the-math/
+///! ref: https://github.com/privacypass/challenge-bypass-server#nizk-proofs-of-discrete-log-equality
+///!
+///! WARNING: highly experimental
+///!
+///! WARNING: meant to work on prime-order EC ops;
+///! *be careful* if this is to be ported to non-prime-order EC ops (e.g. on curve25519)
+///! ref: https://www.shiftleft.org/papers/decaf/decaf.pdf
+///! (see "1.1 Pitfalls of a cofactor")
+use p256::arithmetic::{AffinePoint, ProjectivePoint, Scalar};
+use sha2::{Digest, Sha256};
+use subtle::{ConstantTimeEq, CtOption};
+use zeroize::Zeroize;
+
+/// Information needed by external parties to verify "NACK" claim
+/// FIXME: use the official solution when/if ready in the spec
+pub struct NackDleqProof {
+    /// the computed "r" value
+    r_response: [u8; 32],
+    /// the intermediate hash
+    c_inter_hash: [u8; 32],
+    /// revealed shared secret; same size as uncompressed pubkey
+    dh: [u8; 65],
+}
+
+impl NackDleqProof {
+    /// ref: https://github.com/mlswg/mls-protocol/issues/21#issuecomment-455392023
+    /// in the case that a receiver couldn't get information from Commit/Welcome message
+    /// ciphertext, they can disclose the shared secret and DLEQ proof
+    /// to show others they couldn't receive the information.
+    ///
+    /// WARNING: `kem_output` is assumed to be checked with e.g. https://tools.ietf.org/html/rfc8235
+    /// (i.e. the sender produced some proof of knowledge of the secret value altogether with the ciphertext
+    /// -- the sender secret is currently "hidden" away in HPKE API), so that it's not "tweaked" for compromises
+    /// FIXME: there's a lot of marshalling/unmarshaling due to the current API
+    /// + intermediate / secret value zeroing may not be happening
+    pub fn get_nack_dleq_proof(receiver: &HPKEPrivateKey, kem_output: &[u8]) -> Result<Self, ()> {
+        let encapped_key =
+            <<hpke::kem::DhP256HkdfSha256 as hpke::Kem>::Kex as hpke::KeyExchange>::PublicKey::unmarshal(kem_output).map_err(|_| ())?;
+
+        // assuming `SetupBaseS` / `SetupBaseR` (used in mls spec draft 10)
+        let shared = <<hpke::kem::DhP256HkdfSha256 as hpke::Kem>::Kex as hpke::KeyExchange>::kex(
+            &receiver.kex_secret(),
+            &encapped_key,
+        )
+        .map_err(|_| ())?;
+
+        // gen_g = encapped_key
+        // pub_h = shared
+        // gen_m = base point
+        // pub_z = receiver pubkey
+
+        // no panic: encapped_key is already parsed/validated by hpke::KeyExchange::PublicKey `unmarshal`
+        let g = p256::PublicKey::from_bytes(&encapped_key.marshal()).unwrap();
+        let gen_g = AffinePoint::from_pubkey(&g).unwrap();
+        // no panic: shared is already validated by hpke::KeyExchange `kex`
+        let h = p256::PublicKey::from_bytes(&shared.marshal()).unwrap();
+        let pub_h = AffinePoint::from_pubkey(&h).unwrap();
+        let gen_m = AffinePoint::generator();
+        // no panic: HPKEPrivateKey produces valid pubkey
+        let z = p256::PublicKey::from_bytes(&receiver.public_key().marshal()).unwrap();
+        let pub_z = AffinePoint::from_pubkey(&z).unwrap();
+        // no panic: HPKEPrivateKey is a valid scalar
+        let mut x = Scalar::from_bytes(receiver.marshal_arr_unsafe()).unwrap();
+        let mproof = Proof::new_p256_sha256(gen_g, pub_h, gen_m, pub_z, &x);
+        x.zeroize();
+        let proof = mproof?;
+        let mut dh = [0u8; 65];
+        dh.copy_from_slice(h.as_bytes());
+        Ok(NackDleqProof {
+            r_response: proof.r_response.to_bytes(),
+            c_inter_hash: proof.c_inter_hash.to_bytes(),
+            dh,
+        })
+    }
+
+    /// to be verifier by other parties:
+    /// 1) receiver public key should be known from the keypackage
+    /// 2) `sender_kem_output` should be known from some part of the MLS handshake message
+    /// TODO: message wrapping the proof will need to contain those information
+    /// (i.e. signature with identity key and receiver leaf index +
+    /// reference to the invalid part of Commit or Welcome that the parties can retrieve
+    /// and verify it's invalid by then using the disclosed `dh` to get HPKE context)
+    /// FIXME: there's a lot of marshalling/unmarshaling due to the current API
+    pub fn verify(&self, receiver: &HPKEPublicKey, sender_kem_output: &[u8]) -> Result<(), ()> {
+        let encapped_key =
+            <<hpke::kem::DhP256HkdfSha256 as hpke::Kem>::Kex as hpke::KeyExchange>::PublicKey::unmarshal(sender_kem_output).map_err(|_| ())?;
+        // no panic: encapped_key is already parsed/validated by hpke::KeyExchange::PublicKey `unmarshal`
+        let g = p256::PublicKey::from_bytes(&encapped_key.marshal()).unwrap();
+        let gen_g = AffinePoint::from_pubkey(&g).unwrap();
+        let h = p256::PublicKey::from_bytes(&self.dh[..]).ok_or(())?;
+        let pub_h = AffinePoint::from_pubkey(&h);
+        // no panic: HPKEPublicKey should be valid
+        let z = p256::PublicKey::from_bytes(&receiver.marshal()).unwrap();
+        let pub_z = AffinePoint::from_pubkey(&z).unwrap();
+
+        let r_response = Scalar::from_bytes(self.r_response);
+        let c_inter_hash = Scalar::from_bytes(self.c_inter_hash);
+        let gen_m = AffinePoint::generator();
+
+        // NOTE: these are subtle::Choice, not booleans
+        let error = pub_h.is_none() | r_response.is_none() | c_inter_hash.is_none();
+
+        if error.into() {
+            Err(())
+        } else {
+            let proof = Proof {
+                gen_g,
+                gen_m,
+                pub_h: pub_h.unwrap(),
+                pub_z,
+                r_response: r_response.unwrap(),
+                c_inter_hash: c_inter_hash.unwrap(),
+            };
+            proof.verify()
+        }
+    }
+}
+
+/// Internal type -- "single letter" naming tries to follow the paper conventions;
+/// for a higher level / end-user API, see [NackDleqProof]
+struct Proof {
+    gen_g: AffinePoint,
+    gen_m: AffinePoint,
+    pub_h: AffinePoint,
+    pub_z: AffinePoint,
+    r_response: Scalar,
+    c_inter_hash: Scalar,
+}
+
+impl Proof {
+    /// given h = g^x, z = m^x
+    /// prove log_g(h) == log_m(z)
+    fn new_p256_sha256(
+        gen_g: AffinePoint,
+        pub_h: AffinePoint,
+        gen_m: AffinePoint,
+        pub_z: AffinePoint,
+        secret_x: &Scalar,
+    ) -> Result<Self, ()> {
+        // points are on the same curve + the point at infinity doesn't have the affine representation
+        // -> not checking the points
+        // TODO: check secret_x or as this is internal API, one assumes it's been validated?
+        let g = ProjectivePoint::from(gen_g);
+        let m = ProjectivePoint::from(gen_m);
+        // random element
+        let (s_rand_nonce, _s_pub) = HPKEPrivateKey::generate();
+        // no panic: HPKEPrivateKey should produce a valid scalar
+        let s_scalar = Scalar::from_bytes(s_rand_nonce.marshal_arr_unsafe()).unwrap();
+        // (a, b) = (g^s, m^s)
+        let ma = (g * &s_scalar).to_affine();
+        let mb = (m * &s_scalar).to_affine();
+        if (ma.is_none() | mb.is_none()).into() {
+            // TODO: is this possible?
+            return Err(());
+        }
+        let a = ma.unwrap();
+        let b = mb.unwrap();
+        // c = H(g, h, m, z, a, b)
+        // note: in the paper, it's H(m, z, a, b)
+        let mut hasher = Sha256::new();
+        hasher.input(b"dleq proof");
+        hasher.input(gen_g.to_uncompressed_pubkey().as_bytes());
+        hasher.input(pub_h.to_uncompressed_pubkey().as_bytes());
+        hasher.input(gen_m.to_uncompressed_pubkey().as_bytes());
+        hasher.input(pub_z.to_uncompressed_pubkey().as_bytes());
+        hasher.input(a.to_uncompressed_pubkey().as_bytes());
+        hasher.input(b.to_uncompressed_pubkey().as_bytes());
+        let c_bytes: [u8; 32] = hasher.result().into();
+
+        let mc_inter_hash = Scalar::from_bytes(c_bytes);
+        if mc_inter_hash.is_none().into() {
+            return Err(());
+        }
+        let c_inter_hash = mc_inter_hash.unwrap();
+        // note: r = s - cx instead of r = s + cx,
+        // so that inversion of c doesn't need to be computed by the verifier
+        //
+        // (all ops should be `mod p` from Scalar)
+        //
+        // r = s - cx
+        let r_response = s_scalar + &(-c_inter_hash * secret_x);
+
+        Ok(Proof {
+            gen_g,
+            gen_m,
+            pub_h,
+            pub_z,
+            r_response,
+            c_inter_hash,
+        })
+    }
+
+    fn verify(&self) -> Result<(), ()> {
+        // assuming complete proof; points on the same curve + affine representations
+        // (not points at infinity)
+        // TODO: check scalars or that should be ok, as A, B operations are checked ?
+
+        // prover: c = H(g, h, m, z, a, b)
+        // verifier: calculate rG and rM; C' = H(g, h, m, z, rG + cH, rM + cZ)
+        // verifier: C ?= C'
+        let g_point = ProjectivePoint::from(self.gen_g);
+        let m_point = ProjectivePoint::from(self.gen_m);
+        let z_point = ProjectivePoint::from(self.pub_z);
+        let h_point = ProjectivePoint::from(self.pub_h);
+
+        // a = (g^r)(h^c)
+        // A = rG + cH
+        let c_h = h_point * &self.c_inter_hash;
+        let r_g = g_point * &self.r_response;
+        let a_p = &r_g + &c_h;
+
+        // b = (m^r)(z^c)
+        // B = rM + cZ
+        let c_z = z_point * &self.c_inter_hash;
+        let r_m = m_point * &self.r_response;
+        let b_p = &r_m + &c_z;
+
+        let ma = a_p.to_affine();
+        let mb = b_p.to_affine();
+        if (ma.is_none() | mb.is_none()).into() {
+            // TODO: is this possible?
+            return Err(());
+        }
+        let a = ma.unwrap();
+        let b = mb.unwrap();
+
+        // c' = H(g, h, m, z, a, b) ?= c
+        let mut hasher = Sha256::new();
+        hasher.input(b"dleq proof");
+        hasher.input(self.gen_g.to_uncompressed_pubkey().as_bytes());
+        hasher.input(self.pub_h.to_uncompressed_pubkey().as_bytes());
+        hasher.input(self.gen_m.to_uncompressed_pubkey().as_bytes());
+        hasher.input(self.pub_z.to_uncompressed_pubkey().as_bytes());
+        hasher.input(a.to_uncompressed_pubkey().as_bytes());
+        hasher.input(b.to_uncompressed_pubkey().as_bytes());
+        let c_bytes: [u8; 32] = hasher.result().into();
+
+        let c_inter_hash_prime = Scalar::from_bytes(c_bytes);
+        let c_inter_hash = CtOption::new(self.c_inter_hash, 1u8.into());
+        if c_inter_hash.ct_eq(&c_inter_hash_prime).into() {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn setup() -> (Scalar, AffinePoint, AffinePoint) {
+        let (x, _) = HPKEPrivateKey::generate();
+        let x_scalar = Scalar::from_bytes(x.marshal_arr_unsafe()).unwrap();
+        let (_, g_pub) = HPKEPrivateKey::generate();
+        let (_, m_pub) = HPKEPrivateKey::generate();
+
+        let g = p256::PublicKey::from_bytes(&g_pub.marshal()).unwrap();
+        let gen_g = AffinePoint::from_pubkey(&g).unwrap();
+
+        let m = p256::PublicKey::from_bytes(&m_pub.marshal()).unwrap();
+        let gen_m = AffinePoint::from_pubkey(&m).unwrap();
+
+        (x_scalar, gen_g, gen_m)
+    }
+
+    #[test]
+    fn test_external_proof() {
+        let (receive_secret, receiver_pk) = HPKEPrivateKey::generate();
+        let mut csprng = rand::thread_rng();
+
+        let (kem_output, _) = hpke::setup_sender::<
+            hpke::aead::AesGcm128,
+            hpke::kdf::HkdfSha256,
+            hpke::kem::DhP256HkdfSha256,
+            _,
+        >(
+            &hpke::OpModeS::Base,
+            receiver_pk.kex_pubkey(),
+            b"",
+            &mut csprng,
+        )
+        .expect("setup sender");
+
+        // assume sender e.g. put invalid content in ciphertext of EncryptedGroupSecrets
+        // the receiver can then reveal the shared secret + dleq proof
+        let kem_in_mls_payload = kem_output.marshal();
+        let proof_for_nack =
+            NackDleqProof::get_nack_dleq_proof(&receive_secret, &kem_in_mls_payload)
+                .expect("valid proof");
+
+        // others can then verify the proof
+        assert!(proof_for_nack
+            .verify(&receiver_pk, &kem_in_mls_payload)
+            .is_ok());
+        // and then use the disclosed shared secret to decrypt the ciphertext
+        // and verify it's invalid
+    }
+
+    #[test]
+    fn test_proof_valid() {
+        let (x, gen_g, gen_m) = setup();
+        let pub_h = ProjectivePoint::from(gen_g.clone()) * &x;
+        let pub_z = ProjectivePoint::from(gen_m.clone()) * &x;
+        let proof = Proof::new_p256_sha256(
+            gen_g,
+            pub_h.to_affine().unwrap(),
+            gen_m,
+            pub_z.to_affine().unwrap(),
+            &x,
+        )
+        .expect("dleq proof");
+        assert!(proof.verify().is_ok())
+    }
+
+    #[test]
+    fn test_proof_invalid() {
+        let (x, gen_g, gen_m) = setup();
+        let (n, _) = HPKEPrivateKey::generate();
+        let n_scalar = Scalar::from_bytes(n.marshal_arr_unsafe()).unwrap();
+
+        let pub_h = ProjectivePoint::from(gen_g.clone()) * &x;
+        // z = nM instead
+        let pub_z = ProjectivePoint::from(gen_m.clone()) * &n_scalar;
+        let proof = Proof::new_p256_sha256(
+            gen_g,
+            pub_h.to_affine().unwrap(),
+            gen_m,
+            pub_z.to_affine().unwrap(),
+            &x,
+        )
+        .expect("dleq proof");
+        assert!(proof.verify().is_err())
+    }
+}

--- a/chain-tx-enclave-next/mls/src/extras/mod.rs
+++ b/chain-tx-enclave-next/mls/src/extras/mod.rs
@@ -1,0 +1,30 @@
+///! This module contains additional parts that are a part of the MLS draft spec,
+///! but are required for resolving relevant open issues in the draft spec.
+///!
+///! At the moment, one issue is that the node generating Commit/Welcome
+///! may put "bogus" in the ciphertext, which will block nodes (newly joining or on the affected
+///! path) from obtaining the new group state.
+///! The sketched out / unverified solution to that is that the affected member may
+///! reveal the shared secret, so that other members can verify that the affected member
+///! received a bad update.
+///!
+///! NOTE: https://mailarchive.ietf.org/arch/msg/mls/DCEKbsnoRKmFTmCuMT-rHIfDapA/
+///! one discussed issue is that the attacker may choose the ephemeral pubkey,
+///! such that some previous secret value is revealed to him through this "NACK" mechanism.
+///! The suggestion is to use Schnorr NIZK proof of the ephemeral pubkey for every ciphertext,
+///! but:
+///! 1) this is clumsy, as the HPKE setup API doesn't expose the ephemeral secrets.
+///! 2) in our case / threat model, it does not seem to matter:
+///! - if the attacker can do something like this, it means the attacker managed to breach TEE
+///! (unless it's through a bug in the Rust code itself)
+///! - if the attacker breached TEE, the "expected" worst case is
+///!   "breaking confidentiality" temporarily, i.e. they can read old ledger records
+///! -> they don't need to produce tweaked MLS handshakes messages for that,
+///!    they could instead "unseal" old TEE-sealed data.
+///!
+///! the "unexpected" worst case would be breaking ledger integrity (such as through DoS
+///! on certain honest nodes / MLS members) which should be prevented
+///! by handshake NACK mechanism + BFT consensus.
+mod dleq;
+
+pub use dleq::NackDleqProof;

--- a/chain-tx-enclave-next/mls/src/key.rs
+++ b/chain-tx-enclave-next/mls/src/key.rs
@@ -127,6 +127,10 @@ impl HPKEPrivateKey {
         )
     }
 
+    pub fn marshal_arr_unsafe(&self) -> [u8; 32] {
+        <hpke::kex::DhP256 as hpke::KeyExchange>::PrivateKey::marshal(&self.0).into()
+    }
+
     pub fn public_key(&self) -> HPKEPublicKey {
         HPKEPublicKey(<hpke::kex::DhP256 as hpke::KeyExchange>::sk_to_pk(&self.0))
     }

--- a/chain-tx-enclave-next/mls/src/lib.rs
+++ b/chain-tx-enclave-next/mls/src/lib.rs
@@ -3,6 +3,7 @@ pub mod astree;
 pub mod ciphersuite;
 pub mod credential;
 pub mod extensions;
+pub mod extras;
 pub mod group;
 pub mod key;
 pub mod keypackage;


### PR DESCRIPTION
Solution: sketched out core of "NACK" mechanism
which involves revealing shared secrets from invalid
message parts and including DLEQ proofs.

