### PR TITLE
Problem: tx-validation not yet ported to EDP (fixes #1867)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,6 +4558,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tx-validation-next"
+version = "0.6.0"
+dependencies = [
+ "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm-siv 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chain-core 0.6.0",
+ "chain-tx-filter 0.6.0",
+ "chain-tx-validation 0.6.0",
+ "enclave-macro 0.6.0",
+ "enclave-protocol 0.6.0",
+ "enclave-utils 0.6.0",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1zkp 0.13.0 (git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=f8759809f6e3fed793b37166f7cd91c57cdb2eab)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "chain-tx-enclave/tx-validation/enclave",
     "chain-tx-enclave-next/tx-query-next/app-runner",
     "chain-tx-enclave-next/tx-query-next/enclave-app",
+    "chain-tx-enclave-next/tx-validation-next",
     "chain-tx-enclave/mock-utils",
     "chain-tx-enclave-next/mls",
     "cro-clib",

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -26,7 +26,8 @@ use aead::Payload;
 use data::input::{TxoPointer, TxoSize};
 use data::output::TxOut;
 
-const TX_AUX_SIZE: usize = 1024 * 60; // 60 KB
+/// Maximum (Tendermint-outer payload) transaction size
+pub const TX_AUX_SIZE: usize = 1024 * 60; // 60 KB
 
 /// wrapper around transactions with outputs
 #[derive(Encode, Decode, Clone)]

--- a/chain-tx-enclave-next/tx-validation-next/Cargo.toml
+++ b/chain-tx-enclave-next/tx-validation-next/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "tx-validation-next"
+version = "0.6.0"
+authors = ["Crypto.com <chain@crypto.com>"]
+description = "The transaction validation enclave."
+readme = "../../README.md"
+edition = "2018"
+
+[target.'cfg(target_env = "sgx")'.dependencies]
+enclave-macro = { path = "../../chain-tx-enclave/enclave-macro" }
+chain-tx-validation   = {  path = "../../chain-tx-validation" }
+chain-core   = {  path = "../../chain-core" }
+secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism", "edp"] }
+parity-scale-codec = { version = "1.3" }
+enclave-protocol   = { path = "../../enclave-protocol" }
+chain-tx-filter   = { path = "../../chain-tx-filter" }
+aes-gcm-siv = "0.4"
+aead = "0.2"
+zeroize = { version = "1.1" }
+env_logger = { version = "0.7", default-features = false }
+log = "0.4"
+rs-libc = "0.2"
+rand = "0.7"
+enclave-utils = { path = "../../chain-tx-enclave-next/enclave-utils", features = ["sgxstd"] }
+
+[package.metadata.fortanix-sgx]
+# stack size (in bytes) for each thread, the default stack size is 0x20000.
+stack-size=0x40000
+# heap size (in bytes), the default heap size is 0x2000000.
+heap-size=0x20000000
+# the default number of threads is equal to the number of available CPUs of
+# the current system.
+# Gotcha: Don't forget to count the main thread when counting number of
+# threads.
+threads=2
+# SSA frame size (in pages) for each thread, the default SSA frame size is 1.
+# You normally don't need to change the SSA frame size.
+ssaframesize=1
+# whether to enable EDP debugging features in the enclave, debugging is
+# enabled by default.
+debug=true

--- a/chain-tx-enclave-next/tx-validation-next/src/main.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/main.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(target_env = "sgx", feature(proc_macro_hygiene))]
+
+#[cfg(target_env = "sgx")]
+mod sgx_module;
+
+#[cfg(target_env = "sgx")]
+fn main() -> std::io::Result<()> {
+    sgx_module::entry()
+}
+
+#[cfg(not(target_env = "sgx"))]
+fn main() {
+    println!("`tx-validation-next` cannot be compiled for non-sgx environment!");
+}

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
@@ -1,0 +1,436 @@
+// TODO: remove, as it's not required on newer nightly
+mod obfuscate;
+mod validate;
+
+#[allow(unused_imports)]
+use rs_libc::alloc::*;
+
+use chain_core::tx::TX_AUX_SIZE;
+use chain_tx_filter::BlockFilter;
+use chain_tx_validation::Error;
+use enclave_macro::get_network_id;
+use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponse, IntraEnclaveResponseOk};
+use parity_scale_codec::{Decode, Encode};
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+
+/// FIXME: genesis app hash etc.?
+pub const NETWORK_HEX_ID: u8 = get_network_id!();
+
+pub(crate) fn write_response<I: Write>(response: IntraEnclaveResponse, output: &mut I) {
+    if let Err(e) = output.write_all(&response.encode()) {
+        log::error!("writing response failed: {:?}", e);
+    }
+}
+
+/// `process_signal` is used in unit tests
+/// where the bool is used to stop the thread
+/// and sender is used for signalling that response was written
+fn handling_loop<I: Read + Write>(
+    mut chain_abci: I,
+    process_signal: Option<(Arc<AtomicBool>, Sender<()>)>,
+) {
+    let mut filter = BlockFilter::default();
+    let mut request_buf = vec![0u8; 2 * TX_AUX_SIZE];
+
+    loop {
+        if let Some((ref b, _)) = process_signal {
+            if b.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+        log::debug!("waiting for chain-abci request");
+        match chain_abci.read(&mut request_buf) {
+            Ok(n) if n > 0 => match IntraEnclaveRequest::decode(&mut &request_buf.as_slice()[0..n])
+            {
+                Ok(IntraEnclaveRequest::ValidateTx { request, tx_inputs }) => {
+                    log::debug!("validate tx request");
+                    validate::handle_validate_tx(request, tx_inputs, &mut filter, &mut chain_abci);
+                    if let Some((_, ref s)) = process_signal {
+                        let _ = s.send(());
+                    }
+                }
+                Ok(IntraEnclaveRequest::EndBlock) => {
+                    log::debug!("end block request");
+
+                    let maybe_filter = if filter.is_modified() {
+                        Some(Box::new(filter.get_raw()))
+                    } else {
+                        None
+                    };
+                    filter.reset();
+                    let response: IntraEnclaveResponse =
+                        Ok(IntraEnclaveResponseOk::EndBlock(maybe_filter));
+                    write_response(response, &mut chain_abci);
+                    if let Some((_, ref s)) = process_signal {
+                        let _ = s.send(());
+                    }
+                }
+                Ok(IntraEnclaveRequest::Encrypt(request)) => {
+                    obfuscate::handle_encrypt_request(request, &mut chain_abci);
+                    if let Some((_, ref s)) = process_signal {
+                        let _ = s.send(());
+                    }
+                }
+                Err(e) => {
+                    log::error!("check tx failed: {:?}", e);
+                    write_response(Err(Error::EnclaveRejected), &mut chain_abci);
+                }
+            },
+            Ok(_) => {
+                // n == 0
+                log::trace!("end of stream?");
+            }
+            Err(e) => {
+                log::error!("error reading from chain-abci: {:?}", e);
+            }
+        }
+    }
+}
+
+pub fn entry() -> std::io::Result<()> {
+    std::env::set_var("RUST_LOG", "debug");
+    env_logger::init();
+
+    log::info!("Network ID: {:x}", NETWORK_HEX_ID);
+    log::info!("Connecting to chain-abci");
+    // not really TCP -- stream provided by the runner
+    let chain_abci = TcpStream::connect("chain-abci")?;
+    handling_loop(chain_abci, None);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_core::common::MerkleTree;
+    use chain_core::init::address::RedeemAddress;
+    use chain_core::init::coin::Coin;
+    use chain_core::state::account::{
+        StakedState, StakedStateAddress, StakedStateOpWitness, WithdrawUnbondedTx,
+    };
+    use chain_core::state::tendermint::BlockHeight;
+    use chain_core::tx::fee::Fee;
+    use chain_core::tx::witness::tree::RawXOnlyPubkey;
+    use chain_core::tx::witness::EcdsaSignature;
+    use chain_core::tx::witness::TxWitness;
+    use chain_core::tx::TransactionId;
+    use chain_core::tx::{
+        data::{
+            access::{TxAccess, TxAccessPolicy},
+            address::ExtendedAddr,
+            attribute::TxAttributes,
+            input::{TxoPointer, TxoSize},
+            output::TxOut,
+            Tx, TxId,
+        },
+        witness::TxInWitness,
+        TxEnclaveAux,
+    };
+    use chain_core::tx::{PlainTxAux, TxToObfuscate};
+    use chain_core::ChainInfo;
+    use chain_tx_validation::Error;
+    use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponseOk, VerifyTxRequest};
+    use log::debug;
+    use parity_scale_codec::{Decode, Encode};
+    use secp256k1::{
+        key::PublicKey, key::SecretKey, key::XOnlyPublicKey, schnorrsig::schnorr_sign, Message,
+        Secp256k1, Signing,
+    };
+    use std::io::{Cursor, Read, Result, Write};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    pub struct FakeStream {
+        reader: Cursor<Vec<u8>>,
+        writer: Cursor<Vec<u8>>,
+    }
+
+    impl FakeStream {
+        pub fn push_bytes(&mut self, bytes: &[u8]) {
+            let avail = self.reader.get_ref().len();
+            if self.reader.position() == avail as u64 {
+                self.reader = Default::default();
+            }
+            self.reader.get_mut().extend(bytes.iter().map(|c| *c));
+        }
+
+        pub fn pop_written_bytes(&mut self) -> Vec<u8> {
+            let mut result = Vec::new();
+            std::mem::swap(&mut result, self.writer.get_mut());
+            self.writer.set_position(0);
+            result
+        }
+    }
+
+    impl Read for FakeStream {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            self.reader.read(buf)
+        }
+    }
+
+    impl Write for FakeStream {
+        fn write<'a>(&mut self, buf: &'a [u8]) -> Result<usize> {
+            self.writer.write(buf)
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            self.writer.flush()
+        }
+    }
+
+    #[derive(Clone, Default)]
+    pub struct SyncStream {
+        pub stream: Arc<Mutex<FakeStream>>,
+    }
+
+    impl Read for SyncStream {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            self.stream.lock().unwrap().read(buf)
+        }
+    }
+
+    impl Write for SyncStream {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            self.stream.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            self.stream.lock().unwrap().flush()
+        }
+    }
+
+    pub fn push_bytes(stream: Arc<Mutex<FakeStream>>, bytes: &[u8]) {
+        stream.lock().unwrap().push_bytes(bytes)
+    }
+
+    pub fn pop_written_bytes(stream: Arc<Mutex<FakeStream>>) -> Vec<u8> {
+        stream.lock().unwrap().pop_written_bytes()
+    }
+
+    fn assert_stop_thread(stop: Arc<AtomicBool>, cond: bool, msg: &'static str) {
+        if !cond {
+            stop.store(true, Ordering::Relaxed);
+            eprintln!("{}", msg);
+            assert!(cond, msg);
+        }
+    }
+
+    fn get_ecdsa_witness<C: Signing>(
+        secp: &Secp256k1<C>,
+        txid: &TxId,
+        secret_key: &SecretKey,
+    ) -> EcdsaSignature {
+        let message = Message::from_slice(&txid[..]).expect("32 bytes");
+        let sig = secp.sign_recoverable(&message, &secret_key);
+        return sig;
+    }
+
+    fn get_account(account_address: &RedeemAddress) -> StakedState {
+        let mut state = StakedState::default(StakedStateAddress::from(*account_address));
+        state.unbonded = Coin::one();
+        state
+    }
+    const TEST_NETWORK_ID: u8 = 0xab;
+
+    // can be run with cargo test --target x86_64-fortanix-unknown-sgx
+    #[test]
+    fn test_sealing() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop2 = stop.clone();
+        let stream = SyncStream::default();
+        let stream2 = stream.stream.clone();
+        push_bytes(stream2.clone(), &IntraEnclaveRequest::EndBlock.encode());
+
+        let _handler = std::thread::spawn(move || {
+            handling_loop(stream, Some((stop2, sender)));
+        });
+
+        let _ = receiver.recv().unwrap();
+        let end_b =
+            IntraEnclaveResponse::decode(&mut pop_written_bytes(stream2.clone()).as_slice());
+
+        match end_b {
+            Ok(Ok(IntraEnclaveResponseOk::EndBlock(b))) => {
+                debug!("request filter in the beginning");
+                assert_stop_thread(stop.clone(), b.is_none(), "empty filter");
+            }
+            _ => {
+                assert_stop_thread(stop.clone(), false, "filter not returned");
+            }
+        };
+
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
+        let public_key = PublicKey::from_secret_key(&secp, &secret_key);
+        let x_public_key = XOnlyPublicKey::from_secret_key(&secp, &secret_key);
+
+        let addr = RedeemAddress::from(&public_key);
+
+        let merkle_tree = MerkleTree::new(vec![RawXOnlyPubkey::from(x_public_key.serialize())]);
+
+        let eaddr = ExtendedAddr::OrTree(merkle_tree.root_hash());
+        let tx0 = WithdrawUnbondedTx::new(
+            0,
+            vec![TxOut::new_with_timelock(eaddr.clone(), Coin::one(), 0)],
+            TxAttributes::new_with_access(
+                TEST_NETWORK_ID,
+                vec![TxAccessPolicy::new(public_key.clone(), TxAccess::AllData)],
+            ),
+        );
+        let txid = &tx0.id();
+        let witness0 = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &txid, &secret_key));
+        let account = get_account(&addr);
+        let withdrawtx = TxEnclaveAux::WithdrawUnbondedStakeTx {
+            no_of_outputs: tx0.outputs.len() as TxoSize,
+            witness: witness0.clone(),
+            payload: crate::sgx_module::obfuscate::encrypt(
+                TxToObfuscate::from(PlainTxAux::WithdrawUnbondedStakeTx(tx0.clone()), *txid)
+                    .expect("tx"),
+            ),
+        };
+
+        let info = ChainInfo {
+            min_fee_computed: Fee::new(Coin::zero()),
+            chain_hex_id: TEST_NETWORK_ID,
+            block_time: 1,
+            block_height: BlockHeight::genesis(),
+            max_evidence_age: 0,
+        };
+
+        let request0 = IntraEnclaveRequest::ValidateTx {
+            request: Box::new(VerifyTxRequest {
+                tx: withdrawtx,
+                account: Some(account),
+                info,
+            }),
+            tx_inputs: None,
+        };
+        push_bytes(stream2.clone(), &request0.encode());
+        let _ = receiver.recv().unwrap();
+        let r = IntraEnclaveResponse::decode(&mut pop_written_bytes(stream2.clone()).as_slice());
+
+        let sealedtx = match r {
+            Ok(Ok(IntraEnclaveResponseOk::TxWithOutputs { sealed_tx, .. })) => sealed_tx,
+            _ => vec![],
+        };
+
+        push_bytes(stream2.clone(), &IntraEnclaveRequest::EndBlock.encode());
+        let _ = receiver.recv().unwrap();
+        let end_b =
+            IntraEnclaveResponse::decode(&mut pop_written_bytes(stream2.clone()).as_slice());
+
+        match end_b {
+            Ok(Ok(IntraEnclaveResponseOk::EndBlock(b))) => {
+                debug!("request filter after one tx");
+                assert_stop_thread(
+                    stop.clone(),
+                    b.unwrap().iter().any(|x| *x != 0u8),
+                    "non-empty filter",
+                );
+            }
+            _ => {
+                assert_stop_thread(stop.clone(), false, "filter not returned");
+            }
+        };
+
+        let utxo1 = TxoPointer::new(*txid, 0);
+        let mut tx1 = Tx::new();
+        tx1.attributes = TxAttributes::new(TEST_NETWORK_ID);
+        tx1.add_input(utxo1.clone());
+        tx1.add_output(TxOut::new(eaddr.clone(), Coin::one()));
+        let txid1 = tx1.id();
+        let witness1: TxWitness = vec![TxInWitness::TreeSig(
+            schnorr_sign(&secp, &Message::from_slice(&txid1).unwrap(), &secret_key),
+            merkle_tree
+                .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
+                .unwrap(),
+        )]
+        .into();
+        let transfertx = TxEnclaveAux::TransferTx {
+            inputs: tx1.inputs.clone(),
+            no_of_outputs: tx1.outputs.len() as TxoSize,
+            payload: crate::sgx_module::obfuscate::encrypt(
+                TxToObfuscate::from(PlainTxAux::TransferTx(tx1.clone(), witness1.clone()), txid1)
+                    .expect("tx"),
+            ),
+        };
+
+        let request1 = IntraEnclaveRequest::ValidateTx {
+            request: Box::new(VerifyTxRequest {
+                tx: transfertx,
+                account: None,
+                info,
+            }),
+            tx_inputs: Some(vec![sealedtx.clone()]),
+        };
+        push_bytes(stream2.clone(), &request1.encode());
+        let _ = receiver.recv().unwrap();
+        let r2 = IntraEnclaveResponse::decode(&mut pop_written_bytes(stream2.clone()).as_slice());
+
+        match r2 {
+            Ok(Ok(IntraEnclaveResponseOk::TxWithOutputs { .. })) => {}
+            _ => {
+                assert_stop_thread(stop.clone(), false, "valid tx not accepted");
+            }
+        };
+
+        let mut tx2 = Tx::new();
+        tx2.attributes = TxAttributes::new(TEST_NETWORK_ID);
+        tx2.add_input(utxo1);
+        tx2.add_output(TxOut::new(eaddr.clone(), Coin::zero()));
+        let txid2 = tx2.id();
+        let witness2: TxWitness = vec![TxInWitness::TreeSig(
+            schnorr_sign(&secp, &Message::from_slice(&txid2).unwrap(), &secret_key),
+            merkle_tree
+                .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
+                .unwrap(),
+        )]
+        .into();
+        let transfertx2 = TxEnclaveAux::TransferTx {
+            inputs: tx2.inputs.clone(),
+            no_of_outputs: tx2.outputs.len() as TxoSize,
+            payload: crate::sgx_module::obfuscate::encrypt(
+                TxToObfuscate::from(PlainTxAux::TransferTx(tx2.clone(), witness2.clone()), txid2)
+                    .expect("tx"),
+            ),
+        };
+        let request2 = IntraEnclaveRequest::ValidateTx {
+            request: Box::new(VerifyTxRequest {
+                tx: transfertx2,
+                account: None,
+                info,
+            }),
+            tx_inputs: Some(vec![sealedtx]),
+        };
+        push_bytes(stream2.clone(), &request2.encode());
+        let _ = receiver.recv().unwrap();
+        let r3 = IntraEnclaveResponse::decode(&mut pop_written_bytes(stream2.clone()).as_slice());
+
+        match r3 {
+            Ok(Err(Error::ZeroCoin)) => {
+                debug!("invalid transaction rejected and error code returned");
+            }
+            Err(_) | Ok(Err(_)) => {
+                assert_stop_thread(
+                    stop.clone(),
+                    false,
+                    "something else happened (tx not correctly rejected)",
+                );
+            }
+            Ok(Ok(_)) => {
+                assert_stop_thread(
+                    stop.clone(),
+                    false,
+                    "something else happened (invalid tx accepted)",
+                );
+            }
+        };
+        stop.store(true, Ordering::Relaxed);
+    }
+}

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module/obfuscate.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module/obfuscate.rs
@@ -1,0 +1,169 @@
+// TODO: remove, as it's not required on newer nightly
+use crate::sgx_module::write_response;
+use aead::{generic_array::GenericArray, Aead, NewAead};
+use aes_gcm_siv::Aes128GcmSiv;
+use chain_core::state::tendermint::BlockHeight;
+use chain_core::tx::data::TxId;
+use chain_core::tx::TransactionId;
+use chain_core::tx::TxWithOutputs;
+use chain_core::tx::{PlainTxAux, TxObfuscated, TxToObfuscate};
+use chain_tx_validation::Error;
+use chain_tx_validation::{
+    verify_bonded_deposit_core, verify_transfer, verify_unbonded_withdraw_core,
+    witness::verify_tx_recover_address,
+};
+use enclave_macro::mock_key;
+use enclave_protocol::{EncryptionRequest, IntraEncryptRequest};
+use enclave_protocol::{IntraEnclaveResponse, IntraEnclaveResponseOk};
+use enclave_utils::SealedData;
+use parity_scale_codec::Decode;
+use std::io::Write;
+use std::prelude::v1::Box;
+use zeroize::Zeroize;
+
+/// this will be injected by TDBE connection
+const MOCK_KEY: [u8; 16] = mock_key!();
+
+pub(crate) fn encrypt(tx: TxToObfuscate) -> TxObfuscated {
+    let init_vector: [u8; 12] = rand::random();
+    let key = GenericArray::clone_from_slice(&MOCK_KEY);
+    let aead = Aes128GcmSiv::new(key);
+    let nonce = GenericArray::from_slice(&init_vector);
+    let ciphertext = aead.encrypt(nonce, &tx).expect("encryption failure!");
+    TxObfuscated {
+        key_from: BlockHeight::genesis(),
+        init_vector,
+        txpayload: ciphertext,
+        txid: tx.txid,
+    }
+}
+
+pub(crate) fn decrypt(tx: &TxObfuscated) -> Result<PlainTxAux, ()> {
+    let key = GenericArray::clone_from_slice(&MOCK_KEY);
+    let aead = Aes128GcmSiv::new(key);
+    let nonce = GenericArray::from_slice(&tx.init_vector);
+    let plaintext = aead.decrypt(nonce, tx).map_err(|_| ())?;
+    let result = PlainTxAux::decode(&mut plaintext.as_slice());
+    result.map_err(|_| ())
+}
+
+#[inline]
+fn unseal_request(request: &IntraEncryptRequest) -> Option<EncryptionRequest> {
+    let sealed_data = SealedData::try_copy_from(&request.sealed_enc_request)?;
+    if sealed_data.aes_data.additional_txt != request.txid {
+        return None;
+    }
+
+    let result = sealed_data.unseal();
+    let unsealed_data = match result {
+        Ok(x) => x,
+        Err(e) => {
+            log::error!("Error while unsealing sealed data: {:?}", e);
+            return None;
+        }
+    };
+    let otx = EncryptionRequest::decode(&mut unsealed_data.as_slice());
+    match otx {
+        Ok(o) => Some(o),
+        Err(e) => {
+            log::error!("decode encryption request failed: {:?}", e);
+            None
+        }
+    }
+}
+
+#[inline]
+pub fn check_unseal<I>(txids: I, sealed_logs: Vec<Vec<u8>>) -> Option<Vec<TxWithOutputs>>
+where
+    I: IntoIterator<Item = TxId> + ExactSizeIterator,
+{
+    let mut return_result = Vec::with_capacity(sealed_logs.len());
+
+    for (txid, sealed_log) in txids.into_iter().zip(sealed_logs.into_iter()) {
+        let sealed_data = SealedData::try_copy_from(&sealed_log)?;
+
+        if sealed_data.aes_data.additional_txt != txid {
+            return None;
+        }
+
+        let mut unsealed_data = sealed_data.unseal().ok()?;
+        let otx = TxWithOutputs::decode(&mut unsealed_data.as_slice());
+        if let Ok(tx) = otx {
+            return_result.push(tx.clone());
+        } else {
+            return None;
+        }
+
+        unsealed_data.zeroize();
+    }
+    Some(return_result)
+}
+
+#[inline]
+pub(crate) fn handle_encrypt_request<I: Write>(request: Box<IntraEncryptRequest>, output: &mut I) {
+    match (unseal_request(&request), request.tx_inputs) {
+        (Some(EncryptionRequest::TransferTx(tx, witness)), Some(sealed_inputs)) => {
+            let unsealed_inputs = check_unseal(tx.inputs.iter().map(|x| x.id), sealed_inputs);
+            if let Some(inputs) = unsealed_inputs {
+                let result = verify_transfer(&tx, &witness, &request.info, inputs);
+                let txid = tx.id();
+                let response: IntraEnclaveResponse = result.map(|_| {
+                    IntraEnclaveResponseOk::Encrypt(encrypt(
+                        TxToObfuscate::from(PlainTxAux::TransferTx(tx, witness), txid)
+                            .expect("construct plain payload"),
+                    ))
+                });
+                write_response(response, output);
+            } else {
+                log::debug!("failed to unseal inputs");
+                write_response(Err(Error::EnclaveRejected), output);
+            }
+        }
+        (Some(EncryptionRequest::DepositStake(tx, witness)), Some(sealed_inputs)) => {
+            let unsealed_inputs = check_unseal(tx.inputs.iter().map(|x| x.id), sealed_inputs);
+            if let Some(inputs) = unsealed_inputs {
+                let result = verify_bonded_deposit_core(&tx, &witness, &request.info, inputs);
+                let txid = tx.id();
+                let response: IntraEnclaveResponse = result.map(|_| {
+                    IntraEnclaveResponseOk::Encrypt(encrypt(
+                        TxToObfuscate::from(PlainTxAux::DepositStakeTx(witness), txid)
+                            .expect("construct plain payload"),
+                    ))
+                });
+                write_response(response, output);
+            } else {
+                log::debug!("failed to unseal inputs");
+                write_response(Err(Error::EnclaveRejected), output);
+            }
+        }
+        (Some(EncryptionRequest::WithdrawStake(tx, witness)), None) => {
+            if let Some(account) = request.account {
+                let txid = tx.id();
+                let maddress = verify_tx_recover_address(&witness, &txid);
+                match maddress {
+                    Ok(address) if address == account.address => {
+                        let result = verify_unbonded_withdraw_core(&tx, &request.info, &account);
+                        let response: IntraEnclaveResponse = result.map(|_| {
+                            IntraEnclaveResponseOk::Encrypt(encrypt(
+                                TxToObfuscate::from(PlainTxAux::WithdrawUnbondedStakeTx(tx), txid)
+                                    .expect("construct plain payload"),
+                            ))
+                        });
+                        write_response(response, output);
+                    }
+                    _ => {
+                        log::debug!("invalid address");
+                        write_response(Err(Error::EnclaveRejected), output);
+                    }
+                }
+            } else {
+                log::debug!("no account");
+                write_response(Err(Error::EnclaveRejected), output);
+            }
+        }
+        (_, _) => {
+            log::debug!("invalid request");
+            write_response(Err(Error::EnclaveRejected), output);
+        }
+    }
+}

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module/validate.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module/validate.rs
@@ -1,0 +1,180 @@
+use crate::sgx_module::obfuscate::check_unseal;
+use crate::sgx_module::write_response;
+use chain_core::init::coin::Coin;
+use chain_core::tx::data::TxId;
+use chain_core::tx::fee::Fee;
+use chain_core::tx::TransactionId;
+use chain_core::tx::{data::input::TxoSize, PlainTxAux, TxEnclaveAux, TxObfuscated};
+use chain_tx_filter::BlockFilter;
+use chain_tx_validation::witness::verify_tx_recover_address;
+use chain_tx_validation::Error;
+use chain_tx_validation::{
+    verify_bonded_deposit_core, verify_transfer, verify_unbonded_withdraw_core, TxWithOutputs,
+};
+use enclave_protocol::{
+    is_basic_valid_tx_request, IntraEnclaveResponse, IntraEnclaveResponseOk, VerifyTxRequest,
+};
+use enclave_utils::SealedData;
+use parity_scale_codec::Encode;
+use std::io::Write;
+use std::prelude::v1::{Box, Vec};
+
+#[inline]
+fn add_view_keys(wraptx: &TxWithOutputs, filter: &mut BlockFilter) {
+    match wraptx {
+        TxWithOutputs::Transfer(tx) => {
+            for view in tx.attributes.allowed_view.iter() {
+                filter.add_view_key(&view.view_key);
+            }
+        }
+        TxWithOutputs::StakeWithdraw(tx) => {
+            for view in tx.attributes.allowed_view.iter() {
+                filter.add_view_key(&view.view_key);
+            }
+        }
+    }
+}
+
+#[inline]
+fn construct_sealed_response(
+    result: Result<Fee, chain_tx_validation::Error>,
+    txid: &TxId,
+    to_seal_tx: TxWithOutputs,
+    filter: &mut BlockFilter,
+) -> IntraEnclaveResponse {
+    result.map(|fee| {
+        let to_seal = to_seal_tx.encode();
+        // TODO: no panic?
+        let sealed_log = SealedData::seal(&to_seal, *txid).expect("seal");
+        add_view_keys(&to_seal_tx, filter);
+
+        IntraEnclaveResponseOk::TxWithOutputs {
+            paid_fee: fee,
+            sealed_tx: sealed_log,
+        }
+    })
+}
+
+#[inline]
+fn construct_simple_response(
+    result: Result<Coin, chain_tx_validation::Error>,
+) -> IntraEnclaveResponse {
+    result.map(|input_coins| IntraEnclaveResponseOk::DepositStakeTx { input_coins })
+}
+
+#[inline]
+fn decrypt(payload: &TxObfuscated) -> Result<PlainTxAux, ()> {
+    crate::sgx_module::obfuscate::decrypt(payload)
+}
+
+/// takes a request to verify transaction and writes back the result
+#[inline]
+pub(crate) fn handle_validate_tx<I: Write>(
+    request: Box<VerifyTxRequest>,
+    tx_inputs: Option<Vec<Vec<u8>>>,
+    filter: &mut BlockFilter,
+    output: &mut I,
+) {
+    if let Err(e) =
+        is_basic_valid_tx_request(&request, &tx_inputs, crate::sgx_module::NETWORK_HEX_ID)
+    {
+        log::error!("check request failed: {}", e);
+    } else {
+        match (tx_inputs, request.tx) {
+            (
+                Some(sealed_inputs),
+                TxEnclaveAux::TransferTx {
+                    payload,
+                    no_of_outputs,
+                    inputs,
+                },
+            ) => {
+                let plaintx = decrypt(&payload);
+                let unsealed_inputs = check_unseal(inputs.iter().map(|x| x.id), sealed_inputs);
+                match (plaintx, unsealed_inputs) {
+                    (Ok(PlainTxAux::TransferTx(tx, witness)), Some(inputs)) => {
+                        if tx.id() != payload.txid || tx.outputs.len() as TxoSize != no_of_outputs {
+                            log::error!("input invalid txid or outputs index not match!");
+                        } else {
+                            let result = verify_transfer(&tx, &witness, &request.info, inputs);
+                            let response = construct_sealed_response(
+                                result,
+                                &payload.txid,
+                                TxWithOutputs::Transfer(tx),
+                                filter,
+                            );
+                            write_response(response, output);
+                        }
+                    }
+                    _ => {
+                        log::error!("can not find plain transfer transaction or unsealed inputs");
+                        write_response(Err(Error::EnclaveRejected), output);
+                    }
+                }
+            }
+            (Some(sealed_inputs), TxEnclaveAux::DepositStakeTx { tx, payload }) => {
+                let plaintx = decrypt(&payload);
+                let inputs = check_unseal(tx.inputs.iter().map(|x| x.id), sealed_inputs);
+                match (plaintx, inputs) {
+                    (Ok(PlainTxAux::DepositStakeTx(witness)), Some(inputs)) => {
+                        let result =
+                            verify_bonded_deposit_core(&tx, &witness, &request.info, inputs);
+                        let response = construct_simple_response(result);
+                        write_response(response, output);
+                    }
+                    _ => {
+                        log::error!(
+                            "can not get plain deposit stake transaction or unsealed inputs"
+                        );
+                        write_response(Err(Error::EnclaveRejected), output);
+                    }
+                }
+            }
+            (
+                None,
+                TxEnclaveAux::WithdrawUnbondedStakeTx {
+                    no_of_outputs,
+                    payload,
+                    witness,
+                },
+            ) => {
+                let address = verify_tx_recover_address(&witness, &payload.txid);
+                if let Err(e) = address {
+                    log::error!("get recover address failed: {:?}", e);
+                    write_response(Err(Error::EnclaveRejected), output);
+                } else {
+                    let plaintx = decrypt(&payload);
+                    match (plaintx, request.account) {
+                        (Ok(PlainTxAux::WithdrawUnbondedStakeTx(tx)), Some(account)) => {
+                            if tx.id() != payload.txid
+                                || no_of_outputs != tx.outputs.len() as TxoSize
+                                || account.address != address.unwrap()
+                            {
+                                log::error!("invalid parameter");
+                                write_response(Err(Error::EnclaveRejected), output);
+                            } else {
+                                let result =
+                                    verify_unbonded_withdraw_core(&tx, &request.info, &account);
+                                let response = construct_sealed_response(
+                                    result,
+                                    &payload.txid,
+                                    TxWithOutputs::StakeWithdraw(tx),
+                                    filter,
+                                );
+                                write_response(response, output);
+                            }
+                        }
+                        _ => {
+                            log::error!("invalid parameter");
+                            write_response(Err(Error::EnclaveRejected), output);
+                        }
+                    }
+                }
+            }
+            (_, _) => {
+                log::error!("invalid parameter");
+                write_response(Err(Error::EnclaveRejected), output);
+            }
+        }
+    }
+}

