### PR TITLE
Problem (Fix #1870): multi-node integration tests occasionally randomly fail

### DIFF
--- a/integration-tests/bot/chainrpc.py
+++ b/integration-tests/bot/chainrpc.py
@@ -274,9 +274,8 @@ class Staking:
             return ''
         else:
             temp = tempfile.NamedTemporaryFile()
-            subprocess.run(["dev-utils", "keypackage", "generate","--path", path, "--output", temp.name])
-            value= temp.read().decode('utf-8')
-            return value 
+            subprocess.run(["dev-utils", "keypackage", "generate", "--path", path, "--output", temp.name], check=True)
+            return temp.read().decode('utf-8')
 
 
 class MultiSig:

--- a/integration-tests/multinode/reward_test.py
+++ b/integration-tests/multinode/reward_test.py
@@ -54,7 +54,7 @@ block_time = latest_block_time(rpc)
 
 if last_bonded == bonded_rewarded:
     # wait for it to get jailed and slashed later
-    wait_for_blocks(rpc, 5)
+    wait_for_blocks(rpc, 6)
 
     # jailed and slashed
     slashed = int(last_bonded * 0.2)


### PR DESCRIPTION
Solution:
- increase blocks waited in reward test
- wait for ra-sp-server to startup before running multinode tests