### PR TITLE
Problem: no way for mls member to prove invalid ciphertext (fixes #1797)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb6ba8a681d3a9c48875d277f2b11c81934ad690a60a20bcc4eef500ff68e25d"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.4.0",
  "sha2 0.9.1",
  "signature",
 ]
@@ -1390,6 +1390,15 @@ dependencies = [
  "getrandom",
  "subtle 2.2.3",
  "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.5.0-pre"
+source = "git+https://github.com/RustCrypto/traits?rev=3e7b861581185d7350db3315cd1a99b4c6d382e4#3e7b861581185d7350db3315cd1a99b4c6d382e4"
+dependencies = [
+ "generic-array 0.14.2",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -1951,8 +1960,7 @@ dependencies = [
 [[package]]
 name = "hpke"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae019a029d6f8e7bf67c2c2d0730a17f74610412b9b4c1556ac1b3c93ffa7fec"
+source = "git+https://github.com/crypto-com/rust-hpke.git?rev=25686eb87d2862535b1d5107d74e2ac8bd992bae#25686eb87d2862535b1d5107d74e2ac8bd992bae"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1960,7 +1968,7 @@ dependencies = [
  "chacha20poly1305",
  "digest 0.9.0",
  "hkdf",
- "p256",
+ "p256 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3",
  "sha2 0.9.1",
  "subtle 2.2.3",
@@ -2651,6 +2659,8 @@ dependencies = [
  "hkdf",
  "hpke",
  "nom",
+ "p256 0.3.0 (git+https://github.com/crypto-com/elliptic-curves.git?rev=15df32b45d8395a1e00eeb3873e1266063e1ec53)",
+ "parity-scale-codec",
  "ra-client",
  "ra-enclave",
  "rand 0.7.3",
@@ -2662,6 +2672,7 @@ dependencies = [
  "subtle 2.2.3",
  "thiserror",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]
@@ -2879,10 +2890,19 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.3.0"
+source = "git+https://github.com/crypto-com/elliptic-curves.git?rev=15df32b45d8395a1e00eeb3873e1266063e1ec53#15df32b45d8395a1e00eeb3873e1266063e1ec53"
+dependencies = [
+ "elliptic-curve 0.5.0-pre",
+ "zeroize",
+]
+
+[[package]]
+name = "p256"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a425ecb71515663b2735fd1e65bb638fd134c5ad23857eb197c2f157784476cf"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.4.0",
  "subtle 2.2.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,5 @@ default-members = [
 ring = { git = "https://github.com/crypto-com/ring.git", rev = "bdbcc7041095f028d49d9fecd7edcf26d6083274" }
 # FIXME: use upstream when merged
 sha2 = { git = "https://github.com/crypto-com/hashes.git", rev = "289d5b76f2163a3808010341ed1df3cb156d97e1" }
+# FIXME: before official spec has a solution
+hpke = { git = "https://github.com/crypto-com/rust-hpke.git", rev = "25686eb87d2862535b1d5107d74e2ac8bd992bae" }

--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -22,6 +22,10 @@ chrono="0.4.13"
 ra-client = { path = "../enclave-ra/ra-client" }
 subtle = "2.2.3"
 chain-util = { path = "../../chain-util" }
+# FIXME: use upstream when released
+p256 = { version = "0.3.0", features = ["arithmetic", "zeroize"], git = "https://github.com/crypto-com/elliptic-curves.git", rev = "15df32b45d8395a1e00eeb3873e1266063e1ec53" }
+zeroize = "1.1"
+parity-scale-codec = { features = ["derive"], default-features = false, version = "1.3" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/chain-tx-enclave-next/mls/src/extras/dleq.rs
+++ b/chain-tx-enclave-next/mls/src/extras/dleq.rs
@@ -1,0 +1,395 @@
+use crate::key::{HPKEPrivateKey, HPKEPublicKey};
+use crate::message::HPKECiphertext;
+use hpke::{
+    aead::{AeadTag, AesGcm128},
+    kex::{Marshallable, Unmarshallable},
+    EncappedKey,
+};
+///! Highly experimental implementation of (honest-verifier) NIZK proof
+///! of discrete logarithm equality.
+///!
+///! ref: https://www.chaum.com/publications/Wallet_Databases.pdf
+///! ref: https://blog.cloudflare.com/privacy-pass-the-math/
+///! ref: https://github.com/privacypass/challenge-bypass-server#nizk-proofs-of-discrete-log-equality
+///!
+///! WARNING: highly experimental
+///!
+///! WARNING: meant to work on prime-order EC ops;
+///! *be careful* if this is to be ported to non-prime-order EC ops (e.g. on curve25519)
+///! ref: https://www.shiftleft.org/papers/decaf/decaf.pdf
+///! (see "1.1 Pitfalls of a cofactor")
+use p256::{AffinePoint, ProjectivePoint, Scalar};
+use parity_scale_codec::{Decode, Encode};
+use sha2::{Digest, Sha256};
+use subtle::{ConstantTimeEq, CtOption};
+use zeroize::Zeroize;
+
+/// Information needed by external parties to verify "NACK" claim
+/// FIXME: use the official solution when/if ready in the spec
+#[derive(Encode, Decode)]
+pub struct NackDleqProof {
+    /// the computed "r" value
+    r_response: [u8; 32],
+    /// the intermediate hash
+    c_inter_hash: [u8; 32],
+    /// revealed shared secret; same size as uncompressed pubkey
+    dh: [u8; 65],
+}
+
+impl NackDleqProof {
+    /// decryption directly using the revealed shared secret
+    pub fn decrypt_after_proof(
+        &self,
+        receipient_pk: &HPKEPublicKey,
+        ct: &HPKECiphertext,
+        aad: &[u8],
+    ) -> Result<Vec<u8>, ()> {
+        let encapped_key =
+            EncappedKey::<<hpke::kem::DhP256HkdfSha256 as hpke::kem::Kem>::Kex>::unmarshal(
+                &ct.kem_output,
+            )
+            .map_err(|_| ())?;
+        let shared_secret = hpke::kem::decap_external::<hpke::kem::DhP256HkdfSha256>(
+            &self.dh[..],
+            &receipient_pk.kex_pubkey(),
+            &encapped_key,
+        )
+        .map_err(|_| ())?;
+        let mut context = hpke::setup::derive_receiver_ctx::<
+            AesGcm128,
+            hpke::kdf::HkdfSha256,
+            hpke::kem::DhP256HkdfSha256,
+        >(&hpke::OpModeR::Base, shared_secret, b"");
+        let payload_len = ct.ciphertext.len();
+        let mut payload = ct.ciphertext[0..payload_len - 16].to_vec();
+        let tag_bytes = &ct.ciphertext[payload_len - 16..payload_len];
+        let tag = AeadTag::<AesGcm128>::unmarshal(tag_bytes).map_err(|_| ())?;
+
+        context.open(&mut payload, aad, &tag).map_err(|_| ())?;
+        Ok(payload)
+    }
+
+    /// ref: https://github.com/mlswg/mls-protocol/issues/21#issuecomment-455392023
+    /// in the case that a receiver couldn't get information from Commit/Welcome message
+    /// ciphertext, they can disclose the shared secret and DLEQ proof
+    /// to show others they couldn't receive the information.
+    ///
+    /// WARNING: `kem_output` is assumed to be checked with e.g. https://tools.ietf.org/html/rfc8235
+    /// (i.e. the sender produced some proof of knowledge of the secret value altogether with the ciphertext
+    /// -- the sender secret is currently "hidden" away in HPKE API), so that it's not "tweaked" for compromises
+    ///
+    /// Side-note: before `get_nack_dleq_proof` is called, the assumption is that the caller already _fully verified_
+    /// the Commit message -- e.g. verified that the sender indeed signed it by the valid identity key (remote attested)
+    /// -- so from _the point of the other participants_, "Commit" seemed valid.
+    /// If this happened (i.e. sender managed to post invalid ciphertext), it's either:
+    /// 1) bug in the code here or relevant dependencies
+    /// 2) SGX platform was breached.
+    /// In the latter case, the "worst case" is that past-transaction data could be read by the attacker.
+    /// The attacker could use its node's sealed data instead of tweaking a malformed directpath
+    /// and waiting for NACK of the affected node to be broadcasted (assuming the NACK is valid, it'd also
+    /// expose the attacker and have its node removed.) -- so checking kem_output with rfc8235 may not make a difference here.
+    /// This is assuming no other attacks (beyond compromising historical obfuscated data) are possible
+    /// -- !!!TO BE AUDITED!!!
+    ///
+    /// FIXME: there's a lot of marshalling/unmarshaling due to the current API
+    /// + intermediate / secret value zeroing may not be happening
+    pub fn get_nack_dleq_proof(receiver: &HPKEPrivateKey, kem_output: &[u8]) -> Result<Self, ()> {
+        let encapped_key =
+            <<hpke::kem::DhP256HkdfSha256 as hpke::Kem>::Kex as hpke::KeyExchange>::PublicKey::unmarshal(kem_output).map_err(|_| ())?;
+
+        // assuming `SetupBaseS` / `SetupBaseR` (used in mls spec draft 10)
+        let shared = <<hpke::kem::DhP256HkdfSha256 as hpke::Kem>::Kex as hpke::KeyExchange>::kex(
+            &receiver.kex_secret(),
+            &encapped_key,
+        )
+        .map_err(|_| ())?;
+
+        // gen_g = encapped_key
+        // pub_h = shared
+        // gen_m = base point
+        // pub_z = receiver pubkey
+
+        // no panic: encapped_key is already parsed/validated by hpke::KeyExchange::PublicKey `unmarshal`
+        let g = p256::PublicKey::from_bytes(&encapped_key.marshal()).unwrap();
+        let gen_g = AffinePoint::from_pubkey(&g).unwrap();
+        // no panic: shared is already validated by hpke::KeyExchange `kex`
+        let h = p256::PublicKey::from_bytes(&shared.marshal()).unwrap();
+        let pub_h = AffinePoint::from_pubkey(&h).unwrap();
+        let gen_m = AffinePoint::generator();
+        // no panic: HPKEPrivateKey produces valid pubkey
+        let z = p256::PublicKey::from_bytes(&receiver.public_key().marshal()).unwrap();
+        let pub_z = AffinePoint::from_pubkey(&z).unwrap();
+        // no panic: HPKEPrivateKey is a valid scalar
+        let mut x = Scalar::from_bytes(receiver.marshal_arr_unsafe()).unwrap();
+        let mproof = Proof::new_p256_sha256(gen_g, pub_h, gen_m, pub_z, &x);
+        x.zeroize();
+        let proof = mproof?;
+        let mut dh = [0u8; 65];
+        dh.copy_from_slice(h.as_bytes());
+        Ok(NackDleqProof {
+            r_response: proof.r_response.to_bytes(),
+            c_inter_hash: proof.c_inter_hash.to_bytes(),
+            dh,
+        })
+    }
+
+    /// to be verifier by other parties:
+    /// 1) receiver public key should be known from the keypackage
+    /// 2) `sender_kem_output` should be known from some part of the MLS handshake message
+    /// TODO: message wrapping the proof will need to contain those information
+    /// (i.e. signature with identity key and receiver leaf index +
+    /// reference to the invalid part of Commit or Welcome that the parties can retrieve
+    /// and verify it's invalid by then using the disclosed `dh` to get HPKE context)
+    /// FIXME: there's a lot of marshalling/unmarshaling due to the current API
+    pub fn verify(&self, receiver: &HPKEPublicKey, sender_kem_output: &[u8]) -> Result<(), ()> {
+        let encapped_key =
+            <<hpke::kem::DhP256HkdfSha256 as hpke::Kem>::Kex as hpke::KeyExchange>::PublicKey::unmarshal(sender_kem_output).map_err(|_| ())?;
+        // no panic: encapped_key is already parsed/validated by hpke::KeyExchange::PublicKey `unmarshal`
+        let g = p256::PublicKey::from_bytes(&encapped_key.marshal()).unwrap();
+        let gen_g = AffinePoint::from_pubkey(&g).unwrap();
+        let h = p256::PublicKey::from_bytes(&self.dh[..]).ok_or(())?;
+        let pub_h = AffinePoint::from_pubkey(&h);
+        // no panic: HPKEPublicKey should be valid
+        let z = p256::PublicKey::from_bytes(&receiver.marshal()).unwrap();
+        let pub_z = AffinePoint::from_pubkey(&z).unwrap();
+
+        let r_response = Scalar::from_bytes(self.r_response);
+        let c_inter_hash = Scalar::from_bytes(self.c_inter_hash);
+        let gen_m = AffinePoint::generator();
+
+        // NOTE: these are subtle::Choice, not booleans
+        let error = pub_h.is_none() | r_response.is_none() | c_inter_hash.is_none();
+
+        if error.into() {
+            Err(())
+        } else {
+            let proof = Proof {
+                gen_g,
+                gen_m,
+                pub_h: pub_h.unwrap(),
+                pub_z,
+                r_response: r_response.unwrap(),
+                c_inter_hash: c_inter_hash.unwrap(),
+            };
+            proof.verify()
+        }
+    }
+}
+
+/// Internal type -- "single letter" naming tries to follow the paper conventions;
+/// for a higher level / end-user API, see [NackDleqProof]
+struct Proof {
+    gen_g: AffinePoint,
+    gen_m: AffinePoint,
+    pub_h: AffinePoint,
+    pub_z: AffinePoint,
+    r_response: Scalar,
+    c_inter_hash: Scalar,
+}
+
+impl Proof {
+    /// given h = g^x, z = m^x
+    /// prove log_g(h) == log_m(z)
+    fn new_p256_sha256(
+        gen_g: AffinePoint,
+        pub_h: AffinePoint,
+        gen_m: AffinePoint,
+        pub_z: AffinePoint,
+        secret_x: &Scalar,
+    ) -> Result<Self, ()> {
+        // points are on the same curve + the point at infinity doesn't have the affine representation
+        // -> not checking the points
+        // TODO: check secret_x or as this is internal API, one assumes it's been validated?
+        let g = ProjectivePoint::from(gen_g);
+        let m = ProjectivePoint::from(gen_m);
+        // random element
+        let (s_rand_nonce, _s_pub) = HPKEPrivateKey::generate();
+        // no panic: HPKEPrivateKey should produce a valid scalar
+        let s_scalar = Scalar::from_bytes(s_rand_nonce.marshal_arr_unsafe()).unwrap();
+        // (a, b) = (g^s, m^s)
+        let ma = (g * &s_scalar).to_affine();
+        let mb = (m * &s_scalar).to_affine();
+        if (ma.is_none() | mb.is_none()).into() {
+            // TODO: is this possible?
+            return Err(());
+        }
+        let a = ma.unwrap();
+        let b = mb.unwrap();
+        // c = H(g, h, m, z, a, b)
+        // note: in the paper, it's H(m, z, a, b)
+        let mut hasher = Sha256::new();
+        hasher.update(b"dleq proof");
+        hasher.update(gen_g.to_uncompressed_pubkey().as_bytes());
+        hasher.update(pub_h.to_uncompressed_pubkey().as_bytes());
+        hasher.update(gen_m.to_uncompressed_pubkey().as_bytes());
+        hasher.update(pub_z.to_uncompressed_pubkey().as_bytes());
+        hasher.update(a.to_uncompressed_pubkey().as_bytes());
+        hasher.update(b.to_uncompressed_pubkey().as_bytes());
+        let c_bytes: [u8; 32] = hasher.finalize().into();
+
+        let mc_inter_hash = Scalar::from_bytes(c_bytes);
+        if mc_inter_hash.is_none().into() {
+            return Err(());
+        }
+        let c_inter_hash = mc_inter_hash.unwrap();
+        // note: r = s - cx instead of r = s + cx,
+        // so that inversion of c doesn't need to be computed by the verifier
+        //
+        // (all ops should be `mod p` from Scalar)
+        //
+        // r = s - cx
+        let r_response = s_scalar + &(-c_inter_hash * secret_x);
+
+        Ok(Proof {
+            gen_g,
+            gen_m,
+            pub_h,
+            pub_z,
+            r_response,
+            c_inter_hash,
+        })
+    }
+
+    fn verify(&self) -> Result<(), ()> {
+        // assuming complete proof; points on the same curve + affine representations
+        // (not points at infinity)
+        // TODO: check scalars or that should be ok, as A, B operations are checked ?
+
+        // prover: c = H(g, h, m, z, a, b)
+        // verifier: calculate rG and rM; C' = H(g, h, m, z, rG + cH, rM + cZ)
+        // verifier: C ?= C'
+        let g_point = ProjectivePoint::from(self.gen_g);
+        let m_point = ProjectivePoint::from(self.gen_m);
+        let z_point = ProjectivePoint::from(self.pub_z);
+        let h_point = ProjectivePoint::from(self.pub_h);
+
+        // a = (g^r)(h^c)
+        // A = rG + cH
+        let c_h = h_point * &self.c_inter_hash;
+        let r_g = g_point * &self.r_response;
+        let a_p = &r_g + &c_h;
+
+        // b = (m^r)(z^c)
+        // B = rM + cZ
+        let c_z = z_point * &self.c_inter_hash;
+        let r_m = m_point * &self.r_response;
+        let b_p = &r_m + &c_z;
+
+        let ma = a_p.to_affine();
+        let mb = b_p.to_affine();
+        if (ma.is_none() | mb.is_none()).into() {
+            // TODO: is this possible?
+            return Err(());
+        }
+        let a = ma.unwrap();
+        let b = mb.unwrap();
+
+        // c' = H(g, h, m, z, a, b) ?= c
+        let mut hasher = Sha256::new();
+        hasher.update(b"dleq proof");
+        hasher.update(self.gen_g.to_uncompressed_pubkey().as_bytes());
+        hasher.update(self.pub_h.to_uncompressed_pubkey().as_bytes());
+        hasher.update(self.gen_m.to_uncompressed_pubkey().as_bytes());
+        hasher.update(self.pub_z.to_uncompressed_pubkey().as_bytes());
+        hasher.update(a.to_uncompressed_pubkey().as_bytes());
+        hasher.update(b.to_uncompressed_pubkey().as_bytes());
+        let c_bytes: [u8; 32] = hasher.finalize().into();
+
+        let c_inter_hash_prime = Scalar::from_bytes(c_bytes);
+        let c_inter_hash = CtOption::new(self.c_inter_hash, 1u8.into());
+        if c_inter_hash.ct_eq(&c_inter_hash_prime).into() {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn setup() -> (Scalar, AffinePoint, AffinePoint) {
+        let (x, _) = HPKEPrivateKey::generate();
+        let x_scalar = Scalar::from_bytes(x.marshal_arr_unsafe()).unwrap();
+        let (_, g_pub) = HPKEPrivateKey::generate();
+        let (_, m_pub) = HPKEPrivateKey::generate();
+
+        let g = p256::PublicKey::from_bytes(&g_pub.marshal()).unwrap();
+        let gen_g = AffinePoint::from_pubkey(&g).unwrap();
+
+        let m = p256::PublicKey::from_bytes(&m_pub.marshal()).unwrap();
+        let gen_m = AffinePoint::from_pubkey(&m).unwrap();
+
+        (x_scalar, gen_g, gen_m)
+    }
+
+    #[test]
+    fn test_external_proof() {
+        let (receive_secret, receiver_pk) = HPKEPrivateKey::generate();
+        let mut csprng = rand::thread_rng();
+
+        let (kem_output, _) = hpke::setup_sender::<
+            hpke::aead::AesGcm128,
+            hpke::kdf::HkdfSha256,
+            hpke::kem::DhP256HkdfSha256,
+            _,
+        >(
+            &hpke::OpModeS::Base,
+            receiver_pk.kex_pubkey(),
+            b"",
+            &mut csprng,
+        )
+        .expect("setup sender");
+
+        // assume sender e.g. put invalid content in ciphertext of EncryptedGroupSecrets
+        // the receiver can then reveal the shared secret + dleq proof
+        let kem_in_mls_payload = kem_output.marshal();
+        let proof_for_nack =
+            NackDleqProof::get_nack_dleq_proof(&receive_secret, &kem_in_mls_payload)
+                .expect("valid proof");
+
+        // others can then verify the proof
+        assert!(proof_for_nack
+            .verify(&receiver_pk, &kem_in_mls_payload)
+            .is_ok());
+        // and then use the disclosed shared secret to decrypt the ciphertext
+        // and verify it's invalid
+    }
+
+    #[test]
+    fn test_proof_valid() {
+        let (x, gen_g, gen_m) = setup();
+        let pub_h = ProjectivePoint::from(gen_g.clone()) * &x;
+        let pub_z = ProjectivePoint::from(gen_m.clone()) * &x;
+        let proof = Proof::new_p256_sha256(
+            gen_g,
+            pub_h.to_affine().unwrap(),
+            gen_m,
+            pub_z.to_affine().unwrap(),
+            &x,
+        )
+        .expect("dleq proof");
+        assert!(proof.verify().is_ok())
+    }
+
+    #[test]
+    fn test_proof_invalid() {
+        let (x, gen_g, gen_m) = setup();
+        let (n, _) = HPKEPrivateKey::generate();
+        let n_scalar = Scalar::from_bytes(n.marshal_arr_unsafe()).unwrap();
+
+        let pub_h = ProjectivePoint::from(gen_g.clone()) * &x;
+        // z = nM instead
+        let pub_z = ProjectivePoint::from(gen_m.clone()) * &n_scalar;
+        let proof = Proof::new_p256_sha256(
+            gen_g,
+            pub_h.to_affine().unwrap(),
+            gen_m,
+            pub_z.to_affine().unwrap(),
+            &x,
+        )
+        .expect("dleq proof");
+        assert!(proof.verify().is_err())
+    }
+}

--- a/chain-tx-enclave-next/mls/src/extras/mod.rs
+++ b/chain-tx-enclave-next/mls/src/extras/mod.rs
@@ -1,8 +1,433 @@
 ///! This module contains additional parts that are a part of the MLS draft spec,
 ///! but are required for resolving relevant open issues in the draft spec
 ///! or for extra conventions / operations: https://github.com/crypto-com/chain-docs/blob/master/docs/modules/tdbe.md.
+///!
+///! At the moment, one issue is that the node generating Commit/Welcome
+///! may put "bogus" in the ciphertext, which will block nodes (newly joining or on the affected
+///! path) from obtaining the new group state.
+///! The sketched out / unverified solution to that is that the affected member may
+///! reveal the shared secret, so that other members can verify that the affected member
+///! received a bad update.
+///!
+///! NOTE: https://mailarchive.ietf.org/arch/msg/mls/DCEKbsnoRKmFTmCuMT-rHIfDapA/
+///! one discussed issue is that the attacker may choose the ephemeral pubkey,
+///! such that some previous secret value is revealed to him through this "NACK" mechanism.
+///! The suggestion is to use Schnorr NIZK proof of the ephemeral pubkey for every ciphertext,
+///! but:
+///! 1) this is clumsy, as the HPKE setup API doesn't expose the ephemeral secrets.
+///! 2) in our case / threat model, it does not seem to matter:
+///! - if the attacker can do something like this, it means the attacker managed to breach TEE
+///! (unless it's through a bug in the Rust code itself)
+///! - if the attacker breached TEE, the "expected" worst case is
+///!   "breaking confidentiality" temporarily, i.e. they can read old ledger records
+///! -> they don't need to produce tweaked MLS handshakes messages for that,
+///!    they could instead "unseal" old TEE-sealed data.
+///!
+///! the "unexpected" worst case would be breaking ledger integrity (such as through DoS
+///! on certain honest nodes / MLS members) which should be prevented
+///! by handshake NACK mechanism + BFT consensus.
 
 /// module for external validation
 mod validation;
 
+use crate::key::IdentityPublicKey;
+use crate::keypackage::Timespec;
+use crate::message::MLSPlaintext;
+use crate::tree::TreePublicKey;
+use crate::tree_math::{LeafSize, NodeSize, ParentSize};
+use parity_scale_codec::{Decode, Encode};
+use ra_client::AttestedCertVerifier;
+use rustls::internal::msgs::codec::Codec;
+use secrecy::SecretVec;
+use subtle::ConstantTimeEq;
 pub use validation::{check_nodejoin, NodeJoinError, NodeJoinResult};
+/// module for dleq proofs
+mod dleq;
+
+pub use dleq::NackDleqProof;
+
+/// FIXME: official spec may differ
+#[derive(Encode, Decode)]
+pub struct NackMsgContent {
+    /// the sender leaf of NACK -- i.e. affected receiver of Commit
+    pub sender: u32,
+    /// sha-2 hash of `MLSPlaintext` with Commit
+    pub commit_id: [u8; 32],
+    /// index of affected encrypted_path_secret
+    pub path_secret_index: u32,
+    /// proof with the disclosed shared secret
+    pub proof: NackDleqProof,
+}
+
+/// FIXME: official spec may differ
+#[derive(Encode, Decode)]
+pub struct NackMsg {
+    pub content: NackMsgContent,
+    /// ecdsa signature on the NackMsgContent (SCALE-serialized,
+    /// as there's no "official" NACK defined for compatibility checking)
+    pub signature: Vec<u8>,
+}
+
+/// FIXME: official spec may differ
+#[derive(Debug)]
+pub enum NackError {
+    InvalidSender,
+    InvalidCommit,
+    InvalidPath,
+    InvalidProof,
+    InvalidSignature,
+    /// no problem was found
+    ValidPath,
+}
+
+/// FIXME: official spec may differ
+#[derive(Debug)]
+pub enum NackResult {
+    /// path secret could not possibly be decrypted by the receiver
+    CannotDecrypt,
+    /// path secret does not correspond to the public node key
+    PathSecretMismatch,
+}
+
+impl NackMsg {
+    /// verifies Nack message against a previously sent Commit
+    pub fn verify(
+        &self,
+        tree: &TreePublicKey,
+        commit: &MLSPlaintext,
+        ra_verifier: &impl AttestedCertVerifier,
+        now: Timespec,
+        encoded_ctx: &[u8],
+    ) -> Result<NackResult, NackError> {
+        let leaf_len = tree.leaf_len();
+        let commit_sender = LeafSize(commit.content.sender.sender);
+        let nack_sender = LeafSize(self.content.sender);
+        let nack_sender_kp = tree
+            .get_package(nack_sender)
+            .ok_or(NackError::InvalidSender)?;
+        let commit_id = tree.cs.hash(&commit.get_encoding());
+        if !bool::from(commit_id.ct_eq(&self.content.commit_id)) {
+            return Err(NackError::InvalidCommit);
+        }
+        let commit_content = commit.get_commit().ok_or(NackError::InvalidCommit)?;
+        // only applies to removal/update, as for Add/Welcome, there's no path and for Welcome, the requesting member can request elsewhere if invalid
+        let path = commit_content
+            .path
+            .as_ref()
+            .ok_or(NackError::InvalidCommit)?;
+        // if there's no ancestor, this would be meaningless -- committer sending NACK for its own commit?
+        let ancestor = ParentSize::common_ancestor(commit_sender, nack_sender)
+            .ok_or(NackError::InvalidCommit)?;
+        // incomplete paths are expected to be checked: https://github.com/crypto-com/chain-docs/issues/190 https://github.com/crypto-com/chain-docs/issues/189
+        let path_node = NodeSize::from(commit_sender)
+            .direct_path(leaf_len)
+            .into_iter()
+            .zip(path.nodes.iter())
+            .find(|(n, _)| *n == ancestor)
+            .ok_or(NackError::InvalidCommit)?
+            .1;
+
+        let affected_path_secret = path_node
+            .encrypted_path_secret
+            .get(self.content.path_secret_index as usize)
+            .ok_or(NackError::InvalidCommit)?;
+        let sender_node_index = NodeSize::from(nack_sender);
+        let path_indices = tree.resolve(sender_node_index);
+        let node_index = path_indices
+            .get(self.content.path_secret_index as usize)
+            .ok_or(NackError::InvalidPath)?;
+        // one won't encrypt to blank nodes
+        let node_key = tree.nodes[node_index.node_index()]
+            .public_key()
+            .ok_or(NackError::InvalidPath)?;
+        self.content
+            .proof
+            .verify(&node_key, &affected_path_secret.kem_output)
+            .map_err(|_| NackError::InvalidProof)?;
+        let nack_sender_id = nack_sender_kp
+            .verify(ra_verifier, now)
+            .map_err(|_| NackError::InvalidSignature)?
+            .public_key;
+        let public_key = IdentityPublicKey::new_unsafe(nack_sender_id.to_vec());
+        public_key
+            .verify_signature(&self.content.encode(), &self.signature)
+            .map_err(|_| NackError::InvalidSignature)?;
+        let overlap_path_secret =
+            self.content
+                .proof
+                .decrypt_after_proof(&node_key, &affected_path_secret, encoded_ctx);
+        if let Ok(path_secret) = overlap_path_secret {
+            let overlap_path_secret = SecretVec::new(path_secret);
+            let direct_path = NodeSize::from(nack_sender).direct_path(leaf_len);
+            let overlap_pos = direct_path
+                .iter()
+                .position(|&p| p == ancestor)
+                .expect("overlap is supposed to be ancestor");
+            let overlap_path = &direct_path[overlap_pos + 1..];
+
+            // the path secrets above(not including) the overlap node
+            let mut secrets = vec![];
+            for _ in overlap_path.iter() {
+                secrets.push(
+                    tree.cs
+                        .expand_label(
+                            secrets.last().unwrap_or(&overlap_path_secret),
+                            vec![],
+                            "path",
+                            &[],
+                            tree.cs.secret_size(),
+                        )
+                        .expect("expand label works"),
+                );
+            }
+
+            // verify the new path secrets match public keys
+            if tree
+                .verify_node_private_key(&overlap_path_secret, ancestor)
+                .is_err()
+            {
+                return Ok(NackResult::PathSecretMismatch);
+            }
+            for (secret, &parent) in secrets.iter().skip(1).zip(overlap_path) {
+                if tree.verify_node_private_key(secret, parent).is_err() {
+                    return Ok(NackResult::PathSecretMismatch);
+                }
+            }
+            Err(NackError::ValidPath)
+        } else {
+            Ok(NackResult::CannotDecrypt)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::group::test::{get_fake_keypackage, three_member_setup, MockVerifier};
+    use crate::group::GroupAux;
+    use crate::message::{ContentType, MLSPlaintextTBS};
+
+    fn corrupt_and_sign_commit(
+        commit: &MLSPlaintext,
+        sender: &GroupAux,
+        valid_ciphertext: bool,
+    ) -> MLSPlaintext {
+        let mut new_commit = commit.clone();
+        let (mut new_commit_content, confirmation) = match &new_commit.content.content {
+            ContentType::Commit {
+                commit,
+                confirmation,
+            } => (commit.clone(), confirmation.clone()),
+            _ => unreachable!(),
+        };
+        let mut path = new_commit_content.path.clone().expect("path");
+        if valid_ciphertext {
+            let init_key = sender.tree.nodes[0]
+                .public_key()
+                .expect("not blank node TODO");
+            path.nodes[0].encrypted_path_secret[0] = sender
+                .tree
+                .cs
+                .encrypt(vec![0u8; 32], &init_key, &sender.context.get_encoding())
+                .expect("encrypt")
+        } else {
+            path.nodes[0].encrypted_path_secret[0].ciphertext[0] = 0;
+        }
+
+        new_commit_content.path = Some(path);
+        new_commit.content.content = ContentType::Commit {
+            commit: new_commit_content,
+            confirmation,
+        };
+        let to_be_signed = MLSPlaintextTBS {
+            context: sender.context.clone(),
+            content: new_commit.content.clone(),
+        }
+        .get_encoding();
+        let signature = sender
+            .kp_secret
+            .credential_private_key
+            .sign(&to_be_signed)
+            .unwrap();
+        new_commit.signature = signature;
+
+        new_commit
+    }
+
+    #[test]
+    fn test_nack_verify_fail_valid() {
+        // FIXME: test other errors
+        let ra_verifier = MockVerifier {};
+        let (mut member1_group, mut member2_group, mut member3_group) = three_member_setup();
+
+        let (member2, member2_secret) = get_fake_keypackage();
+        let proposals = vec![member2_group
+            .get_signed_self_update(member2.clone(), member2_secret)
+            .unwrap()];
+        let (commit, _welcome) = member2_group.commit_proposals(&proposals).unwrap();
+        let path = commit
+            .get_commit()
+            .expect("commit")
+            .path
+            .as_ref()
+            .expect("path");
+        let proof = NackDleqProof::get_nack_dleq_proof(
+            &member1_group.kp_secret.init_private_key,
+            &path.nodes[0].encrypted_path_secret[0].kem_output,
+        )
+        .expect("proof");
+        let mut commit_id = [0u8; 32];
+
+        commit_id.copy_from_slice(&member1_group.tree.cs.hash(&commit.get_encoding()));
+        let nack_content = NackMsgContent {
+            sender: 0,
+            commit_id,
+            path_secret_index: 0,
+            proof,
+        };
+        let nack_signature = member1_group
+            .kp_secret
+            .credential_private_key
+            .sign(&nack_content.encode())
+            .unwrap();
+        let nack = NackMsg {
+            content: nack_content,
+            signature: nack_signature,
+        };
+        member1_group
+            .process_commit(commit.clone(), &proposals, &ra_verifier, 0)
+            .expect("commit ok");
+        let ctx = member3_group.context.get_encoding();
+        member3_group
+            .process_commit(commit.clone(), &proposals, &ra_verifier, 0)
+            .expect("commit ok");
+        assert!(matches!(
+            nack.verify(&member3_group.tree, &commit, &ra_verifier, 0, &ctx),
+            Err(NackError::ValidPath)
+        ));
+    }
+
+    #[test]
+    fn test_nack_verify_decrypt_fail() {
+        let ra_verifier = MockVerifier {};
+        let (mut member1_group, mut member2_group, mut member3_group) = three_member_setup();
+
+        // member 1 -- affected
+        // member 2 -- malicious / unaffected
+        // member 3 -- honest / unaffected (verifying member1 claim)
+        let (member2, member2_secret) = get_fake_keypackage();
+        let proposals = vec![member2_group
+            .get_signed_self_update(member2.clone(), member2_secret)
+            .unwrap()];
+        let (commit, _welcome) = member2_group.commit_proposals(&proposals).unwrap();
+        // case 1: decryption fails
+        let commit = corrupt_and_sign_commit(&commit, &member2_group, false);
+
+        // FIXME: the error shouldn't be discovered in "process commit", but some "verify" commit
+        // + many things in Commit should be verified -- e.g. that "kem_output" is a valid pubkey
+        member1_group
+            .process_commit(commit.clone(), &proposals, &ra_verifier, 0)
+            .expect_err("commit not ok");
+        let ctx = member3_group.context.get_encoding();
+        // for group 3, it should look ok
+        member3_group
+            .process_commit(commit.clone(), &proposals, &ra_verifier, 0)
+            .expect("commit ok");
+        let path = commit
+            .get_commit()
+            .expect("commit")
+            .path
+            .as_ref()
+            .expect("path");
+        let proof = NackDleqProof::get_nack_dleq_proof(
+            &member1_group.kp_secret.init_private_key,
+            &path.nodes[0].encrypted_path_secret[0].kem_output,
+        )
+        .expect("proof");
+        let mut commit_id = [0u8; 32];
+
+        commit_id.copy_from_slice(&member1_group.tree.cs.hash(&commit.get_encoding()));
+        let nack_content = NackMsgContent {
+            sender: 0,
+            commit_id,
+            path_secret_index: 0,
+            proof,
+        };
+        let nack_signature = member1_group
+            .kp_secret
+            .credential_private_key
+            .sign(&nack_content.encode())
+            .unwrap();
+        let nack = NackMsg {
+            content: nack_content,
+            signature: nack_signature,
+        };
+        assert!(matches!(
+            nack.verify(&member3_group.tree, &commit, &ra_verifier, 0, &ctx),
+            Ok(NackResult::CannotDecrypt)
+        ));
+    }
+
+    #[test]
+    fn test_nack_verify_path_fail() {
+        let ra_verifier = MockVerifier {};
+        let (mut member1_group, mut member2_group, mut member3_group) = three_member_setup();
+
+        // member 1 -- affected
+        // member 2 -- malicious / unaffected
+        // member 3 -- honest / unaffected (verifying member1 claim)
+        let (member2, member2_secret) = get_fake_keypackage();
+        let proposals = vec![member2_group
+            .get_signed_self_update(member2.clone(), member2_secret)
+            .unwrap()];
+        let (commit, _welcome) = member2_group.commit_proposals(&proposals).unwrap();
+
+        // case 2: path secret doesn't match
+        let commit = corrupt_and_sign_commit(&commit, &member2_group, true);
+
+        // FIXME: the error shouldn't be discovered in "process commit", but some "verify" commit
+        // + many things in Commit should be verified -- e.g. that "kem_output" is a valid pubkey
+        member1_group
+            .process_commit(commit.clone(), &proposals, &ra_verifier, 0)
+            .expect_err("commit not ok");
+        let ctx = member3_group.context.get_encoding();
+        // for group 3, it should look ok
+        member3_group
+            .process_commit(commit.clone(), &proposals, &ra_verifier, 0)
+            .expect("commit ok");
+
+        let path = commit
+            .get_commit()
+            .expect("commit")
+            .path
+            .as_ref()
+            .expect("path");
+        let proof = NackDleqProof::get_nack_dleq_proof(
+            &member1_group.kp_secret.init_private_key,
+            &path.nodes[0].encrypted_path_secret[0].kem_output,
+        )
+        .expect("proof");
+        let mut commit_id = [0u8; 32];
+
+        commit_id.copy_from_slice(&member1_group.tree.cs.hash(&commit.get_encoding()));
+        let nack_content = NackMsgContent {
+            sender: 0,
+            commit_id,
+            path_secret_index: 0,
+            proof,
+        };
+        let nack_signature = member1_group
+            .kp_secret
+            .credential_private_key
+            .sign(&nack_content.encode())
+            .unwrap();
+        let nack = NackMsg {
+            content: nack_content,
+            signature: nack_signature,
+        };
+        assert!(matches!(
+            nack.verify(&member3_group.tree, &commit, &ra_verifier, 0, &ctx),
+            Ok(NackResult::PathSecretMismatch)
+        ));
+    }
+}

--- a/chain-tx-enclave-next/mls/src/group.rs
+++ b/chain-tx-enclave-next/mls/src/group.rs
@@ -994,7 +994,7 @@ pub enum InitGroupError {
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
 
     use super::*;
     use crate::credential::Credential;
@@ -1012,7 +1012,7 @@ mod test {
     use rustls::internal::msgs::codec::Codec;
 
     #[derive(Clone)]
-    struct MockVerifier();
+    pub struct MockVerifier();
 
     impl AttestedCertVerifier for MockVerifier {
         fn verify_attested_cert(
@@ -1035,7 +1035,7 @@ mod test {
         }
     }
 
-    fn get_fake_keypackage() -> (KeyPackage, KeyPackageSecret) {
+    pub fn get_fake_keypackage() -> (KeyPackage, KeyPackageSecret) {
         let keypair = ring::signature::EcdsaKeyPair::generate_pkcs8(
             &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
             &ring::rand::SystemRandom::new(),
@@ -1156,8 +1156,7 @@ mod test {
         assert!(!tree.nodes[2].is_empty_node());
     }
 
-    #[test]
-    fn test_group_update() {
+    pub fn three_member_setup() -> (GroupAux, GroupAux, GroupAux) {
         let (member1, member1_secret) = get_fake_keypackage();
         let (member2, member2_secret) = get_fake_keypackage();
         let (member3, member3_secret) = get_fake_keypackage();
@@ -1190,7 +1189,7 @@ mod test {
         member2_group
             .process_commit(commit, &proposals, &ra_verifier, 0)
             .expect("commit ok");
-        let mut member3_group =
+        let member3_group =
             GroupAux::init_group_from_welcome(member3, member3_secret, welcome, &ra_verifier, 0)
                 .expect("group init from welcome");
 
@@ -1204,6 +1203,13 @@ mod test {
             .tree
             .get_package(member3_group.tree.my_pos)
             .expect("member3 should exists");
+        (member1_group, member2_group, member3_group)
+    }
+
+    #[test]
+    fn test_group_update() {
+        let ra_verifier = MockVerifier {};
+        let (mut member1_group, mut member2_group, mut member3_group) = three_member_setup();
 
         // member2 do a self update
         let (member2, member2_secret) = get_fake_keypackage();

--- a/chain-tx-enclave-next/mls/src/key.rs
+++ b/chain-tx-enclave-next/mls/src/key.rs
@@ -126,6 +126,10 @@ impl HPKEPrivateKey {
         )
     }
 
+    pub fn marshal_arr_unsafe(&self) -> [u8; 32] {
+        <hpke::kex::DhP256 as hpke::KeyExchange>::PrivateKey::marshal(&self.0).into()
+    }
+
     pub fn public_key(&self) -> HPKEPublicKey {
         HPKEPublicKey(<hpke::kex::DhP256 as hpke::KeyExchange>::sk_to_pk(&self.0))
     }

--- a/chain-tx-enclave-next/mls/src/message.rs
+++ b/chain-tx-enclave-next/mls/src/message.rs
@@ -214,6 +214,12 @@ impl Codec for MLSPlaintextTBS {
 }
 
 impl MLSPlaintext {
+    pub fn get_commit(&self) -> Option<&Commit> {
+        match &self.content.content {
+            ContentType::Commit { commit, .. } => Some(commit),
+            _ => None,
+        }
+    }
     pub fn get_add(&self) -> Option<&Add> {
         match &self.content.content {
             ContentType::Proposal(Proposal::Add(add)) => Some(add),

--- a/chain-tx-enclave-next/mls/src/tree.rs
+++ b/chain-tx-enclave-next/mls/src/tree.rs
@@ -617,7 +617,7 @@ impl TreePublicKey {
 
     /// draft-ietf-mls-protocol.md#ratchet-tree-nodes
     /// no blank nodes return
-    fn resolve(&self, index: NodeSize) -> Vec<NodeSize> {
+    pub(crate) fn resolve(&self, index: NodeSize) -> Vec<NodeSize> {
         match &self.nodes[index.node_index()] {
             // Resolution of blank leaf is the empty list
             Node::Leaf(None) => vec![],


### PR DESCRIPTION
Solution: sketched out core of "NACK" mechanism
which involves revealing shared secrets from invalid
message parts and including DLEQ proofs.

-- currently, needs:
1) latest master of p256 which contains scalar arithmetic (not yet released)
2) for the high-level API, it needs to directly decrypt HPKE ciphertext
from a shared secret -- this may not ever be released

also needs "verify_node_private_key" from https://github.com/crypto-com/chain/pull/2018


