### PR TITLE
Problem: (fix #1951) no certificate expiration handling tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,7 @@ steps:
   - export CARGO_HOME=$PWD/drone/cargo
   - export CARGO_TARGET_DIR=$PWD/drone/target
   - export PATH=$CARGO_HOME/bin:$PATH
+  - export CERTIFICATE_EXPIRATION_SECS=200
   - ./docker/build.sh
 
 - name: unit-tests
@@ -136,6 +137,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 3dce97b3e6be0fc210afbdb02e08038d0b64ee09ce8d3af530dddf29770ea00a
+hmac: 5b35c24e5f5071022a34edaeb72dbd31824c4d330fd4d69541741772ee24ec9a
 
 ...

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ name = "tdb-enclave-app"
 version = "0.6.0"
 dependencies = [
  "chain-core",
+ "chrono",
  "enclave-protocol",
  "enclave-utils",
  "env_logger",
@@ -4646,6 +4647,15 @@ dependencies = [
  "tendermint",
  "tendermint-light-client",
  "tendermint-rpc",
+]
+
+[[package]]
+name = "test_cert_expiration"
+version = "0.1.0"
+dependencies = [
+ "ra-client",
+ "rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -5092,6 +5102,7 @@ name = "tx-query2-enclave-app"
 version = "0.6.0"
 dependencies = [
  "chain-core",
+ "chrono",
  "enclave-protocol",
  "enclave-utils",
  "env_logger",
@@ -5142,6 +5153,7 @@ dependencies = [
  "chain-core",
  "chain-tx-filter",
  "chain-tx-validation",
+ "chrono",
  "enclave-macro",
  "enclave-protocol",
  "enclave-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "chain-tx-enclave/mock-utils",
     "chain-tx-enclave-next/mls",
     "cro-clib",
+    "integration-tests/rust_tests/test_cert_expiration",
 ]
 
 default-members = [

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/src/certificate.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/src/certificate.rs
@@ -16,7 +16,13 @@ impl Certificate {
     /// Checks if current certificate is valid or not
     pub fn is_valid(&self, validity_duration: Duration) -> bool {
         let current_time = Utc::now();
-        self.created + validity_duration >= current_time
+        // add extra 15 seconds offset to avoid the impact of network transfer delay
+        // and difference of the os system time
+        if validity_duration > Duration::seconds(15) {
+            current_time - self.created <= validity_duration - Duration::seconds(15)
+        } else {
+            current_time - self.created < validity_duration
+        }
     }
 
     /// Sets current certificate in given `rustls` server config

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/src/config.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/src/config.rs
@@ -1,3 +1,5 @@
+use chrono::Duration;
+
 /// Configuration required by SP for remote attestation
 #[derive(Debug)]
 pub struct EnclaveRaConfig {
@@ -5,4 +7,6 @@ pub struct EnclaveRaConfig {
     pub sp_addr: String,
     /// Duration for which a certificate will be valid (in secs)
     pub certificate_validity_secs: u32,
+    /// The certificate expiration tie
+    pub certificate_expiration_time: Option<Duration>,
 }

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/src/lib.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/src/lib.rs
@@ -30,4 +30,4 @@ mod context;
 
 pub use self::{certificate::Certificate, config::EnclaveRaConfig};
 #[cfg(target_env = "sgx")]
-pub use context::{EnclaveRaContext, EnclaveRaContextError};
+pub use context::{EnclaveRaContext, EnclaveRaContextError, DEFAULT_EXPIRATION_SECS};

--- a/chain-tx-enclave-next/mls/src/main.rs
+++ b/chain-tx-enclave-next/mls/src/main.rs
@@ -5,14 +5,15 @@ pub type Timespec = u64;
 #[cfg(target_env = "sgx")]
 fn main() -> io::Result<()> {
     use mls::KeyPackageSecret;
-    use ra_enclave::{EnclaveRaConfig, EnclaveRaContext};
+    use ra_enclave::{EnclaveRaConfig, EnclaveRaContext, DEFAULT_EXPIRATION_SECS};
     #[allow(unused_imports)]
     use rs_libc::alloc::*;
     use rustls::internal::msgs::codec::Codec;
 
     let config = EnclaveRaContext::new(&EnclaveRaConfig {
         sp_addr: "0.0.0.0:8989".to_owned(),
-        certificate_validity_secs: 86400,
+        certificate_validity_secs: DEFAULT_EXPIRATION_SECS as u32,
+        certificate_expiration_time: None,
     });
     if config.is_err() {
         eprintln!("cannot connect ra-sp-server, run ra-sp-server beforehand e.g.) ra-sp-server --quote-type Unlinkable --ias-key $IAS_API_KEY --spid $SPID")

--- a/chain-tx-enclave-next/tdbe/enclave-app/Cargo.toml
+++ b/chain-tx-enclave-next/tdbe/enclave-app/Cargo.toml
@@ -16,6 +16,7 @@ sgx-isa = { version = "0.3", features = ["sgxstd"] }
 thread-pool = "0.1"
 webpki = "0.21"
 zeroize = "1.1"
+chrono = "0.4"
 
 chain-core = { path = "../../../chain-core", default-features = false, features = ["edp"] }
 enclave-protocol = { path = "../../../enclave-protocol", features = ["edp"] }

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
@@ -16,6 +16,7 @@ rustls = "0.18"
 secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["lowmemory"] }
 thread-pool = "0.1"
 zeroize = "1.1"
+chrono = "0.4"
 
 chain-core = { path = "../../../chain-core", default-features = false, features = ["edp"] }
 enclave-protocol = { path = "../../../enclave-protocol", features = ["edp"] }

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/src/main.rs
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/src/main.rs
@@ -1,9 +1,17 @@
 #[cfg(target_env = "sgx")]
 mod sgx_module;
+#[cfg(target_env = "sgx")]
+use chrono::Duration;
 
 #[cfg(target_env = "sgx")]
 fn main() -> std::io::Result<()> {
-    sgx_module::entry()
+    let cert_expiration: Option<Duration> = option_env!("CERTIFICATE_EXPIRATION_SECS").map(|s| {
+        let sec = s
+            .parse()
+            .expect("invalid CERTIFICATE_EXPIRATION_SECS, expect u64");
+        Duration::seconds(sec)
+    });
+    sgx_module::entry(cert_expiration)
 }
 
 #[cfg(not(target_env = "sgx"))]

--- a/chain-tx-enclave-next/tx-validation-next/Cargo.toml
+++ b/chain-tx-enclave-next/tx-validation-next/Cargo.toml
@@ -17,6 +17,7 @@ enclave-protocol   = { path = "../../enclave-protocol" }
 chain-tx-filter   = { path = "../../chain-tx-filter" }
 aes-gcm-siv = "0.5"
 aead = "0.3"
+chrono = "0.4"
 zeroize = { version = "1.1" }
 env_logger = { version = "0.7", default-features = false }
 log = "0.4"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -29,6 +29,7 @@ if [ $BUILD_MODE == "sgx" ]; then
 
     cargo build $CARGO_ARGS
     cargo build $CARGO_ARGS --features mock-hardware-wallet --manifest-path client-cli/Cargo.toml
+    cargo build $CARGO_ARGS --manifest-path integration-tests/rust_tests/test_cert_expiration/Cargo.toml
     make -C chain-tx-enclave/tx-validation
 
     # Add fortanix target and tools

--- a/integration-tests/pytests/test_client_cli.py
+++ b/integration-tests/pytests/test_client_cli.py
@@ -2,7 +2,7 @@ import json
 import pytest
 import os
 import time
-from client_cli import Wallet, Transaction
+from client_cli import Wallet, Transaction, run
 
 PASSPHRASE = "123456"
 CRO = 10**8
@@ -21,6 +21,10 @@ def write_wallet_info_to_file(wallet_list, from_file = "/tmp/from_file"):
     with open(from_file, "w") as f:
         json.dump(wallet_info, f)
 
+def test_cert_expiration():
+    if os.environ.get("BUILD_MODE", "sgx") == "sgx":
+        cmd = ["test_cert_expiration", "26651", "202"]
+        run(cmd)
 
 @pytest.mark.zerofee
 def test_wallet_basic():
@@ -223,7 +227,8 @@ def test_deposit_to_other_wallet():
 
 @pytest.mark.zerofee
 def test_withdraw_to_other_wallet():
-    time.sleep(3)
+    # the tx-query cert_validation is 200 (setted in .drone.yaml), check the cert refresh or not
+    test_cert_expiration()
     state2 = wallet_2.state(staking_address_wallet_1)
     unbounded_transaction(wallet_1, staking_address_wallet_1, 10000)
     wallet_2.sync()

--- a/integration-tests/rust_tests/test_cert_expiration/Cargo.toml
+++ b/integration-tests/rust_tests/test_cert_expiration/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test_cert_expiration"
+version = "0.1.0"
+authors = ["linfeng <linfeng@crypto.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rustls =  { version = "0.18", features = ["dangerous_configuration"]  }
+webpki = "0.21"
+ra-client = { path = "../../../chain-tx-enclave-next/enclave-ra/ra-client" }

--- a/integration-tests/rust_tests/test_cert_expiration/src/main.rs
+++ b/integration-tests/rust_tests/test_cert_expiration/src/main.rs
@@ -1,0 +1,48 @@
+use ra_client::EnclaveCertVerifier;
+use rustls::{Certificate, ClientSession, Session};
+use std::env;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub fn get_cert(port: u32) -> Certificate {
+    let address = format!("127.0.0.1:{}", port);
+    println!("connect to address: {}", address);
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost")
+        .unwrap()
+        .to_owned();
+    let verifier = EnclaveCertVerifier::default();
+    let client_config = Arc::new(verifier.into_client_config());
+    // client_config.dangerous().set_certificate_verifier();
+    let mut session = ClientSession::new(&client_config, dns_name.as_ref());
+    let mut conn = TcpStream::connect(&address)
+        .map_err(|e| {
+            println!("can not connect to address: {}, {:?}", address, e);
+        })
+        .unwrap();
+    let mut tls = rustls::Stream::new(&mut session, &mut conn);
+    tls.write_all(&[0; 32]).expect("write to tls");
+    tls.flush().expect("flush");
+    let mut r = [0u8; 16];
+    tls.read(&mut r).expect("read");
+    println!("get result: {:?}", &r);
+    let certifications = session
+        .get_peer_certificates()
+        .expect("get certifications first time");
+    println!("first get certification finished");
+    assert_eq!(certifications.len(), 1);
+    certifications[0].clone()
+}
+
+pub fn test_cert_refresh(port: u32, sleep_secs: u64) {
+    let cert_1 = get_cert(port);
+    sleep(Duration::from_secs(sleep_secs));
+    let cert_2 = get_cert(port);
+    assert_ne!(cert_1, cert_2);
+}
+fn main() {
+    let args: Vec<_> = env::args().collect();
+    test_cert_refresh(args[1].parse().unwrap(), args[2].parse().unwrap());
+}


### PR DESCRIPTION
solution:
* make certificate expiration as a compile-time parameter
* set default validity_duration to 90 days, which is as same as certificate expiration
* add a small time duration when check certificate is expired or not
* use the min(default validity_duration, cert_expiration) as the validity_duration to check the certificate is expired or not