### PR TITLE
Problem: rust-secp256k1 fork diverged from upstream (fixes #757)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,8 @@ dependencies = [
  "protobuf",
  "quickcheck",
  "ra-client",
- "secp256k1zkp",
+ "rand 0.7.3",
+ "secp256k1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -574,7 +575,8 @@ dependencies = [
  "parity-scale-codec",
  "quickcheck",
  "ra-client",
- "secp256k1zkp",
+ "rand 0.7.3",
+ "secp256k1",
  "serde",
  "serde_json",
  "sgx_tstd",
@@ -613,7 +615,7 @@ dependencies = [
  "hex 0.4.2",
  "parity-scale-codec",
  "quickcheck",
- "secp256k1zkp",
+ "secp256k1",
  "sgx_tstd",
 ]
 
@@ -623,7 +625,8 @@ version = "0.6.0"
 dependencies = [
  "chain-core",
  "parity-scale-codec",
- "secp256k1zkp",
+ "rand 0.7.3",
+ "secp256k1",
  "sgx_tstd",
  "thiserror",
 ]
@@ -724,6 +727,7 @@ dependencies = [
  "base64 0.12.3",
  "bit-vec",
  "blake3",
+ "cfg-if",
  "chain-core",
  "chain-tx-filter",
  "chrono",
@@ -743,7 +747,7 @@ dependencies = [
  "rand 0.7.3",
  "rust-argon2 0.8.2",
  "rustls 0.18.0",
- "secp256k1zkp",
+ "secp256k1",
  "secstr",
  "serde",
  "serde_json",
@@ -784,7 +788,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "ripemd160",
- "secp256k1zkp",
+ "secp256k1",
  "secstr",
  "serde",
  "serde_json",
@@ -811,7 +815,7 @@ dependencies = [
  "client-core",
  "hex 0.4.2",
  "parity-scale-codec",
- "secp256k1zkp",
+ "secp256k1",
  "secstr",
  "tendermint",
  "test-common",
@@ -956,7 +960,7 @@ dependencies = [
  "jsonrpc-core",
  "libc",
  "parity-scale-codec",
- "secp256k1zkp",
+ "secp256k1",
  "secstr",
  "serde",
  "serde_json",
@@ -1226,7 +1230,7 @@ dependencies = [
  "parity-scale-codec",
  "quest",
  "ra-client",
- "secp256k1zkp",
+ "secp256k1",
  "secstr",
  "serde",
  "serde_json",
@@ -1356,7 +1360,7 @@ dependencies = [
  "chain-core",
  "chain-tx-validation",
  "parity-scale-codec",
- "secp256k1zkp",
+ "secp256k1",
  "sgx_tstd",
 ]
 
@@ -1388,7 +1392,7 @@ version = "0.6.0"
 dependencies = [
  "chain-core",
  "parity-scale-codec",
- "secp256k1zkp",
+ "secp256k1",
  "sgx_tseal",
  "sgx_tstd",
  "sgx_types",
@@ -3797,15 +3801,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1zkp"
-version = "0.13.0"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=f8759809f6e3fed793b37166f7cd91c57cdb2eab#f8759809f6e3fed793b37166f7cd91c57cdb2eab"
+name = "secp256k1"
+version = "0.17.2"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=535790e91fac1b3b00c770cb339a06feadc5f48d#535790e91fac1b3b00c770cb339a06feadc5f48d"
+dependencies = [
+ "rand 0.7.3",
+ "secp256k1-sys",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.1.3"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=535790e91fac1b3b00c770cb339a06feadc5f48d#535790e91fac1b3b00c770cb339a06feadc5f48d"
 dependencies = [
  "cc",
- "rand 0.7.3",
- "serde",
- "sgx_tstd",
- "zeroize",
 ]
 
 [[package]]
@@ -4484,7 +4495,7 @@ dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "protobuf",
- "secp256k1zkp",
+ "secp256k1",
  "secstr",
  "serde_json",
  "sha2",
@@ -4951,7 +4962,7 @@ dependencies = [
  "rand 0.7.3",
  "rs-libc",
  "rustls 0.18.0",
- "secp256k1zkp",
+ "secp256k1",
  "thread-pool",
  "zeroize",
 ]
@@ -4972,7 +4983,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parity-scale-codec",
- "secp256k1zkp",
+ "secp256k1",
  "sgx_rand",
  "sgx_tcrypto",
  "sgx_trts",
@@ -5000,7 +5011,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.7.3",
  "rs-libc",
- "secp256k1zkp",
+ "secp256k1",
  "zeroize",
 ]
 

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4"
 protobuf = "2.7.0"
 integer-encoding = "1.1.5"
 structopt = "0.3"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 thiserror = "1.0"
 
@@ -43,6 +43,7 @@ enclave-u-common = { path = "../chain-tx-enclave/enclave-u-common" }
 sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 zmq = "0.9"
+rand = "0.7"
 
 [build-dependencies]
 cc = "1.0"
@@ -58,6 +59,7 @@ base64 = "0.12"
 kvdb = "0.7"
 kvdb-memorydb = "0.7"
 test-common = { path = "../test-common" }
+rand = "0.7"
 
 # TODO: currently not maintained benchmarks
 # [[bench]]

--- a/chain-abci/src/enclave_bridge/real/test/seal.rs
+++ b/chain-abci/src/enclave_bridge/real/test/seal.rs
@@ -196,7 +196,12 @@ pub fn test_sealing() {
     tx1.add_output(TxOut::new(eaddr.clone(), Coin::one()));
     let txid1 = tx1.id();
     let witness1 = vec![TxInWitness::TreeSig(
-        schnorr_sign(&secp, &Message::from_slice(&txid1).unwrap(), &secret_key),
+        schnorr_sign(
+            &secp,
+            &Message::from_slice(&txid1).unwrap(),
+            &secret_key,
+            &mut rand::thread_rng(),
+        ),
         merkle_tree
             .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
             .unwrap(),
@@ -228,7 +233,12 @@ pub fn test_sealing() {
     tx2.add_output(TxOut::new(eaddr.clone(), Coin::zero()));
     let txid2 = tx2.id();
     let witness2 = vec![TxInWitness::TreeSig(
-        schnorr_sign(&secp, &Message::from_slice(&txid2).unwrap(), &secret_key),
+        schnorr_sign(
+            &secp,
+            &Message::from_slice(&txid2).unwrap(),
+            &secret_key,
+            &mut rand::thread_rng(),
+        ),
         merkle_tree
             .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
             .unwrap(),

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -908,7 +908,12 @@ fn all_valid_tx_types_should_commit() {
     tx1.add_output(TxOut::new(eaddr, Coin::from(99999700u32)));
     let txid1 = tx1.id();
     let witness1 = vec![TxInWitness::TreeSig(
-        schnorr_sign(&secp, &Message::from_slice(&txid1).unwrap(), &secret_key),
+        schnorr_sign(
+            &secp,
+            &Message::from_slice(&txid1).unwrap(),
+            &secret_key,
+            &mut rand::thread_rng(),
+        ),
         merkle_tree
             .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
             .unwrap(),
@@ -934,7 +939,12 @@ fn all_valid_tx_types_should_commit() {
     let utxo2 = TxoPointer::new(*txid, 1);
     let tx2 = DepositBondTx::new(vec![utxo2], addr.into(), StakedStateOpAttributes::new(0));
     let witness2 = vec![TxInWitness::TreeSig(
-        schnorr_sign(&secp, &Message::from_slice(&tx2.id()).unwrap(), &secret_key),
+        schnorr_sign(
+            &secp,
+            &Message::from_slice(&tx2.id()).unwrap(),
+            &secret_key,
+            &mut rand::thread_rng(),
+        ),
         merkle_tree
             .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
             .unwrap(),
@@ -964,7 +974,12 @@ fn all_valid_tx_types_should_commit() {
     let utxo3 = TxoPointer::new(*txid, 2);
     let tx3 = DepositBondTx::new(vec![utxo3], addr2.into(), StakedStateOpAttributes::new(0));
     let witness3 = vec![TxInWitness::TreeSig(
-        schnorr_sign(&secp, &Message::from_slice(&tx3.id()).unwrap(), &secret_key),
+        schnorr_sign(
+            &secp,
+            &Message::from_slice(&tx3.id()).unwrap(),
+            &secret_key,
+            &mut rand::thread_rng(),
+        ),
         merkle_tree
             .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
             .unwrap(),

--- a/chain-abci/tests/tx_validation.rs
+++ b/chain-abci/tests/tx_validation.rs
@@ -100,7 +100,7 @@ pub fn get_tx_witness<C: Signing>(
     let proof = merkle_tree
         .generate_proof(RawXOnlyPubkey::from(public_key.serialize()))
         .unwrap();
-    let signature = schnorr_sign(&secp, &message, secret_key);
+    let signature = schnorr_sign(&secp, &message, secret_key, &mut rand::thread_rng());
 
     TxInWitness::TreeSig(signature, proof)
 }

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -7,9 +7,9 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["serde", "bech32", "hex", "base64", "secp256k1zkp/serde", "secp256k1zkp/std", "mls", "ra-client"]
-edp = ["secp256k1zkp/edp"]
-mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx"]
+default = ["serde", "bech32", "hex", "base64", "secp256k1/serde", "secp256k1/std", "mls", "ra-client"]
+edp = ["secp256k1/lowmemory"]
+mesalock_sgx = ["secp256k1/lowmemory", "sgx_tstd"]
 
 [dependencies]
 mls = { path = "../chain-tx-enclave-next/mls", optional = true }
@@ -18,7 +18,7 @@ digest = { version = "0.8", default-features = false}
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 sha2 = { version = "0.8", default-features = false }
 hex = { version = "0.4", optional = true }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake3 = { version = "0.3.5", default-features = false }
 parity-scale-codec = { features = ["derive"], default-features = false, version = "1.3" }
@@ -34,3 +34,4 @@ quickcheck = "0.9"
 serde_json = "1.0"
 fixed = "1.0.0"
 test-common = { path = "../test-common" }
+rand = "0.7"

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -654,7 +654,7 @@ pub mod tests {
         let merkle = MerkleTree::new(raw_public_keys.clone());
 
         let w1 = TxInWitness::TreeSig(
-            schnorr_sign(&secp, &msg, &sk1),
+            schnorr_sign(&secp, &msg, &sk1, &mut rand::thread_rng()),
             merkle.generate_proof(raw_public_keys[0].clone()).unwrap(),
         );
         let txa = PlainTxAux::TransferTx(tx, vec![w1].into());

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
@@ -13,7 +13,7 @@ parity-scale-codec = "1.3"
 rand = "0.7"
 rs-libc = "0.2"
 rustls = "0.18"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["edp"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["lowmemory"] }
 thread-pool = "0.1"
 zeroize = "1.1"
 

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module/handler/decryption_request.rs
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module/handler/decryption_request.rs
@@ -25,9 +25,10 @@ pub fn get_random_challenge() -> H256 {
 }
 
 pub fn verify_decryption_request(decryption_request: &DecryptionRequest, challenge: H256) -> bool {
-    decryption_request
-        .verify(&Secp256k1::verification_only(), challenge)
-        .is_ok()
+    // FIXME: provide secp as ref
+    let mut buf_vfy = vec![0u8; Secp256k1::preallocate_verification_size()];
+    let secp = Secp256k1::preallocated_verification_only(&mut buf_vfy).expect("allocation");
+    decryption_request.verify(&secp, challenge).is_ok()
 }
 
 pub fn handle_decryption_request(

--- a/chain-tx-enclave-next/tx-validation-next/Cargo.toml
+++ b/chain-tx-enclave-next/tx-validation-next/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2018"
 enclave-macro = { path = "../../chain-tx-enclave/enclave-macro" }
 chain-tx-validation   = {  path = "../../chain-tx-validation" }
 chain-core   = {  path = "../../chain-core" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism", "edp"] }
+# TODO: "rand" feature may only be dev-dependency / needed for tests
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig", "rand"] }
 parity-scale-codec = { version = "1.3" }
 enclave-protocol   = { path = "../../enclave-protocol" }
 chain-tx-filter   = { path = "../../chain-tx-filter" }

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
@@ -346,7 +346,12 @@ mod tests {
         tx1.add_output(TxOut::new(eaddr.clone(), Coin::one()));
         let txid1 = tx1.id();
         let witness1: TxWitness = vec![TxInWitness::TreeSig(
-            schnorr_sign(&secp, &Message::from_slice(&txid1).unwrap(), &secret_key),
+            schnorr_sign(
+                &secp,
+                &Message::from_slice(&txid1).unwrap(),
+                &secret_key,
+                &mut rand::thread_rng(),
+            ),
             merkle_tree
                 .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
                 .unwrap(),
@@ -386,7 +391,12 @@ mod tests {
         tx2.add_output(TxOut::new(eaddr.clone(), Coin::zero()));
         let txid2 = tx2.id();
         let witness2: TxWitness = vec![TxInWitness::TreeSig(
-            schnorr_sign(&secp, &Message::from_slice(&txid2).unwrap(), &secret_key),
+            schnorr_sign(
+                &secp,
+                &Message::from_slice(&txid2).unwrap(),
+                &secret_key,
+                &mut rand::thread_rng(),
+            ),
             merkle_tree
                 .generate_proof(RawXOnlyPubkey::from(x_public_key.serialize()))
                 .unwrap(),

--- a/chain-tx-enclave/enclave-t-common/Cargo.toml
+++ b/chain-tx-enclave/enclave-t-common/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 sgx_tstd    = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 chain-core   = { path = "../../chain-core", default-features = false, features = ["mesalock_sgx"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism", "sgx"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig"] }
 zeroize = { version = "1.0", default-features = false }
 sgx_tseal     = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 parity-scale-codec = { default-features = false, version = "1.0" }

--- a/chain-tx-enclave/tx-validation/enclave/Cargo.toml
+++ b/chain-tx-enclave/tx-validation/enclave/Cargo.toml
@@ -24,7 +24,7 @@ sgx_tcrypto   = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-
 enclave-macro = { path = "../../enclave-macro" }
 chain-tx-validation   = {  path = "../../../chain-tx-validation", default-features = false, features = ["mesalock_sgx"] }
 chain-core   = {  path = "../../../chain-core", default-features = false, features = ["mesalock_sgx"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism", "sgx"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig"] }
 parity-scale-codec = { default-features = false, version = "1.3" }
 enclave-protocol   = { path = "../../../enclave-protocol", default-features = false, features = ["mesalock_sgx"] }
 chain-tx-filter   = { path = "../../../chain-tx-filter", default-features = false, features = ["mesalock_sgx"] }

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 
 [features]
 default = ["bit-vec/std", "chain-core/default"]
-mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx"]
+mesalock_sgx = ["sgx_tstd", "secp256k1/lowmemory"]
 
 [dependencies]
 chain-core = { default-features = false, path = "../chain-core" }
 parity-scale-codec = { default-features = false, version = "1.3" }
-secp256k1zkp = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["endomorphism"] }
+secp256k1 = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["endomorphism"] }
 bit-vec = { default-features = false, version = "0.6" }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -8,11 +8,14 @@ edition = "2018"
 
 [features]
 default = ["chain-core/default", "thiserror"]
-mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx"]
+mesalock_sgx = ["sgx_tstd", "secp256k1/lowmemory"]
 
 [dependencies]
 chain-core = { path = "../chain-core", default-features = false }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
 parity-scale-codec = { features = ["derive"], default-features = false, version = "1.3" }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 thiserror = { version = "1.0", default-features = false, optional = true }
+
+[dev-dependencies]
+rand = "0.7"

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0"
 base64 = "0.12"
 bit-vec = "0.6.2"
 blake3 = "0.3.5"
+cfg-if = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = { version = "0.3", optional = true }
 gcd = "2.0"
@@ -30,7 +31,8 @@ parity-scale-codec = { features = ["derive"], version = "1.3" }
 rand = "0.7"
 rust-argon2 = "0.8"
 rustls =  { version = "0.18", features = ["dangerous_configuration"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+# secp256k1experimental = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "cccfdb77c068b9cefa07b6884849f8473683d6d4", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "schnorrsig"] }
 secstr = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -49,3 +51,4 @@ quickcheck = "0.9"
 default = ["sled", "websocket-rpc"]
 websocket-rpc = ["futures-util", "tokio", "tokio-tungstenite"]
 mock-enclave = []
+experimental = []

--- a/client-common/src/key/private_key.rs
+++ b/client-common/src/key/private_key.rs
@@ -45,7 +45,7 @@ impl PrivateKeyAction for PrivateKey {
                 "Unable to deserialize message to sign",
             )
         })?;
-        let signature = SECP.with(|secp| schnorr_sign(&secp, &message, &self.0));
+        let signature = SECP.with(|secp| schnorr_sign(&secp, &message, &self.0, &mut OsRng));
         Ok(signature)
     }
 
@@ -111,7 +111,7 @@ impl From<&PrivateKey> for PublicKey {
 
 impl From<&PrivateKey> for SecretKey {
     fn from(private_key: &PrivateKey) -> Self {
-        private_key.0.clone()
+        private_key.0
     }
 }
 

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -14,7 +14,8 @@ chain-tx-validation = { path = "../chain-tx-validation" }
 chain-storage = { path = "../chain-storage", default-features = false }
 once_cell = "1.4"
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+# secp256k1experimental = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "cccfdb77c068b9cefa07b6884849f8473683d6d4", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["serde", "rand", "recovery", "endomorphism", "schnorrsig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.7"
@@ -51,3 +52,4 @@ default = ["sled"]
 sled = ["client-common/sled"]
 websocket-rpc = ["client-common/websocket-rpc"]
 mock-hardware-wallet = []
+experimental = ["client-common/experimental"]

--- a/client-core/src/hd_wallet/extended_key.rs
+++ b/client-core/src/hd_wallet/extended_key.rs
@@ -148,7 +148,7 @@ impl ExtendedPubKey {
         let sig_bytes = signature.as_ref();
         let (key, chain_code) = sig_bytes.split_at(sig_bytes.len() / 2);
         let private_key = SecretKey::from_slice(key)?;
-        let mut public_key = self.public_key.clone();
+        let mut public_key = self.public_key;
         public_key.add_exp_assign(&*SECP256K1_VERIFY_ONLY, &private_key[..])?;
         Ok(ExtendedPubKey {
             public_key,

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hd_seed;
 pub mod hd_wallet;
 pub mod input_selection;
 pub mod mnemonic;
+#[cfg(feature = "experimental")]
 pub mod multi_sig;
 pub mod service;
 pub mod signer;
@@ -38,7 +39,11 @@ pub use crate::transaction_builder::WalletTransactionBuilder;
 #[doc(inline)]
 pub use crate::unspent_transactions::{SelectedUnspentTransactions, UnspentTransactions};
 #[doc(inline)]
-pub use crate::wallet::{MultiSigWalletClient, WalletClient};
+pub use crate::wallet::WalletClient;
+
+#[cfg(feature = "experimental")]
+#[doc(inline)]
+pub use crate::wallet::MultiSigWalletClient;
 
 #[macro_use]
 extern crate lazy_static;

--- a/client-core/src/multi_sig/session.rs
+++ b/client-core/src/multi_sig/session.rs
@@ -2,15 +2,23 @@ use std::convert::TryFrom;
 
 use parity_scale_codec::{Decode, Encode};
 use rand::rngs::OsRng;
-use secp256k1::key::MuSigPreSession;
-use secp256k1::musig::{
+use secp256k1::key::pubkey_combine;
+
+use secp256k1experimental::key::MuSigPreSession;
+use secp256k1experimental::musig::{
     MuSigNonce, MuSigNonceCommitment, MuSigPartialSignature, MuSigSession, MuSigSessionID,
 };
-use secp256k1::schnorrsig::SchnorrSignature;
-use secp256k1::{key::XOnlyPublicKey, Message, SecretKey};
+use secp256k1experimental::schnorrsig::SchnorrSignature;
+use secp256k1experimental::{key::XOnlyPublicKey, Message, SecretKey};
+use secp256k1experimental::{All, Secp256k1};
+
+thread_local! {
+    /// Thread local static Secp object
+    static SECP: Secp256k1<All> = Secp256k1::new();
+}
 
 use chain_core::common::H256;
-use client_common::{Error, ErrorKind, PrivateKey, PublicKey, Result, ResultExt, SECP};
+use client_common::{Error, ErrorKind, PrivateKey, PublicKey, Result, ResultExt};
 
 use super::Signer;
 
@@ -384,6 +392,7 @@ impl MultiSigSession {
                         "Unable to combine partial signatures",
                     )
                 })?)
+            .map(|x| SchnorrSignature::from_default(&x.serialize()).expect("experimental"))
         })
     }
 

--- a/client-core/src/service.rs
+++ b/client-core/src/service.rs
@@ -4,6 +4,7 @@ mod hw_key_service;
 mod key_service;
 #[cfg(feature = "mock-hardware-wallet")]
 mod mock_hw_key_service;
+#[cfg(feature = "experimental")]
 mod multi_sig_session_service;
 mod root_hash_service;
 mod sync_state_service;
@@ -18,6 +19,7 @@ pub use self::hw_key_service::{HwKeyService, UnauthorizedHwKeyService};
 pub use self::key_service::KeyService;
 #[cfg(feature = "mock-hardware-wallet")]
 pub use self::mock_hw_key_service::{MockHardwareKey, MockHardwareService, MockHardwareWallet};
+#[cfg(feature = "experimental")]
 pub use self::multi_sig_session_service::MultiSigSessionService;
 pub use self::root_hash_service::RootHashService;
 pub use self::sync_state_service::{

--- a/client-core/src/service/root_hash_service.rs
+++ b/client-core/src/service/root_hash_service.rs
@@ -143,7 +143,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "experimental"))]
 mod tests {
     use super::*;
     use secstr::SecUtf8;
@@ -284,7 +284,7 @@ mod tests {
         let mut signers = vec![public_keys[0].clone(), public_keys[1].clone()];
         signers.sort();
 
-        let signer = RawXOnlyPubkey::from(PublicKey::combine(&signers).unwrap().0.serialize());
+        let signer = RawXOnlyPubkey::from(combine(&signers).unwrap().0.serialize());
 
         assert_eq!(proof.value(), &signer);
     }

--- a/client-core/src/signer/wallet_signer.rs
+++ b/client-core/src/signer/wallet_signer.rs
@@ -249,6 +249,7 @@ mod wallet_signer_tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn check_2_of_3_invalid_signing_flow() {
         let name = "name";
         let passphrase = SecUtf8::from("passphrase");

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -7,6 +7,7 @@ mod syncer_logic;
 pub use default_wallet_client::DefaultWalletClient;
 
 use indexmap::IndexSet;
+#[cfg(feature = "experimental")]
 use secp256k1::schnorrsig::SchnorrSignature;
 use secstr::SecUtf8;
 use std::collections::BTreeSet;
@@ -19,7 +20,9 @@ use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
-use chain_core::tx::data::{Tx, TxId};
+#[cfg(feature = "experimental")]
+use chain_core::tx::data::Tx;
+use chain_core::tx::data::TxId;
 use chain_core::tx::witness::tree::RawXOnlyPubkey;
 use chain_core::tx::TxAux;
 use client_common::tendermint::types::BroadcastTxResponse;
@@ -392,6 +395,7 @@ pub trait WalletClient: Send + Sync {
     fn get_sync_state(&self, name: &str) -> Result<SyncState>;
 }
 
+#[cfg(feature = "experimental")]
 /// Interface for a generic wallet for multi-signature transactions
 pub trait MultiSigWalletClient: WalletClient {
     /// Creates a 1-of-n schnorr signature.

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -7,9 +7,10 @@ use crate::types::{
 };
 use crate::wallet::syncer::{get_genesis_sync_state, AddressRecovery};
 use crate::wallet::syncer_logic::create_transaction_change;
+#[cfg(feature = "experimental")]
+use crate::MultiSigWalletClient;
 use crate::{
-    InputSelectionStrategy, Mnemonic, MultiSigWalletClient, UnspentTransactions, WalletClient,
-    WalletTransactionBuilder,
+    InputSelectionStrategy, Mnemonic, UnspentTransactions, WalletClient, WalletTransactionBuilder,
 };
 use bit_vec::BitVec;
 use chain_core::common::{Proof, H256};
@@ -21,20 +22,26 @@ use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::input::{str2txid, TxoPointer};
 use chain_core::tx::data::output::TxOut;
-use chain_core::tx::data::{Tx, TxId};
+#[cfg(feature = "experimental")]
+use chain_core::tx::data::Tx;
+use chain_core::tx::data::TxId;
 use chain_core::tx::fee::Fee;
 use chain_core::tx::witness::tree::RawXOnlyPubkey;
+#[cfg(feature = "experimental")]
 use chain_core::tx::witness::{TxInWitness, TxWitness};
 use chain_core::tx::{TransactionId, TxAux, TxEnclaveAux, TxObfuscated};
 use client_common::tendermint::types::Time;
 use client_common::tendermint::types::{AbciQueryExt, BlockResults, BroadcastTxResponse};
 use client_common::tendermint::{Client, UnauthorizedClient};
+#[cfg(feature = "experimental")]
+use client_common::SignedTransaction;
 use client_common::{
     seckey::derive_enckey, Error, ErrorKind, MultiSigAddress, PrivateKey, PrivateKeyAction,
-    PublicKey, Result, ResultExt, SecKey, SignedTransaction, Storage, Transaction, TransactionInfo,
+    PublicKey, Result, ResultExt, SecKey, Storage, Transaction, TransactionInfo,
 };
 use indexmap::IndexSet;
 use parity_scale_codec::Encode;
+#[cfg(feature = "experimental")]
 use secp256k1::schnorrsig::SchnorrSignature;
 use secstr::SecUtf8;
 use std::collections::BTreeMap;
@@ -58,6 +65,7 @@ where
     wallet_state_service: WalletStateService<S>,
     sync_state_service: SyncStateService<S>,
     root_hash_service: RootHashService<S>,
+    #[cfg(feature = "experimental")]
     multi_sig_session_service: MultiSigSessionService<S>,
 
     tendermint_client: C,
@@ -86,8 +94,9 @@ where
             wallet_service: WalletService::new(storage.clone()),
             wallet_state_service: WalletStateService::new(storage.clone()),
             sync_state_service: SyncStateService::new(storage.clone()),
-            root_hash_service: RootHashService::new(storage.clone()),
-            multi_sig_session_service: MultiSigSessionService::new(storage),
+            #[cfg(feature = "experimental")]
+            multi_sig_session_service: MultiSigSessionService::new(storage.clone()),
+            root_hash_service: RootHashService::new(storage),
             tendermint_client,
             transaction_builder,
             block_height_ensure,
@@ -1244,6 +1253,7 @@ where
     }
 }
 
+#[cfg(feature = "experimental")]
 impl<S, C, T> MultiSigWalletClient for DefaultWalletClient<S, C, T>
 where
     S: Storage,

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -17,9 +17,9 @@ base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 hex = "0.4.2"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery"] }
 tendermint = { git = "https://github.com/crypto-com/tendermint-rs.git", default-features = false, rev = "e8d350960726b242fdaa67d293d71ba8cfdb8024" }
 
 [dev-dependencies]
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["serde", "zeroize", "rand", "recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["serde", "rand", "recovery", "endomorphism"] }
 test-common = { path = "../test-common" }

--- a/client-rpc/Cargo.toml
+++ b/client-rpc/Cargo.toml
@@ -24,3 +24,4 @@ parity-scale-codec = "1.3"
 
 [features]
 mock-enclave = ["client-common/mock-enclave"]
+experimental = ["client-common/experimental", "client-core/experimental"]

--- a/client-rpc/src/handler.rs
+++ b/client-rpc/src/handler.rs
@@ -12,9 +12,11 @@ use client_core::wallet::syncer::{ObfuscationSyncerConfig, SyncerOptions};
 use client_core::wallet::DefaultWalletClient;
 use client_network::network_ops::DefaultNetworkOpsClient;
 
+#[cfg(feature = "experimental")]
+use crate::rpc::multisig_rpc::{MultiSigRpc, MultiSigRpcImpl};
+
 use crate::rpc::{
     info_rpc::{InfoRpc, InfoRpcImpl},
-    multisig_rpc::{MultiSigRpc, MultiSigRpcImpl},
     staking_rpc::{StakingRpc, StakingRpcImpl},
     sync_rpc::{CBindingCore, SyncRpc, SyncRpcImpl},
     transaction_rpc::{TransactionRpc, TransactionRpcImpl},
@@ -68,6 +70,7 @@ impl RpcHandler {
             sync_options,
         );
 
+        #[cfg(feature = "experimental")]
         let multisig_rpc = MultiSigRpcImpl::new(wallet_client.clone());
         let transaction_rpc = TransactionRpcImpl::new(network_id);
         let staking_rpc =
@@ -80,6 +83,7 @@ impl RpcHandler {
         let sync_rpc = SyncRpcImpl::new(syncer_config, progress_callback, sync_wallet_client);
         let wallet_rpc = WalletRpcImpl::new(wallet_client, network_id);
 
+        #[cfg(feature = "experimental")]
         io.extend_with(multisig_rpc.to_delegate());
         io.extend_with(transaction_rpc.to_delegate());
         io.extend_with(staking_rpc.to_delegate());

--- a/client-rpc/src/rpc.rs
+++ b/client-rpc/src/rpc.rs
@@ -1,4 +1,5 @@
 pub mod info_rpc;
+#[cfg(feature = "experimental")]
 pub mod multisig_rpc;
 pub mod staking_rpc;
 pub mod sync_rpc;

--- a/client-rpc/src/rpc/staking_rpc.rs
+++ b/client-rpc/src/rpc/staking_rpc.rs
@@ -17,7 +17,7 @@ use chain_core::tx::data::input::TxoPointer;
 use chain_core::tx::data::output::TxOut;
 use client_common::{Error, ErrorKind, PublicKey, Result as CommonResult, ResultExt, Transaction};
 use client_core::wallet::WalletRequest;
-use client_core::{MultiSigWalletClient, WalletClient};
+use client_core::WalletClient;
 use client_network::NetworkOpsClient;
 
 #[rpc(server)]
@@ -98,7 +98,7 @@ where
 
 impl<T, N> StakingRpc for StakingRpcImpl<T, N>
 where
-    T: WalletClient + MultiSigWalletClient + 'static,
+    T: WalletClient + 'static,
     N: NetworkOpsClient + 'static,
 {
     fn deposit_stake(

--- a/client-rpc/src/rpc/wallet_rpc.rs
+++ b/client-rpc/src/rpc/wallet_rpc.rs
@@ -12,7 +12,9 @@ use client_core::service::WalletInfo;
 use client_core::transaction_builder::SignedTransferTransaction;
 use client_core::types::{TransactionChange, WalletBalance, WalletKind};
 use client_core::wallet::{CreateWalletRequest, WalletRequest};
-use client_core::{Mnemonic, MultiSigWalletClient, UnspentTransactions, WalletClient};
+#[cfg(feature = "experimental")]
+use client_core::MultiSigWalletClient;
+use client_core::{Mnemonic, UnspentTransactions, WalletClient};
 use parity_scale_codec::{Decode, Encode};
 
 use crate::{rpc_error_from_string, to_rpc_error};
@@ -152,7 +154,7 @@ where
 
 impl<T> WalletRpc for WalletRpcImpl<T>
 where
-    T: WalletClient + MultiSigWalletClient + 'static,
+    T: WalletClient + 'static,
 {
     fn balance(&self, request: WalletRequest) -> Result<WalletBalance> {
         self.client

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -22,7 +22,7 @@ client-core = { path = "../client-core" }
 client-network = { path = "../client-network" }
 client-rpc-core = { path = "../client-rpc" }
 secstr = { version = "0.4.0", features = ["serde"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism"] }
 jsonrpc-core = "14.2"
 libc = "0.2.72"
 

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -22,7 +22,7 @@ dirs = "3.0.1"
 quest = "0.3"
 secstr = "0.4.0"
 parity-scale-codec = { version = "1.3" }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
 base64 = "0.12"
 mls = { path = "../chain-tx-enclave-next/mls" }
 ra-client = { path = "../chain-tx-enclave-next/enclave-ra/ra-client" }

--- a/dev-utils/src/commands/test_vector_command.rs
+++ b/dev-utils/src/commands/test_vector_command.rs
@@ -261,6 +261,9 @@ impl VectorFactory {
         let tx = Tx::new_with(inputs.clone(), outputs.clone(), attributes);
         let tx_id = tx.id();
         let proof = TestVectorWallet::gen_proof(public_key)?.unwrap();
+        // FIXME: schnorr sign is non-deterministic
+        // -> test vectors should be deterministic, i.e. use a fixed random payload
+        // and `schnorr_sign_aux`
         let witness: TxWitness = vec![TxInWitness::TreeSig(
             sign_key.schnorr_sign(&Transaction::TransferTransaction(tx.clone()))?,
             proof,

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 
 [features]
 default = ["chain-core/default"]
-edp = ["chain-core/edp", "secp256k1zkp/edp"]
-mesalock_sgx = ["sgx_tstd", "secp256k1zkp/sgx", "chain-core/mesalock_sgx", "chain-tx-validation/mesalock_sgx"]
+edp = ["chain-core/edp", "secp256k1/lowmemory"]
+mesalock_sgx = ["sgx_tstd", "secp256k1/lowmemory", "chain-core/mesalock_sgx", "chain-tx-validation/mesalock_sgx"]
 
 [dependencies]
 chain-core = { path = "../chain-core", default-features = false }
 chain-tx-validation = { path = "../chain-tx-validation", default-features = false }
 parity-scale-codec = { version = "1.3", default-features = false, features = ["derive"] }
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab" }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d" }
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -17,7 +17,7 @@ signature = "1.0.0-pre.1"
 abci = "0.7"
 kvdb-memorydb = "0.7"
 protobuf = "2.7.0"
-secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "f8759809f6e3fed793b37166f7cd91c57cdb2eab", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 base64 = "0.12"
 hex = "0.4"


### PR DESCRIPTION
Solution:
- created a branch off upstream rust-secp256k1
https://github.com/crypto-com/rust-secp256k1-zkp/tree/upstream-catchup
- use the vendor script to update the secp256k1 library from PR to upstream with changes to Schnorr signatures
(the vendor script applies custom patches to have mem allocation in Rust etc.)
- updated the code against the upstream changes
(one notable change is that signing uses "synthentic nonces"
-- https://moderncrypto.org/mail-archive/curves/2017/000925.html
-- so needs some fresh randomness)

NOTE: MuSig hasn't been ported up to the latest upstream changes yet,
so its related functionality is currently disabled
(when required, it can later be fixed and enabled
via "experimental" feature flag)

