### PR TITLE
Problem:no option for disabling light client (fix #2012)

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -209,6 +209,12 @@ pub enum Command {
         )]
         enable_fast_forward: bool,
         #[structopt(
+            name = "disable-light-client",
+            long,
+            help = "Disable light client, which is not secure when connecting to outside nodes"
+        )]
+        disable_light_client: bool,
+        #[structopt(
             name = "disable-address-recovery",
             long,
             help = "Disable address recovery, which is not necessary, if addresses already exist"
@@ -382,6 +388,7 @@ impl Command {
                 batch_size,
                 force,
                 enable_fast_forward,
+                disable_light_client,
                 disable_address_recovery,
                 block_height_ensure,
             } => {
@@ -403,6 +410,7 @@ impl Command {
                     tx_obfuscation,
                     SyncerOptions {
                         enable_fast_forward: *enable_fast_forward,
+                        disable_light_client: *disable_light_client,
                         enable_address_recovery: !*disable_address_recovery,
                         batch_size: *batch_size,
                         block_height_ensure: *block_height_ensure,

--- a/client-core/src/wallet/syncer.rs
+++ b/client-core/src/wallet/syncer.rs
@@ -109,6 +109,7 @@ impl<O: TransactionObfuscation> TxDecryptor for TxObfuscationDecryptor<O> {
 #[derive(Clone, Debug)]
 pub struct SyncerOptions {
     pub enable_fast_forward: bool,
+    pub disable_light_client: bool,
     pub enable_address_recovery: bool,
     pub batch_size: usize,
     pub block_height_ensure: u64,
@@ -449,8 +450,9 @@ impl<
         }
 
         let (target_height, target_app_hash, target_block_hash) =
-            if self.env.options.enable_fast_forward {
+            if self.env.options.enable_fast_forward || self.env.options.disable_light_client {
                 (
+                    /* use Tendermint RPC directly */
                     status.sync_info.latest_block_height.value(),
                     status
                         .sync_info
@@ -464,6 +466,7 @@ impl<
                         .unwrap_or_default(),
                 )
             } else {
+                /* use light client */
                 let light_block = self
                     .env
                     .light_client
@@ -1019,6 +1022,7 @@ mod tests {
                 light_client,
                 options: SyncerOptions {
                     enable_fast_forward,
+                    disable_light_client: enable_fast_forward,
                     enable_address_recovery: false,
                     batch_size: 20,
                     block_height_ensure: 50,
@@ -1141,6 +1145,7 @@ mod tests {
                 light_client,
                 options: SyncerOptions {
                     enable_fast_forward,
+                    disable_light_client: enable_fast_forward,
                     enable_address_recovery: false,
                     batch_size: 20,
                     block_height_ensure: 50,
@@ -1193,6 +1198,7 @@ mod tests {
                 light_client,
                 options: SyncerOptions {
                     enable_fast_forward: false,
+                    disable_light_client: false,
                     enable_address_recovery: true,
                     batch_size: 20,
                     block_height_ensure: 50,
@@ -1252,6 +1258,7 @@ mod tests {
                 light_client,
                 options: SyncerOptions {
                     enable_fast_forward: false,
+                    disable_light_client: false,
                     enable_address_recovery: true,
                     batch_size: 20,
                     block_height_ensure: 50,

--- a/client-rpc/server/src/program.rs
+++ b/client-rpc/server/src/program.rs
@@ -50,13 +50,18 @@ pub struct Options {
         help = "Url for connecting with tendermint websocket RPC"
     )]
     pub websocket_url: String,
-
     #[structopt(
         name = "enable-fast-forward",
         long,
         help = "Enable fast forward when syncing wallet, which is not secure when connecting to outside nodes"
     )]
     pub enable_fast_forward: bool,
+    #[structopt(
+        name = "disable-light-client",
+        long,
+        help = "Disable light client, which is not secure when connecting to outside nodes"
+    )]
+    pub disable_light_client: bool,
     #[structopt(
         name = "disable-address-recovery",
         long,

--- a/client-rpc/server/src/server.rs
+++ b/client-rpc/server/src/server.rs
@@ -32,6 +32,7 @@ impl Server {
             websocket_url: options.websocket_url,
             sync_options: SyncerOptions {
                 enable_fast_forward: options.enable_fast_forward,
+                disable_light_client: options.disable_light_client,
                 enable_address_recovery: !options.disable_address_recovery,
                 batch_size: options.batch_size,
                 block_height_ensure: options.block_height_ensure,

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -216,6 +216,7 @@ unsafe fn create_rpc(
 
     let options = SyncerOptions {
         enable_fast_forward: false,
+        disable_light_client: true,
         enable_address_recovery: true,
         batch_size: 50,
         block_height_ensure: 50,


### PR DESCRIPTION
Solution: add --disable-light-client option to skip `light client`

because need to skip `light client` when fee is zero.
also with zero fee, we cannot use fast forward option.
so this option is necessary.

default is
1. not use fastward
2. use light client check
which is the most safest option