### PR TITLE
Problem (Fix #1959): cro-clib don't enable log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "client-core",
  "client-network",
  "client-rpc-core",
+ "env_logger",
  "hex 0.4.2",
  "jsonrpc-core",
  "libc",

--- a/chain-tx-enclave-next/mls/src/group.rs
+++ b/chain-tx-enclave-next/mls/src/group.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use crate::ciphersuite::*;
 use crate::extensions as ext;
@@ -121,7 +121,7 @@ impl GroupAux {
             sender,
             authenticated_data: vec![],
             content: ContentType::Proposal(Proposal::Remove(Remove {
-                removed: to_remove.0.try_into().unwrap(),
+                removed: to_remove.0,
             })),
         };
         let to_be_signed = MLSPlaintextTBS {

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -25,6 +25,7 @@ secstr = { version = "0.4.0", features = ["serde"] }
 secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism"] }
 jsonrpc-core = "14.2"
 libc = "0.2.72"
+env_logger = "0.7"
 
 [build-dependencies]
 cbindgen = "0.14.3"

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -194,6 +194,9 @@ unsafe fn create_rpc(
     progress_callback_user: CroProgressPtr,
     user_data: *const std::ffi::c_void,
 ) -> Result<CroJsonRpc> {
+    // `try_init` only returns `Err` if already initialized, `create_rpc` can be called multiple times,
+    // so we ignore the error
+    let _ = env_logger::try_init();
     let storage_dir = get_string(storage_dir);
     let websocket_url = get_string(websocket_url);
     let cbindingcallback: Option<CBindingCore> = if !progress_callback_user.is_null() {


### PR DESCRIPTION
Solution:
- initialize env_logger

Maybe better to make it into an option, but currently the only use case is the integration tests, so I guess it's good so far.