### PR TITLE
Problem (Fix #1835): non-determinism in reward distribution

### DIFF
--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -148,6 +148,10 @@ impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
             .last_state
             .as_mut()
             .expect("executing begin block, but no app state stored (i.e. no initchain or recovery was executed)");
+        assert_eq!(
+            block_height,
+            last_state.block_height.checked_add(1).unwrap()
+        );
         last_state.block_time = block_time;
         last_state.block_height = block_height;
 

--- a/chain-abci/tests/punishment.rs
+++ b/chain-abci/tests/punishment.rs
@@ -109,7 +109,7 @@ fn begin_block_should_punish_non_live_validators() {
     // Begin Block
     app.begin_block(&RequestBeginBlock {
         last_commit_info: Some(env.last_commit_info(0, false)).into(),
-        ..env.req_begin_block(2, 0)
+        ..env.req_begin_block(1, 0)
     });
 
     let val = get_account(&env.accounts[0].staking_address(), &app)
@@ -169,7 +169,7 @@ fn begin_block_should_slash_non_live_validators() {
     // Begin Block
     app.begin_block(&RequestBeginBlock {
         last_commit_info: Some(env.last_commit_info(0, false)).into(),
-        ..env.req_begin_block(2, 0)
+        ..env.req_begin_block(1, 0)
     });
 
     let account = get_account(&env.accounts[0].staking_address(), &app);


### PR DESCRIPTION
Solution:
- Add block height assertion in begin block to prevent consensus
  connection re-connect