### PR TITLE
Problem: outdated c-binding example (wip #1845)

### DIFF
--- a/cro-clib/chain.h
+++ b/cro-clib/chain.h
@@ -19,8 +19,6 @@ typedef struct CroJsonRpc CroJsonRpc;
 
 typedef struct CroTx CroTx;
 
-typedef struct Option_ProgressCallback Option_ProgressCallback;
-
 typedef struct CroResult {
   int result;
 } CroResult;
@@ -32,6 +30,18 @@ typedef CroFee *CroFeePtr;
 typedef CroHDWallet *CroHDWalletPtr;
 
 typedef CroJsonRpc *CroJsonRpcPtr;
+
+/**
+ * current, start, end, userdata
+ * return: 1: continue, 0: stop
+ */
+typedef int32_t (*ProgressCallback)(uint64_t, uint64_t, uint64_t, const void*);
+
+typedef struct ProgressWrapper {
+  ProgressCallback core_progress_callback;
+} ProgressWrapper;
+
+typedef ProgressWrapper *CroProgressPtr;
 
 typedef CroTx *CroTxPtr;
 
@@ -46,12 +56,6 @@ typedef struct CroStakedState {
   uint64_t unbonded;
   uint64_t unbonded_from;
 } CroStakedState;
-
-/**
- * current, start, end, userdata
- * return: 1: continue, 0: stop
- */
-typedef int32_t (*ProgressCallback)(uint64_t, uint64_t, uint64_t, const void*);
 
 /**
  * create staking address
@@ -142,7 +146,7 @@ CroResult cro_create_jsonrpc(CroJsonRpcPtr *rpc_out,
                              const char *storage_dir_user,
                              const char *websocket_url_user,
                              uint8_t network_id,
-                             Option_ProgressCallback progress_callback);
+                             CroProgressPtr progress_callback);
 
 /**
  * mock mode, only use for testing
@@ -155,7 +159,7 @@ CroResult cro_create_mock_jsonrpc(CroJsonRpcPtr *rpc_out,
                                   const char *storage_dir_user,
                                   const char *websocket_url_user,
                                   uint8_t network_id,
-                                  Option_ProgressCallback progress_callback);
+                                  CroProgressPtr progress_callback);
 
 /**
  * create staking address from bip44 hdwallet
@@ -353,10 +357,10 @@ CroResult cro_jsonrpc_call(const char *storage_dir,
                            const char *request,
                            char *buf,
                            uintptr_t buf_size,
-                           Option_ProgressCallback progress_callback,
+                           CroProgressPtr progress_callback,
                            const void *user_data);
 
-void cro_jsonrpc_call_dummy(ProgressCallback _progress_callback);
+void cro_jsonrpc_call_dummy(ProgressCallback _progress_callback, ProgressWrapper _wrapper);
 
 /**
  * mock mode, only use for testing
@@ -371,7 +375,7 @@ CroResult cro_jsonrpc_call_mock(const char *storage_dir,
                                 const char *request,
                                 char *buf,
                                 uintptr_t buf_size,
-                                Option_ProgressCallback progress_callback,
+                                CroProgressPtr progress_callback,
                                 const void *user_data);
 
 /**

--- a/cro-clib/examples/Makefile
+++ b/cro-clib/examples/Makefile
@@ -1,5 +1,7 @@
 all: build run
 build:
+# for rocksdb link errors
+	export AR=/usr/bin/ar
 	cargo build
 	gcc -g test.c tx.c rpc.c -o cro -lcro_clib -lssl -lm -lcrypto -ldl -lpthread -L../../target/debug/ -lrocksdb -lstdc++
 run:

--- a/cro-clib/examples/rpc.c
+++ b/cro-clib/examples/rpc.c
@@ -9,7 +9,7 @@
 #include "../chain.h"
 
 //ret 1: continue, 0: stop
-int32_t progress(uint64_t current, uint64_t start, uint64_t end, const void*  user_data)
+int32_t do_progress(uint64_t current, uint64_t start, uint64_t end, const void*  user_data)
 {
     double gap= 0;
     double rate=0;
@@ -21,6 +21,8 @@ int32_t progress(uint64_t current, uint64_t start, uint64_t end, const void*  us
     printf("%8.2lf  progress current=%lu  start= %lu ~ end=%lu   user= %s\n",rate, current,start, end, user);
     return 1;
 }
+
+struct ProgressWrapper progress={&do_progress};
 
 void show_wallets()
 {
@@ -63,7 +65,7 @@ void context_sync()
     char* passphrase=getenv("CRO_PASSPHRASE");
     char* enckey=getenv("CRO_ENCKEY");
     char* mnemonics= getenv("CRO_MNEMONICS");
-    const char* req_template = "{\"jsonrpc\": \"2.0\", \"method\": \"sync\", \"params\": [{\"name\":\"%s\", \"passphrase\":\"%s\",\"enckey\":\"%s\"}], \"id\": 1}";
+    const char* req_template = "{\"jsonrpc\": \"2.0\", \"method\": \"sync\", \"params\": [{\"name\":\"%s\", \"passphrase\":\"%s\",\"enckey\":\"%s\"},{\"blocking\":true, \"reset\":false, \"do_loop\":false}], \"id\": 1}";
     char req[BUFSIZE];
     sprintf(req, req_template, name, passphrase, enckey);
 
@@ -74,7 +76,7 @@ void context_sync()
     sprintf(tmp ,wallet_restore_req, name, passphrase, mnemonics);    
     printf("sync with context\n");
     CroJsonRpcPtr rpc= NULL;
-    cro_create_jsonrpc(&rpc, ".storage", "ws://localhost:26657/websocket", 0xab, &progress);
+    cro_create_jsonrpc(&rpc, ".storage", "ws://localhost:26657/websocket", 0xab, &progress); // set NULL if there is no progress callback
     cro_run_jsonrpc(rpc, wallet_req, buf, sizeof(buf), user);        
     printf("response: %s\n", buf);    
     cro_run_jsonrpc(rpc, tmp, buf, sizeof(buf), user);    

--- a/cro-clib/src/types.rs
+++ b/cro-clib/src/types.rs
@@ -8,12 +8,22 @@ use client_rpc_core::{rpc::sync_rpc::CBindingCore, RpcHandler};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
+/// current, start, end, userdata
+/// return: 1: continue, 0: stop
+pub type ProgressCallback = extern "C" fn(u64, u64, u64, *const std::ffi::c_void) -> i32;
+
+#[derive(Clone)]
+#[repr(C)]
+pub struct ProgressWrapper {
+    pub core_progress_callback: ProgressCallback,
+}
 
 pub type CroHDWalletPtr = *mut CroHDWallet;
 pub type CroAddressPtr = *mut CroAddress;
 pub type CroTxPtr = *mut CroTx;
 pub type CroDepositTxPtr = *mut CroDepositTx;
 pub type CroFeePtr = *mut CroFee;
+pub type CroProgressPtr = *mut ProgressWrapper;
 
 pub const SUCCESS: i32 = 0;
 pub const FAIL: i32 = -1;
@@ -98,10 +108,6 @@ impl Default for CroFee {
         CroFee { fee }
     }
 }
-
-/// current, start, end, userdata
-/// return: 1: continue, 0: stop
-pub type ProgressCallback = extern "C" fn(u64, u64, u64, *const std::ffi::c_void) -> i32;
 
 #[derive(Clone)]
 pub struct CroJsonRpc {


### PR DESCRIPTION
Solution: update sync json-rpc protocol  and added automatic `chain.h` modification for gcc
