### PR TITLE
Problem: fuzzer fails to compile on the latest master (fixes #1975)

### DIFF
--- a/ci-scripts/Dockerfile.fuzzer
+++ b/ci-scripts/Dockerfile.fuzzer
@@ -2,9 +2,5 @@ FROM rustlang/rust:nightly-stretch
 LABEL maintainer="Crypto.com"
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libzmq3-dev clang && \
+    apt-get install -y --no-install-recommends libzmq3-dev clang protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
-
-RUN wget https://download.01.org/intel-sgx/sgx-linux/2.8/distro/ubuntu16.04-server/sgx_linux_x64_sdk_2.8.100.3.bin && \
-    chmod +x sgx_linux_x64_sdk_2.8.100.3.bin
-RUN echo -e 'no\n/opt' | ./sgx_linux_x64_sdk_2.8.100.3.bin


### PR DESCRIPTION
Solution: updated the fuzzer dockerfile to include protoc
