### PR TITLE
Problem: kvdb 0.7 (and related crates) fail to compile (fixes #1821)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,8 +490,8 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mls 0.5.0",
  "mock-utils 0.5.0",
@@ -551,9 +551,9 @@ dependencies = [
  "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jellyfish-merkle 0.1.0 (git+https://github.com/crypto-com/jellyfish-merkle-tree.git?rev=42c0fb190b4034c7939f8876d3f539bd2ff74cd9)",
- "kvdb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-rocksdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-rocksdb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1138,7 +1138,7 @@ dependencies = [
  "client-network 0.5.3",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mls 0.5.0",
  "parity-scale-codec 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quest 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2091,34 +2091,34 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "parity-util-mem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kvdb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4160,7 +4160,7 @@ dependencies = [
  "client-common 0.5.0",
  "client-core 0.5.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5291,9 +5291,9 @@ dependencies = [
 "checksum k256 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0afa79ea8238df7a342756fbf971d4e3ba16f389eaaf730658f3e3f58cf47da4"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvdb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e763b2a9b500ba47948061d1e8bc3b5f03a8a1f067dbcf822a4d2c84d2b54a3a"
-"checksum kvdb-memorydb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73027d5e228de6f503b5b7335d530404fc26230a6ae3e09b33ec6e45408509a4"
-"checksum kvdb-rocksdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84384eca250c7ff67877eda5336f28a86586aaee24acb945643590671f6bfce1"
+"checksum kvdb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
+"checksum kvdb-memorydb 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73de822b260a3bdfb889dbbb65bb2d473eee2253973d6fa4a5d149a2a4a7c66e"
+"checksum kvdb-rocksdb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c341ef15cfb1f923fa3b5138bfbd2d4813a2c1640b473727a53351c7f0b0fa2"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum lexical-core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
@@ -5350,7 +5350,7 @@ dependencies = [
 "checksum p384 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3aee0d9bdeedaea6cdd47f9281a9f8e1037d3037088b70e2af13c64ce65608ec"
 "checksum parity-scale-codec 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a74f02beb35d47e0706155c9eac554b50c671e0d868fe8296bcdf44a9a4847bf"
 "checksum parity-scale-codec-derive 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
-"checksum parity-util-mem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
+"checksum parity-util-mem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 "checksum parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 "checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -55,8 +55,8 @@ quickcheck = "0.9"
 digest = "0.8"
 sha3 = "0.9"
 base64 = "0.11"
-kvdb = "0.6"
-kvdb-memorydb = "0.6"
+kvdb = "0.7"
+kvdb-memorydb = "0.7"
 test-common = { path = "../test-common" }
 
 # TODO: currently not maintained benchmarks

--- a/chain-abci/fuzz/Cargo.toml
+++ b/chain-abci/fuzz/Cargo.toml
@@ -12,8 +12,8 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.3"
 parity-scale-codec = { version = "1.1" }
-kvdb = "0.6"
-kvdb-memorydb = "0.6"
+kvdb = "0.7"
+kvdb-memorydb = "0.7"
 chain-storage = { path = "../../chain-storage" }
 chain-core = { path = "../../chain-core" }
 test-common = { path = "../../test-common" }

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 blake3 = "0.3.4"
-kvdb = "0.6"
-kvdb-rocksdb = "0.8"
-kvdb-memorydb = "0.6"
+kvdb = "0.7"
+kvdb-rocksdb = "0.9"
+kvdb-memorydb = "0.7"
 chain-core = { path = "../chain-core" }
 bit-vec = { version = "0.6.2", features = ["serde_no_std"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }

--- a/cro-clib/chain.h
+++ b/cro-clib/chain.h
@@ -19,6 +19,7 @@ typedef struct CroJsonRpc CroJsonRpc;
 
 typedef struct CroTx CroTx;
 
+typedef struct Option_ProgressCallback Option_ProgressCallback;
 
 typedef struct CroResult {
   int result;
@@ -51,7 +52,6 @@ typedef struct CroStakedState {
  * return: 1: continue, 0: stop
  */
 typedef int32_t (*ProgressCallback)(uint64_t, uint64_t, uint64_t, const void*);
-typedef ProgressCallback Option_ProgressCallback;
 
 /**
  * create staking address

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-kvdb-memorydb = "0.6"
+kvdb-memorydb = "0.7"
 dirs = "2.0.1"
 quest = "0.3"
 secstr = "0.4.0"

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -15,7 +15,7 @@ secstr = { version = "0.4.0", features = ["serde"] }
 lazy_static  = { version = "1.4", features = ["spin_no_std"] }
 signature = "1.0.0-pre.1"
 abci = "0.7"
-kvdb-memorydb = "0.6"
+kvdb-memorydb = "0.7"
 protobuf = "2.7.0"
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }


### PR DESCRIPTION
Solution: bumped all related crates together
