### PR TITLE
Problem (Fix #1919): client don't print inner error details

### DIFF
--- a/client-common/src/error.rs
+++ b/client-common/src/error.rs
@@ -70,7 +70,7 @@ impl fmt::Debug for Error {
 
         if let Some(ref origin) = self.origin {
             writeln!(f)?;
-            write!(f, " => {}", origin)?;
+            write!(f, " => {:?}", origin)?;
         }
 
         Ok(())


### PR DESCRIPTION
Solution:
- print origin error as `{:?}`