### PR TITLE
Problem: no runner for EDP-based tx-validation (fixes #1950)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ steps:
   - export CARGO_TARGET_DIR=/tmp
   - LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service --no-daemon &
   - make -C chain-tx-enclave/tx-validation
-  - cargo build --features sgx-test --manifest-path chain-abci/Cargo.toml
+  - cargo build --no-default-features --features sgx-test --manifest-path chain-abci/Cargo.toml
   - cd $CARGO_TARGET_DIR/debug
   - ./chain-abci
 
@@ -134,6 +134,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 6805b3eb9f8dc619bbca037606e8cd92f6f29105c586f87e4bba3887cb32165d
+hmac: c9c3f16777a662d40c823a00420fd7a764ffa09bf58643e663b4251a19850798
 
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,10 @@ rust: &rust
     - SGX_MODE=SW
     - NETWORK_ID=ab
   before_install: # versions from https://github.com/erickt/rust-zmq/blob/master/.travis.yml
-    - ./ci-scripts/install_sgxsdk.sh
+    - |
+      if [[ "$TRAVIS_RUST_VERSION" != nightly ]]; then
+        sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\"\]/" chain-abci/Cargo.toml;
+      fi
     - |
       if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
         ./ci-scripts/install_kcov.sh 
@@ -82,9 +85,13 @@ rust: &rust
       # a small hack, as kcov doesn't have an option to only build default members
       sed 's/"chain-tx-enclave\//#"chain-tx-enclave\//g' -i Cargo.toml;
       # more hacks for kcov :(
-      sed 's/default = \[\]/default = \["mock-enclave"\]/g' -i chain-abci/Cargo.toml;
-      sed 's/sgx/#sgx/g' -i chain-abci/Cargo.toml;
-      sed 's/enclave-u-common/#enclave-u-common/g' -i chain-abci/Cargo.toml;
+      # sed 's/default = \[\]/default = \["mock-enclave"\]/g' -i chain-abci/Cargo.toml;
+      # sed 's/sgx/#sgx/g' -i chain-abci/Cargo.toml;
+      sed 's/legacy/#legacy/g' -i chain-abci/Cargo.toml;
+      sed 's/enclave-u-common =/#enclave-u-common =/g' -i chain-abci/Cargo.toml;
+      sed 's/sgx_types =/#sgx_types =/g' -i chain-abci/Cargo.toml;
+      sed 's/sgx_urts =/#sgx_urts =/g' -i chain-abci/Cargo.toml;
+      
       sed 's/CARGO/_CARGO/g' -i chain-abci/build.rs;
 
       travis_wait 30 cargo kcov --all;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ name = "chain-abci"
 version = "0.6.0"
 dependencies = [
  "abci",
+ "aesm-client",
  "base64 0.12.3",
  "bit-vec",
  "byteorder",
@@ -536,6 +537,7 @@ dependencies = [
  "chain-tx-validation",
  "digest 0.9.0",
  "enclave-protocol",
+ "enclave-runner",
  "enclave-u-common",
  "env_logger",
  "hex 0.4.2",
@@ -557,10 +559,12 @@ dependencies = [
  "serde_yaml",
  "sgx_types",
  "sgx_urts",
+ "sgxs-loaders",
  "sha3",
  "structopt",
  "test-common",
  "thiserror",
+ "tokio 0.2.20",
  "vergen",
  "zmq",
 ]

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -7,9 +7,11 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = []
-sgx-test = []
+default = ["edp"]
+sgx-test = ["legacy"]
 mock-enclave = []
+edp = ["aesm-client", "enclave-runner", "sgxs-loaders", "tokio"]
+legacy = ["enclave-u-common", "sgx_types", "sgx_urts"]
 
 [dependencies]
 abci = "0.7"
@@ -21,6 +23,11 @@ enclave-protocol = { path = "../enclave-protocol" }
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
 mls = { path = "../chain-tx-enclave-next/mls" }
 ra-client = { path = "../chain-tx-enclave-next/enclave-ra/ra-client" }
+
+aesm-client = {version = "0.5", features = ["sgxs"], optional = true }
+enclave-runner = {version = "0.4", optional = true}
+sgxs-loaders = {version = "0.2", optional = true}
+tokio = { version = "0.2", optional = true }
 
 log = "0.4.11"
 env_logger = "0.7.1"
@@ -39,9 +46,9 @@ parity-scale-codec = { features = ["derive"], version = "1.3" }
 thiserror = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-enclave-u-common = { path = "../chain-tx-enclave/enclave-u-common" }
-sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+enclave-u-common = { path = "../chain-tx-enclave/enclave-u-common", optional = true }
+sgx_types = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_urts = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 zmq = "0.9"
 rand = "0.7"
 

--- a/chain-abci/src/app/commit.rs
+++ b/chain-abci/src/app/commit.rs
@@ -74,7 +74,7 @@ fn process_txs(delivered_txs: &[TxAux], db: &mut impl StoreKV) {
     }
 }
 
-impl<T: EnclaveProxy> ChainNodeApp<T> {
+impl<T: EnclaveProxy + 'static> ChainNodeApp<T> {
     /// Commits delivered TX: flushes updates to the underlying storage
     pub fn commit_handler(&mut self, _req: &RequestCommit) -> ResponseCommit {
         let new_state = self.last_state.as_mut().expect("executing block commit, but no app state stored (i.e. no initchain or recovery was executed)");

--- a/chain-abci/src/app/end_block.rs
+++ b/chain-abci/src/app/end_block.rs
@@ -7,7 +7,7 @@ use chain_core::common::TendermintEventType;
 use chain_tx_filter::BlockFilter;
 use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponseOk};
 
-impl<T: EnclaveProxy> ChainNodeApp<T> {
+impl<T: EnclaveProxy + 'static> ChainNodeApp<T> {
     /// tags the block with the transaction filter + computes validator set changes
     pub fn end_block_handler(&mut self, req: &RequestEndBlock) -> ResponseEndBlock {
         let mut resp = ResponseEndBlock::new();

--- a/chain-abci/src/app/mod.rs
+++ b/chain-abci/src/app/mod.rs
@@ -60,7 +60,7 @@ impl<'a> BeginBlockInfo<'a> {
 }
 
 /// TODO: sanity checks in abci https://github.com/tendermint/rust-abci/issues/49
-impl<T: EnclaveProxy> abci::Application for ChainNodeApp<T> {
+impl<T: EnclaveProxy + 'static> abci::Application for ChainNodeApp<T> {
     /// Query Connection: Called on startup from Tendermint.  The application should normally
     /// return the last know state so Tendermint can determine if it needs to replay blocks
     /// to the application.

--- a/chain-abci/src/app/query.rs
+++ b/chain-abci/src/app/query.rs
@@ -33,7 +33,7 @@ fn get_key(resp: &mut ResponseQuery, data_key: &[u8]) -> Option<H256> {
     }
 }
 
-impl<T: EnclaveProxy> ChainNodeApp<T> {
+impl<T: EnclaveProxy + 'static> ChainNodeApp<T> {
     fn lookup_key(
         &self,
         resp: &mut ResponseQuery,

--- a/chain-abci/src/app/rewards.rs
+++ b/chain-abci/src/app/rewards.rs
@@ -17,7 +17,7 @@ fn mul_micro(n: u64, rate: u64) -> u64 {
 
 pub type RewardsDistribution = Vec<(StakedStateAddress, Coin)>;
 
-impl<T: EnclaveProxy> ChainNodeApp<T> {
+impl<T: EnclaveProxy + 'static> ChainNodeApp<T> {
     /// Distribute rewards pool
     pub fn rewards_try_distribute(&mut self) -> Option<(RewardsDistribution, Coin)> {
         let state = self.last_state.as_mut().unwrap();

--- a/chain-abci/src/app/validate_tx.rs
+++ b/chain-abci/src/app/validate_tx.rs
@@ -60,7 +60,7 @@ impl ResponseWithCodeAndLog for ResponseDeliverTx {
     }
 }
 
-impl<T: EnclaveProxy> ChainNodeApp<T> {
+impl<T: EnclaveProxy + 'static> ChainNodeApp<T> {
     pub fn process_tx(
         &mut self,
         req: &impl RequestWithTx,

--- a/chain-abci/src/enclave_bridge/edp/mod.rs
+++ b/chain-abci/src/enclave_bridge/edp/mod.rs
@@ -1,0 +1,224 @@
+mod server;
+
+use crate::enclave_bridge::EnclaveProxy;
+use aesm_client::AesmClient;
+use chain_storage::ReadOnlyStorage;
+use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponse};
+use enclave_runner::{
+    usercalls::{AsyncStream, UsercallExtension},
+    EnclaveBuilder,
+};
+use parity_scale_codec::{Decode, Encode};
+use sgxs_loaders::isgx::Device;
+use std::io::{Cursor, Read};
+use std::sync::{mpsc::channel, mpsc::Receiver, mpsc::Sender, Arc, Mutex};
+use std::thread::{self};
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Internal type for communicating with EDP-based tx-validation enclave
+#[derive(Debug)]
+pub struct TxValidationStream {
+    /// contains the serialize request
+    reader: Cursor<Vec<u8>>,
+    /// for replying back with the response
+    request_processed: Sender<IntraEnclaveResponse>,
+}
+
+impl TxValidationStream {
+    /// start with a channel to send back responses
+    pub fn new(request_processed: Sender<IntraEnclaveResponse>) -> Self {
+        Self {
+            reader: Default::default(),
+            request_processed,
+        }
+    }
+
+    /// only 1 at a time can push the request (locked outside)
+    pub fn push_request(&mut self, request: IntraEnclaveRequest) {
+        let avail = self.reader.get_ref().len();
+        if self.reader.position() == avail as u64 {
+            self.reader = Default::default();
+        }
+        self.reader.get_mut().extend(&request.encode());
+    }
+}
+
+/// multi-thread wrapper around `TxValidationStream`.
+/// Currently, at least 3 threads are accessing it:
+/// 1) chain-abci main thread (pushing requests when check/delivertx)
+/// 2) zmq server -- temporarily -- pushes requests received from tx-query
+/// 3) enclave runner -- passes requests/responses via async streams
+/// from/to tx-validation enclave
+#[derive(Debug, Clone)]
+pub struct TxValidationAsyncStream {
+    stream: Arc<Mutex<TxValidationStream>>,
+}
+
+impl TxValidationAsyncStream {
+    pub fn new(request_processed: Sender<IntraEnclaveResponse>) -> Self {
+        Self {
+            stream: Arc::new(Mutex::new(TxValidationStream::new(request_processed))),
+        }
+    }
+}
+
+impl AsyncRead for TxValidationAsyncStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        // the locking should not block for too long -- this either succeeds and goes through
+        // or wait for `TxValidationApp` to push the request (it releases the lock
+        // once it pushes it)
+        let mut stream = self.stream.lock().expect("lock for stream -- async read");
+        let r = stream.reader.read(buf);
+        Poll::Ready(r)
+    }
+}
+
+impl AsyncWrite for TxValidationAsyncStream {
+    fn poll_write(self: Pin<&mut Self>, _cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+        // the locking should not block --
+        // at the moment, tx-validation enclave shouldn't
+        // be executed on several threads and `TxValidationApp` won't hold the lock
+        // as it releases it and waits for `send` here
+        let stream = self.stream.lock().expect("lock for stream -- async write");
+        let resp = IntraEnclaveResponse::decode(&mut buf.as_ref())
+            .expect("enclave writes valid responses");
+        if let Err(e) = stream.request_processed.send(resp) {
+            log::warn!("receiver dropped: {:?}", e);
+            Poll::Ready(Err(std::io::ErrorKind::Other.into()))
+        } else {
+            Poll::Ready(Ok(buf.len()))
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TxValidationApp {
+    inner: TxValidationAsyncStream,
+    rx: Arc<Mutex<Receiver<IntraEnclaveResponse>>>,
+}
+
+impl Default for TxValidationApp {
+    fn default() -> Self {
+        let (tx, rx) = channel();
+        TxValidationApp {
+            inner: TxValidationAsyncStream::new(tx),
+            rx: Arc::new(Mutex::new(rx)),
+        }
+    }
+}
+
+/// It launches a ZMQ server that can server tx-query requests;
+/// (used to be in a separate process -- tx-validation-app that had a custom storage;
+/// now it's in a thread of chain-abci and shares its storage)
+pub fn start_zmq<T: EnclaveProxy + 'static>(
+    proxy: T,
+    zmq_conn_str: &str,
+    network_id: u8,
+    storage: ReadOnlyStorage,
+) -> thread::JoinHandle<()> {
+    let (sender, receiver) = channel();
+    let mut server =
+        server::TxValidationServer::new(zmq_conn_str, proxy, storage, network_id, sender)
+            .expect("could not start a zmq server");
+    log::info!("starting zmq server");
+    let child_t = thread::spawn(move || server.execute());
+    receiver.recv().unwrap();
+    child_t
+}
+
+type UserCallStream = io::Result<Option<Box<dyn AsyncStream>>>;
+
+impl UsercallExtension for TxValidationApp {
+    fn connect_stream<'future>(
+        &'future self,
+        addr: &'future str,
+        _local_addr: Option<&'future mut String>,
+        _peer_addr: Option<&'future mut String>,
+    ) -> Pin<Box<dyn Future<Output = UserCallStream> + 'future>> {
+        async fn connect_stream_inner(
+            stream: TxValidationAsyncStream,
+            addr: &str,
+        ) -> UserCallStream {
+            match addr {
+                "chain-abci" => Ok(Some(Box::new(stream))),
+                _ => Ok(None),
+            }
+        }
+
+        Box::pin(connect_stream_inner(self.inner.clone(), addr))
+    }
+}
+
+impl EnclaveProxy for TxValidationApp {
+    fn check_chain(&mut self, network_id: u8) -> Result<(), ()> {
+        self.process_request(IntraEnclaveRequest::InitChainCheck(network_id))
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    fn process_request(&mut self, request: IntraEnclaveRequest) -> IntraEnclaveResponse {
+        // this lock prevents zmq server + chain-abci to submit requests at the same time
+        // as the zmq is temporary, this can later be removed
+        // (and perhaps use some channel that implements both Sync + Send, unlike mpsc)
+        let rx = self.rx.lock().expect("lock for reply");
+        {
+            let mut stream = self.inner.stream.lock().expect("lock for stream -- proxy");
+            stream.push_request(request);
+            // release the lock for `UsercallExtension` processing in async streams
+            // the explicit drop should not be necessary, but here just for sanity
+            drop(stream);
+        }
+        match rx.recv() {
+            Ok(response) => response,
+            Err(e) => {
+                log::warn!("the sender dropped {:?}", e);
+                Err(chain_tx_validation::Error::EnclaveRejected)
+            }
+        }
+    }
+}
+
+/// Launches tx-validation enclave --
+/// it expects "tx-validation-next.sgxs" (+ signature)
+/// to be in the same directory as chain-abci
+pub fn launch_tx_validation() -> TxValidationApp {
+    let app = TxValidationApp::default();
+    let app2 = app.clone();
+    let mut device = Device::new()
+        .expect("SGX device was not found")
+        .einittoken_provider(AesmClient::new())
+        .build();
+    let enclave_path = "tx-validation-next.sgxs";
+    let mut enclave_builder = EnclaveBuilder::new(enclave_path.as_ref());
+    enclave_builder
+        .coresident_signature()
+        .expect("Enclave signature file not found");
+
+    enclave_builder.usercall_extension(app);
+    let enclave = enclave_builder
+        .build(&mut device)
+        .expect("Failed to build enclave");
+    thread::spawn(|| {
+        log::info!("starting tx validation enclave");
+        enclave.run().expect("Failed to start enclave")
+    });
+    app2
+}

--- a/chain-abci/src/enclave_bridge/edp/server.rs
+++ b/chain-abci/src/enclave_bridge/edp/server.rs
@@ -1,0 +1,156 @@
+use crate::app::ChainNodeState;
+use crate::enclave_bridge::EnclaveProxy;
+use chain_core::state::account::StakedState;
+use chain_core::state::account::StakedStateOpWitness;
+use chain_core::tx::data::TxId;
+use chain_storage::buffer::Get;
+use chain_storage::jellyfish::StakingGetter;
+use chain_storage::ReadOnlyStorage;
+use chain_tx_validation::witness::verify_tx_recover_address;
+use chain_tx_validation::ChainInfo;
+use enclave_protocol::IntraEnclaveRequest;
+use enclave_protocol::{
+    EnclaveRequest, EnclaveResponse, IntraEnclaveResponseOk, IntraEncryptRequest, FLAGS,
+};
+use parity_scale_codec::{Decode, Encode};
+use std::sync::mpsc::Sender;
+use zmq::{Context, Error, Socket, REP};
+
+pub struct TxValidationServer<T: EnclaveProxy> {
+    socket: Socket,
+    enclave: T,
+    storage: ReadOnlyStorage,
+    network_id: u8,
+    start_signal: Sender<()>,
+}
+
+impl<T: EnclaveProxy> TxValidationServer<T> {
+    pub fn new(
+        connection_str: &str,
+        enclave: T,
+        storage: ReadOnlyStorage,
+        network_id: u8,
+        start_signal: Sender<()>,
+    ) -> Result<TxValidationServer<T>, Error> {
+        let ctx = Context::new();
+        let socket = ctx.socket(REP)?;
+        socket.bind(connection_str)?;
+
+        Ok(TxValidationServer {
+            socket,
+            enclave,
+            storage,
+            network_id,
+            start_signal,
+        })
+    }
+
+    fn lookup_txids<I>(&self, inputs: I) -> Option<Vec<Vec<u8>>>
+    where
+        I: IntoIterator<Item = TxId> + ExactSizeIterator,
+    {
+        let mut result = Vec::with_capacity(inputs.len());
+        for input in inputs.into_iter() {
+            if let Some(txin) = self.storage.get_sealed_log(&input) {
+                result.push(txin);
+            } else {
+                return None;
+            }
+        }
+        Some(result)
+    }
+
+    fn lookup_state(
+        &self,
+        txid: &TxId,
+        sig: &StakedStateOpWitness,
+        last_version: u64,
+    ) -> Option<StakedState> {
+        let account_getter = StakingGetter::new(&self.storage, last_version);
+        let address = verify_tx_recover_address(sig, txid).ok()?;
+        account_getter.get(&address)
+    }
+
+    pub fn execute(&mut self) {
+        log::info!("running zmq server");
+        self.start_signal.send(()).unwrap();
+        loop {
+            if let Ok(msg) = self.socket.recv_bytes(FLAGS) {
+                log::debug!("received a message");
+                let mcmd = EnclaveRequest::decode(&mut msg.as_slice());
+                let resp = match mcmd {
+                    Ok(EnclaveRequest::GetSealedTxData { txids }) => {
+                        EnclaveResponse::GetSealedTxData(self.lookup_txids(txids.iter().copied()))
+                    }
+                    Ok(EnclaveRequest::EncryptTx(req)) => {
+                        let result = {
+                            let tx_inputs = match req.tx_inputs {
+                                Some(inputs) => self.lookup_txids(inputs.iter().map(|x| x.id)),
+                                _ => None,
+                            };
+                            match self.storage.get_last_app_state() {
+                                Some(state) => {
+                                    let last_state = ChainNodeState::decode(&mut state.as_slice())
+                                        .expect("deserialize app state");
+                                    let account = match req.op_sig {
+                                        Some(sig) => self.lookup_state(
+                                            &req.txid,
+                                            &sig,
+                                            last_state.staking_version,
+                                        ),
+                                        _ => None,
+                                    };
+                                    // TODO: fee in enclave?
+
+                                    let min_fee = last_state
+                                        .top_level
+                                        .network_params
+                                        .calculate_fee(req.tx_size as usize)
+                                        .expect("valid fee");
+                                    let info = ChainInfo {
+                                        min_fee_computed: min_fee,
+                                        chain_hex_id: self.network_id,
+                                        block_time: last_state.block_time,
+                                        block_height: last_state.block_height,
+                                        max_evidence_age: last_state.max_evidence_age,
+                                    };
+                                    let request = IntraEncryptRequest {
+                                        txid: req.txid,
+                                        sealed_enc_request: req.sealed_enc_request,
+                                        tx_inputs,
+                                        info,
+                                        account,
+                                    };
+                                    let response = self.enclave.process_request(
+                                        IntraEnclaveRequest::Encrypt(Box::new(request)),
+                                    );
+                                    match response {
+                                        Ok(IntraEnclaveResponseOk::Encrypt(obftx)) => Ok(obftx),
+                                        Ok(_) => {
+                                            log::error!("unexpected response");
+                                            Err(chain_tx_validation::Error::EnclaveRejected)
+                                        }
+                                        Err(e) => Err(e),
+                                    }
+                                }
+                                None => {
+                                    log::error!("can not find last app state");
+                                    Err(chain_tx_validation::Error::EnclaveRejected)
+                                }
+                            }
+                        };
+                        EnclaveResponse::EncryptTx(result)
+                    }
+                    Err(e) => {
+                        log::error!("unknown request / failed to decode: {}", e);
+                        EnclaveResponse::UnknownRequest
+                    }
+                };
+                let response = resp.encode();
+                self.socket
+                    .send(response, FLAGS)
+                    .expect("reply sending failed");
+            }
+        }
+    }
+}

--- a/chain-abci/src/enclave_bridge/mod.rs
+++ b/chain-abci/src/enclave_bridge/mod.rs
@@ -3,12 +3,15 @@ use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponse};
 /// TODO: feature-guard when workspaces can be built with --features flag: https://github.com/rust-lang/cargo/issues/5015
 pub mod mock;
 
-#[cfg(all(not(feature = "mock-enclave"), target_os = "linux"))]
+#[cfg(all(not(feature = "mock-enclave"), feature = "legacy", target_os = "linux"))]
 pub mod real;
 
+#[cfg(feature = "edp")]
+pub mod edp;
+
 /// Abstracts over communication with an external part that does enclave calls
-pub trait EnclaveProxy: Sync + Send + Sized {
+pub trait EnclaveProxy: Sync + Send + Sized + Clone {
     // sanity check for checking enclave initialization
-    fn check_chain(&self, network_id: u8) -> Result<(), ()>;
+    fn check_chain(&mut self, network_id: u8) -> Result<(), ()>;
     fn process_request(&mut self, request: IntraEnclaveRequest) -> IntraEnclaveResponse;
 }

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module/obfuscate.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module/obfuscate.rs
@@ -27,7 +27,7 @@ const MOCK_KEY: [u8; 16] = mock_key!();
 pub(crate) fn encrypt(tx: TxToObfuscate) -> TxObfuscated {
     let init_vector: [u8; 12] = rand::random();
     let key = GenericArray::clone_from_slice(&MOCK_KEY);
-    let aead = Aes128GcmSiv::new(key);
+    let aead = Aes128GcmSiv::new(&key);
     let nonce = GenericArray::from_slice(&init_vector);
     let ciphertext = aead.encrypt(nonce, &tx).expect("encryption failure!");
     TxObfuscated {
@@ -40,7 +40,7 @@ pub(crate) fn encrypt(tx: TxToObfuscate) -> TxObfuscated {
 
 pub(crate) fn decrypt(tx: &TxObfuscated) -> Result<PlainTxAux, ()> {
     let key = GenericArray::clone_from_slice(&MOCK_KEY);
-    let aead = Aes128GcmSiv::new(key);
+    let aead = Aes128GcmSiv::new(&key);
     let nonce = GenericArray::from_slice(&tx.init_vector);
     let plaintext = aead.decrypt(nonce, tx).map_err(|_| ())?;
     let result = PlainTxAux::decode(&mut plaintext.as_slice());

--- a/chain-tx-enclave/tx-validation/enclave/src/lib.rs
+++ b/chain-tx-enclave/tx-validation/enclave/src/lib.rs
@@ -42,6 +42,7 @@ pub unsafe extern "C" fn ecall_check_tx(
 ) -> sgx_status_t {
     let mut tx_request_slice = slice::from_raw_parts(tx_request, tx_request_len);
     match IntraEnclaveRequest::decode(&mut tx_request_slice) {
+        Ok(IntraEnclaveRequest::InitChainCheck(network_id)) => ecall_initchain(network_id),
         Ok(IntraEnclaveRequest::ValidateTx { request, tx_inputs }) => {
             validate::handle_validate_tx(request, tx_inputs, response_buf, response_len)
         }

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -57,6 +57,10 @@ if [ $BUILD_MODE == "sgx" ]; then
     RUSTFLAGS="-Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3,+pclmul" cargo build --target x86_64-fortanix-unknown-sgx --package tdb-enclave-app
     ftxsgx-elf2sgxs $EDP_TARGET_DIR/tdb-enclave-app --heap-size 0x2000000 --stack-size 0x80000 --threads 6 $EDP_ARGS
     sgxs-sign --key chain-tx-enclave/tx-validation/enclave/Enclave_private.pem $EDP_TARGET_DIR/tdb-enclave-app.sgxs $EDP_TARGET_DIR/tdb-enclave-app.sig -d --xfrm 7/0 --isvprodid 0 --isvsvn 0
+    # tx-validation enclave
+    RUSTFLAGS="-Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3,+pclmul,+sha" cargo build --target x86_64-fortanix-unknown-sgx --package tx-validation-next
+    ftxsgx-elf2sgxs $EDP_TARGET_DIR/tx-validation-next --heap-size 0x20000000 --stack-size 0x40000 --threads 2 $EDP_ARGS
+    sgxs-sign --key chain-tx-enclave/tx-validation/enclave/Enclave_private.pem $EDP_TARGET_DIR/tx-validation-next.sgxs $EDP_TARGET_DIR/tx-validation-next.sig -d --xfrm 7/0 --isvprodid 0 --isvsvn 0
 
 else
     cargo build $CARGO_ARGS --features mock-enclave --manifest-path client-rpc/server/Cargo.toml

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -63,6 +63,7 @@ pub struct IntraEncryptRequest {
 /// variable length request passed to the tx-validation enclave
 #[derive(Encode, Decode)]
 pub enum IntraEnclaveRequest {
+    InitChainCheck(u8),
     ValidateTx {
         request: Box<VerifyTxRequest>,
         tx_inputs: Option<Vec<SealedLog>>,
@@ -142,6 +143,8 @@ pub fn is_basic_valid_tx_request(
 /// positive response from the enclave
 #[derive(Encode, Decode)]
 pub enum IntraEnclaveResponseOk {
+    /// if the the network id matched
+    InitChainCheck,
     /// returns the actual paid fee + transaction data sealed for the local machine for later lookups
     TxWithOutputs { paid_fee: Fee, sealed_tx: SealedLog },
     /// deposit stake pays minimal fee, so this returns the sum of input amounts -- staked stake's bonded balance is added `input_coins-min_fee`

--- a/integration-tests/cleanup.sh
+++ b/integration-tests/cleanup.sh
@@ -26,6 +26,12 @@ fi
 if [ -L tdb-enclave-app.sig ]; then
     rm -f tdb-enclave-app.sig
 fi
+if [ -L tx-validation-next.sgxs ]; then
+    rm -f tx-validation-next.sgxs
+fi
+if [ -L tx-validation-next.sig ]; then
+    rm -f tx-validation-next.sig
+fi
 if [ -L tx_validation_enclave.signed.so ]; then
     rm -f tx_validation_enclave.signed.so
 fi

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -20,6 +20,8 @@ ln -sf $EDP_TARGET_DIR/tx-query2-enclave-app.sgxs .
 ln -sf $EDP_TARGET_DIR/tx-query2-enclave-app.sig .
 ln -sf $EDP_TARGET_DIR/tdb-enclave-app.sgxs .
 ln -sf $EDP_TARGET_DIR/tdb-enclave-app.sig .
+ln -sf $EDP_TARGET_DIR/tx-validation-next.sgxs .
+ln -sf $EDP_TARGET_DIR/tx-validation-next.sig .
 export PATH=$CARGO_TARGET_DIR/$BUILD_PROFILE:$PATH
 
 if [ $BUILD_MODE == "sgx" ]; then

--- a/integration-tests/run_multinode.sh
+++ b/integration-tests/run_multinode.sh
@@ -20,6 +20,8 @@ ln -sf $EDP_TARGET_DIR/tx-query2-enclave-app.sgxs .
 ln -sf $EDP_TARGET_DIR/tx-query2-enclave-app.sig .
 ln -sf $EDP_TARGET_DIR/tdb-enclave-app.sgxs .
 ln -sf $EDP_TARGET_DIR/tdb-enclave-app.sig .
+ln -sf $EDP_TARGET_DIR/tx-validation-next.sgxs .
+ln -sf $EDP_TARGET_DIR/tx-validation-next.sig .
 export PATH=$CARGO_TARGET_DIR/$BUILD_PROFILE:$PATH
 
 if [ $BUILD_MODE == "sgx" ]; then


### PR DESCRIPTION
Solution:
- added a basic req-rep runner writing/reading from two vectors
-- it's using std::sync::* primitives,
because EnclaveProxy is synchronous +
for some, it doesn't matter or may even be preferred
(e.g. tokio Mutex isn't preferred if locks are short-lived
and don't cross multiple await points)
- temporary zmq server to faciliate tx-query
-- because of the treading, EnclaveProxy also needed to
accept lifetime of 'static
- one extra variant in the enclave protocol (mainly used for testing)
- old code temporarily hidden under "legacy" flag
- since EDP runner only compiles on nightly,
there's a fix/hack on Travis to exclude EDP

