### PR TITLE
Problem: Failed to deserialize fields advisoryURL and advisoryIDs in AttestationReportBody (ra-common) (fixes #1884)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,7 @@ version = "0.6.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/chain-tx-enclave-next/enclave-ra/ra-common/Cargo.toml
+++ b/chain-tx-enclave-next/enclave-ra/ra-common/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2018"
 base64 = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/chain-tx-enclave-next/enclave-ra/ra-common/src/report.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-common/src/report.rs
@@ -62,7 +62,9 @@ pub struct AttestationReportBody {
     pub platform_info_blob: Option<String>,
     pub nonce: Option<String>,
     pub epid_pseudonym: Option<String>,
+    #[serde(rename = "advisoryURL")]
     pub advisory_url: Option<String>,
+    #[serde(rename = "advisoryIDs")]
     pub advisory_ids: Option<Vec<String>>,
 }
 
@@ -91,4 +93,58 @@ pub struct AttestationReport {
     pub signature: Vec<u8>,
     /// Report signing certificate
     pub signing_cert: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_attestation_report_body_deserialization() {
+        let response_body = "{\
+\"id\":\"66484602060454922488320076477903784063\",\
+\"timestamp\":\"2020-03-20T10:07:26.711023\",\
+\"version\":4,\
+\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\
+\"isvEnclaveQuoteBody\":\"AAEAAAEAAA+yth5<…encoded_quote_body…>7h38CMfOng\",\
+\"platformInfoBlob\":\"150100650<…pib_structure…>7B094250DB00C610\",\
+\"advisoryURL\":\"https://security-center.intel.com\",\
+\"advisoryIDs\":[\"INTEL-SA-00076\",\"INTEL-SA-00135\"]\
+}";
+        let attestation_report_body: AttestationReportBody =
+            serde_json::from_str(response_body).unwrap();
+        assert_eq!(
+            "66484602060454922488320076477903784063",
+            attestation_report_body.id
+        );
+        assert_eq!(
+            "2020-03-20T10:07:26.711023",
+            attestation_report_body.timestamp
+        );
+        assert_eq!(4, attestation_report_body.version);
+        assert_eq!(
+            "GROUP_OUT_OF_DATE",
+            attestation_report_body.isv_enclave_quote_status
+        );
+        assert_eq!(
+            "AAEAAAEAAA+yth5<…encoded_quote_body…>7h38CMfOng",
+            attestation_report_body.isv_enclave_quote_body
+        );
+        assert_eq!(
+            Some(String::from("150100650<…pib_structure…>7B094250DB00C610")),
+            attestation_report_body.platform_info_blob
+        );
+        assert_eq!(
+            Some(String::from("https://security-center.intel.com")),
+            attestation_report_body.advisory_url
+        );
+        assert_eq!(
+            Some(vec![
+                String::from("INTEL-SA-00076"),
+                String::from("INTEL-SA-00135")
+            ]),
+            attestation_report_body.advisory_ids
+        );
+    }
 }


### PR DESCRIPTION
Fixing #1884 

Solution:
1. Adding field attributes to specify the field names in serialized form.

I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/).

# PR Checklist:

- [x] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/chain/blob/master/CONTRIBUTING.md)?
- [x] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [x] Have you rebased your work on top of the latest master? 
- [x] Have you checked your code compiles? (`cargo build`)
- [x] Have you included tests for any non-trivial functionality?
- [x] Have you checked your code passes the unit tests? (`cargo test`)
- [x] Have you checked your code formatting is correct? (`cargo fmt -- --check --color=auto`)
- [x] Have you checked your basic code style is fine? (`cargo clippy`)
- [x] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`cargo audit`)
- [x] If your changes affect the client infrastructure, have you run the [integration test](https://github.com/crypto-com/chain/tree/master/integration-tests)?
- [x] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [x] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/chain/blob/master/CHANGELOG.md)?
- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/chain/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/chain/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).


