### PR TITLE
Problem: fuzzer not being uploaded (fixes #1879)

### DIFF
--- a/ci-scripts/fuzzit.sh
+++ b/ci-scripts/fuzzit.sh
@@ -6,4 +6,4 @@ cargo install cargo-fuzz
 cargo fuzz run abci-cycle -- -runs=0
 wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.77/fuzzit_Linux_x86_64
 chmod a+x fuzzit
-./fuzzit create job --type fuzzing abci-cycle ./fuzz/target/x86_64-unknown-linux-gnu/debug/abci-cycle
+./fuzzit create job --type fuzzing abci-cycle ./fuzz/target/x86_64-unknown-linux-gnu/release/abci-cycle


### PR DESCRIPTION
Solution: updated the path to the fuzzer binary
(as cargo fuzz now runs/builds in the release mode?)