### PR TITLE
Problem: staking not found error does not provide enough detail (fix #1823)

### DIFF
--- a/client-network/src/network_ops.rs
+++ b/client-network/src/network_ops.rs
@@ -93,7 +93,9 @@ pub trait NetworkOpsClient: Send + Sync {
         verify: bool,
     ) -> Result<StakedState> {
         self.get_staking(name, address, verify)?
-            .err_kind(ErrorKind::InvalidInput, || "staking not found")
+            .err_kind(ErrorKind::InvalidInput, || {
+                "staking address not found, sync to the latest and check staking address is correct"
+            })
     }
 
     /// Returns staked stake corresponding to given address

--- a/cro-clib/src/transaction.rs
+++ b/cro-clib/src/transaction.rs
@@ -120,7 +120,9 @@ fn create_encoded_signed_withdraw(
             ),
         )
     })?;
-    let staked_state = mstaking.err_kind(ErrorKind::InvalidInput, || "staking not found")?;
+    let staked_state = mstaking.err_kind(ErrorKind::InvalidInput, || {
+        "staking address not found, sync to the latest and check staking address is correct"
+    })?;
     let access_policies = viewkeys
         .iter()
         .map(|s| {
@@ -233,7 +235,9 @@ fn query_staked_state(from_address: &CroAddress, tendermint_url: &str) -> Result
             ),
         )
     })?;
-    mstaking.err_kind(ErrorKind::InvalidInput, || "staking not found")
+    mstaking.err_kind(ErrorKind::InvalidInput, || {
+        "staking address not found, sync to the latest and check staking address is correct"
+    })
 }
 
 /// staked -> utxo


### PR DESCRIPTION
because, to fetch synced state, `sync` is required,
so added more comment in error message

