### PR TITLE
Problem: slow wallet operation for over 4,000,000 addresses (fix #1922)

### DIFF
--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -563,7 +563,7 @@ where
 
     /// Returns view key of wallet
     pub fn view_key(&self, name: &str, enckey: &SecKey) -> Result<PublicKey> {
-        let _wallet_found = self.get_wallet(name, enckey)?;
+        let _wallet_found = self.get_wallet_info(name, enckey)?;
         let info_keyspace = get_info_keyspace(name);
         read_pubkey_enc(&self.storage, &info_keyspace, "viewkey", enckey)
     }
@@ -577,7 +577,7 @@ where
             ));
         }
 
-        let _wallet_found = self.get_wallet(name, enckey)?;
+        let _wallet_found = self.get_wallet_info(name, enckey)?;
 
         let public_keyspace = get_public_keyspace(name);
 
@@ -600,7 +600,7 @@ where
                 format!("Wallet with name ({}) not found", name),
             ));
         }
-        let _wallet_found = self.get_wallet(name, enckey)?;
+        let _wallet_found = self.get_wallet_info(name, enckey)?;
         let stakingkey_keyspace = get_stakingkey_keyspace(name);
         let mut ret: IndexSet<PublicKey> = IndexSet::<PublicKey>::new();
         let info_keyspace = get_info_keyspace(name);
@@ -636,7 +636,7 @@ where
                 format!("Wallet with name ({}) not found", name),
             ));
         }
-        let _wallet_found = self.get_wallet(name, enckey)?;
+        let _wallet_found = self.get_wallet_info(name, enckey)?;
         let roothash_keyspace = get_roothash_keyspace(name);
         let mut ret: IndexSet<H256> = IndexSet::<H256>::new();
         let info_keyspace = get_info_keyspace(name);
@@ -880,7 +880,7 @@ where
     /// Delete the key
     // TODO: change api not to use _enckey
     pub fn delete(&self, name: &str, enckey: &SecKey) -> Result<Wallet> {
-        let wallet_found = self.get_wallet(name, enckey)?;
+        let wallet_found = self.get_wallet_info(name, enckey)?;
         self.storage.delete(KEYSPACE, name)?;
         self.delete_wallet_keyspace(name)?;
         Ok(wallet_found)

--- a/client-core/src/signer/wallet_signer.rs
+++ b/client-core/src/signer/wallet_signer.rs
@@ -156,7 +156,9 @@ where
         let public_key = self
             .root_hash_service
             .public_key(self.name, &root_hash, self.enckey)?;
-        let wallet = self.wallet_service.get_wallet(self.name, self.enckey)?;
+        let wallet = self
+            .wallet_service
+            .get_wallet_info(self.name, self.enckey)?;
         let sign_key = match wallet.wallet_kind {
             WalletKind::HW => {
                 let chain_path = self


### PR DESCRIPTION
refactoring to improve sync speed ,
load_wallet now called only in export, import

1. changed load_wallet called only in export, import
2.  update Wallet in address recovering instead of fetching all
