### PR TITLE
Problem: wallet operations slow down with a large number of addresses (fix #1939)

### DIFF
--- a/client-cli/src/command/wallet_command.rs
+++ b/client-cli/src/command/wallet_command.rs
@@ -270,13 +270,13 @@ impl WalletCommand {
 
         let wallet_info_list: Vec<WalletInfo> = serde_json::from_str(&wallet_info_str)
             .chain(|| (ErrorKind::InvalidInput, "Invalid wallet info list"))?;
-        for wallet_info in wallet_info_list {
+        for mut wallet_info in wallet_info_list {
             let name = wallet_info.name.clone();
             let passphrase = match &wallet_info.passphrase {
                 Some(p) => p.clone(),
                 None => ask_passphrase(Some(&format!("Input passphrase for wallet {}:", name)))?,
             };
-            let enckey = wallet_client.import_wallet(&name, &passphrase, wallet_info);
+            let enckey = wallet_client.import_wallet(&name, &passphrase, &mut wallet_info);
             match enckey {
                 Ok(enckey) => success(&format!(
                     "Authentication token of wallet {}: {}",

--- a/client-core/src/service.rs
+++ b/client-core/src/service.rs
@@ -25,7 +25,7 @@ pub use self::root_hash_service::RootHashService;
 pub use self::sync_state_service::{
     delete_sync_state, load_sync_state, save_sync_state, SyncState, SyncStateService,
 };
-pub use self::wallet_service::{load_wallet, Wallet, WalletInfo, WalletService};
+pub use self::wallet_service::{load_wallet, Wallet, WalletInfo, WalletService, WalletStorageImpl};
 pub use self::wallet_state_service::{
     delete_wallet_state, load_wallet_state, modify_wallet_state, save_wallet_state, WalletState,
     WalletStateService,

--- a/client-core/src/signer/wallet_signer.rs
+++ b/client-core/src/signer/wallet_signer.rs
@@ -24,7 +24,7 @@ where
 
 impl<S> WalletSignerManager<S>
 where
-    S: Storage,
+    S: Storage + 'static,
 {
     /// Create an instance fo wallet signer manager
     pub fn new(storage: S, hw_key_service: HwKeyService) -> Self {
@@ -67,7 +67,7 @@ where
 
 impl<'a, S> WalletSigner<'a, S>
 where
-    S: Storage,
+    S: Storage + 'static,
 {
     /// Create an instance of wallet signer
     pub fn new(
@@ -89,7 +89,7 @@ where
 
 impl<'a, S> Signer for WalletSigner<'a, S>
 where
-    S: Storage,
+    S: Storage + 'static,
 {
     fn schnorr_sign_transaction(
         &self,
@@ -134,7 +134,7 @@ where
 
 impl<'a, S> WalletSigner<'a, S>
 where
-    S: Storage,
+    S: Storage + 'static,
 {
     /// Schnorr signs message with private key corresponding to `self_public_key` in given 1-of-n root hash
     fn schnorr_sign_with_root_hash(

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -42,7 +42,7 @@ where
 
 impl<F, S, O> DefaultWalletTransactionBuilder<S, F, O>
 where
-    S: Storage,
+    S: Storage + 'static,
     F: FeeAlgorithm + Clone,
     O: TransactionObfuscation,
 {
@@ -91,7 +91,7 @@ where
 
 impl<S, F, O> WalletTransactionBuilder for DefaultWalletTransactionBuilder<S, F, O>
 where
-    S: Storage,
+    S: Storage + 'static,
     F: FeeAlgorithm + Clone,
     O: TransactionObfuscation,
 {

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -113,7 +113,7 @@ pub trait WalletClient: Send + Sync {
         &self,
         name: &str,
         passphrase: &SecUtf8,
-        wallet_info: WalletInfo,
+        wallet_info: &mut WalletInfo,
     ) -> Result<SecKey>;
 
     /// Restores a HD wallet from given mnemonic

--- a/client-network/src/network_ops/default_network_ops_client.rs
+++ b/client-network/src/network_ops/default_network_ops_client.rs
@@ -109,7 +109,7 @@ where
 impl<W, S, C, F, E> NetworkOpsClient for DefaultNetworkOpsClient<W, S, C, F, E>
 where
     W: WalletClient,
-    S: Storage,
+    S: Storage + 'static,
     C: Client,
     F: FeeAlgorithm,
     E: TransactionObfuscation,

--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -77,7 +77,7 @@ pub trait SyncRpc: Send + Sync {
 
 pub struct SyncRpcImpl<S, C, O, T, L>
 where
-    S: Storage,
+    S: Storage + 'static,
     C: Client,
     O: TransactionObfuscation,
     T: AddressRecovery,
@@ -126,7 +126,7 @@ fn process_sync<S, C, O, T, L>(
     recover_address: T,
 ) -> Result<()>
 where
-    S: Storage,
+    S: Storage + 'static,
     C: Client,
     O: TransactionObfuscation,
     T: AddressRecovery,


### PR DESCRIPTION
## why?
1. removed temporary transfer, staking addresses storing in Wallet
2. query address to sled-storage directly, which is fast in massive address
3. replace 1:1 compare with db-query

## result which this pr solved
1. in massive addresses(over 4,000,000),
sync and other wallet functions will work as fast as when there are small number of addresses
2. also it will not store addresses in memory, which will save some memory space, also memory copying cost.
3. in a block, which contains a lot of txs, it will work very efficiently.
 
## added proxy apis
to query directly, added WalletStorage to Wallet.
WalletStorage is proxy for the storage using `dyn trait` with Arc+Mutex.

1. staking_addresses_contains -> for query
2. transfer_addresses_contains  -> for query
3. get_public_keys -> for import, export
4. get_roothashes -> for import, export 

