### PR TITLE
Problem: EnclaveCertVerifier aborts TLS connection (fixes #1904)

### DIFF
--- a/chain-tx-enclave-next/enclave-ra/ra-client/src/verifier.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-client/src/verifier.rs
@@ -267,8 +267,12 @@ impl ServerCertVerifier for EnclaveCertVerifier {
 }
 
 impl ClientCertVerifier for EnclaveCertVerifier {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
     fn client_auth_root_subjects(&self, _sni: Option<&DNSName>) -> Option<DistinguishedNames> {
-        None
+        Some(DistinguishedNames::new())
     }
 
     fn verify_client_cert(


### PR DESCRIPTION
Solution:
1. As rustls aborts the connection when ClientCertVerifier returns none for server trusted CA, an empty CA list is now returned. It doesn't matter for the verification as for remote attestation, the client certificate is always a self-signed certfiicate

I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/).