--- a/cro-clib/chain-core.h
+++ b/cro-clib/chain-core.h
@@ -55,6 +55,11 @@
 #define REDEEM_ADDRESS_BYTES 20
 
 /**
+ * Maximum (Tendermint-outer payload) transaction size
+ */
+#define TX_AUX_SIZE (1024 * 60)
+
+/**
  * network type
  */
 typedef enum Network {

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -35,6 +35,10 @@ if [ $BUILD_MODE == "sgx" ]; then
     rustup target add x86_64-fortanix-unknown-sgx
     cargo install fortanix-sgx-tools sgxs-tools
 
+    # FIXME: test enclave packages
+    # LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service --no-daemon &
+    # NETWORK_ID="ab" cargo test --target=x86_64-fortanix-unknown-sgx -p tx-validation-next -p enclave-utils
+
     # mls enclave -- FIXME: TDBE, mls should only be a library
     cargo build --target=x86_64-fortanix-unknown-sgx -p mls
     ftxsgx-elf2sgxs $EDP_TARGET_DIR/mls \


### PR DESCRIPTION
Solution:
- ported the tx-validation enclave logic to EDP
-- instead of "ecall", there's a loop reading off
TcpStream (expected to be "usercall extension")
- ported the SGX sealing test
(before it needs to be executed in that custom SGX_TEST=1 compilation,
here the normal cargo test works) + added
the test execution to the drone

NOTE: runner is not yet implemented for the sake of smaller PR
and it's blocked by finalization of
https://github.com/crypto-com/chain/pull/1910
