### PR TITLE
Problem: no paging in client-rpc, address_list (fix #2023)

### DIFF
--- a/client-core/src/service/wallet_service.rs
+++ b/client-core/src/service/wallet_service.rs
@@ -531,6 +531,29 @@ pub fn load_wallet<S: SecureStorage + 'static>(
     }
     Ok(None)
 }
+
+fn generate_page(all_items_count: u64, offset: u64, limit: u64, reversed: bool) -> Vec<u64> {
+    let ret: Vec<u64>;
+    if reversed {
+        let start = all_items_count.saturating_sub(offset);
+        let mut end = 0;
+        if limit > 0 {
+            end = start.saturating_sub(limit);
+        }
+        let mut tmp: Vec<u64> = (end..start).collect();
+        tmp.reverse();
+        ret = tmp;
+    } else {
+        let start = offset;
+        let mut end = all_items_count;
+        if limit > 0 {
+            end = std::cmp::min(offset + limit, all_items_count);
+        }
+        ret = (start..end).collect();
+    }
+    ret
+}
+
 /// Maintains mapping `wallet-name -> wallet-details`
 #[derive(Debug, Default, Clone)]
 pub struct WalletService<T: Storage> {
@@ -618,7 +641,6 @@ where
         redeem_address: &RedeemAddress,
     ) -> Result<Option<PublicKey>> {
         let stakingkey_keyspace = get_stakingkeyset_keyspace(name);
-
         if let Ok(value) = read_pubkey(
             &self.storage,
             &stakingkey_keyspace,
@@ -626,10 +648,7 @@ where
         ) {
             Ok(Some(value))
         } else {
-            Err(Error::new(
-                ErrorKind::InvalidInput,
-                "Address is not found in current wallet",
-            ))
+            Ok(None)
         }
     }
 
@@ -673,7 +692,7 @@ where
             let privatekey = PrivateKey::deserialize_from(&raw_value)?;
             Ok(Some(privatekey))
         } else {
-            Err(Error::new(ErrorKind::InvalidInput, "private_key not found"))
+            Ok(None)
         }
     }
 
@@ -703,7 +722,7 @@ where
             }
         }
 
-        Err(Error::new(ErrorKind::InvalidInput, "private_key not found"))
+        Ok(None)
     }
 
     /// Creates a new wallet and returns wallet ID
@@ -761,7 +780,14 @@ where
     }
 
     /// Returns all public keys corresponding to staking addresses stored in a wallet
-    pub fn staking_keys(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<PublicKey>> {
+    pub fn staking_keys(
+        &self,
+        name: &str,
+        enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
+    ) -> Result<IndexSet<PublicKey>> {
         if !self.storage.contains_key(KEYSPACE, name)? {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
@@ -774,7 +800,9 @@ where
         let info_keyspace = get_info_keyspace(name);
         let staking_count: u64 =
             read_number(&self.storage, &info_keyspace, "stakingkeyindex", None)?;
-        for i in 0..staking_count {
+
+        let items = generate_page(staking_count, offset, limit, reversed);
+        for i in items {
             let pubkey = read_pubkey(&self.storage, &stakingkey_keyspace, &format!("{}", i))?;
             ret.insert(pubkey);
         }
@@ -786,8 +814,12 @@ where
         &self,
         name: &str,
         enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
     ) -> Result<IndexSet<StakedStateAddress>> {
-        let pubkeys: IndexSet<PublicKey> = self.staking_keys(name, enckey)?;
+        let pubkeys: IndexSet<PublicKey> =
+            self.staking_keys(name, enckey, offset, limit, reversed)?;
         let mut ret: IndexSet<StakedStateAddress> = IndexSet::<StakedStateAddress>::new();
         for pubkey in &pubkeys {
             let staked = StakedStateAddress::BasicRedeem(RedeemAddress::from(pubkey));
@@ -797,7 +829,14 @@ where
     }
 
     /// Returns all multi-sig addresses stored in a wallet
-    pub fn root_hashes(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<H256>> {
+    pub fn root_hashes(
+        &self,
+        name: &str,
+        enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
+    ) -> Result<IndexSet<H256>> {
         if !self.storage.contains_key(KEYSPACE, name)? {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
@@ -810,7 +849,9 @@ where
         let info_keyspace = get_info_keyspace(name);
         let roothash_count: u64 =
             read_number(&self.storage, &info_keyspace, "roothashindex", None)?;
-        for i in 0..roothash_count {
+
+        let items = generate_page(roothash_count, offset, limit, reversed);
+        for i in items {
             let value = self.storage.get(&roothash_keyspace, format!("{}", i))?;
             if let Some(raw_value) = value {
                 let mut roothash_found: H256 = H256::default();
@@ -818,6 +859,7 @@ where
                 ret.insert(roothash_found);
             }
         }
+
         Ok(ret)
     }
 
@@ -826,8 +868,11 @@ where
         &self,
         name: &str,
         enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
     ) -> Result<IndexSet<ExtendedAddr>> {
-        let roothashes: IndexSet<H256> = self.root_hashes(name, enckey)?;
+        let roothashes: IndexSet<H256> = self.root_hashes(name, enckey, offset, limit, reversed)?;
         let mut ret: IndexSet<ExtendedAddr> = IndexSet::<ExtendedAddr>::new();
         for roothash_found in &roothashes {
             let extended_addr = ExtendedAddr::OrTree(*roothash_found);

--- a/client-core/src/wallet.rs
+++ b/client-core/src/wallet.rs
@@ -158,10 +158,20 @@ pub trait WalletClient: Send + Sync {
         &self,
         name: &str,
         enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
     ) -> Result<IndexSet<StakedStateAddress>>;
 
     /// Returns all the multi-sig transfer addresses in current wallet
-    fn transfer_addresses(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<ExtendedAddr>>;
+    fn transfer_addresses(
+        &self,
+        name: &str,
+        enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
+    ) -> Result<IndexSet<ExtendedAddr>>;
 
     /// Finds staking key corresponding to given redeem address
     fn find_staking_key(

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -156,8 +156,8 @@ where
     ) -> Result<bool> {
         let is_exist = self
             .wallet_service
-            .find_root_hash(name, enckey, &extended_addr)
-            .is_ok();
+            .find_root_hash(name, enckey, &extended_addr)?
+            .is_some();
         if is_exist {
             // no need
             return Ok(false);
@@ -631,12 +631,12 @@ where
 
     #[inline]
     fn staking_keys(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<PublicKey>> {
-        self.wallet_service.staking_keys(name, enckey)
+        self.wallet_service.staking_keys(name, enckey, 0, 0, false)
     }
 
     #[inline]
     fn root_hashes(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<H256>> {
-        self.wallet_service.root_hashes(name, enckey)
+        self.wallet_service.root_hashes(name, enckey, 0, 0, false)
     }
 
     #[inline]
@@ -644,13 +644,25 @@ where
         &self,
         name: &str,
         enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
     ) -> Result<IndexSet<StakedStateAddress>> {
-        self.wallet_service.staking_addresses(name, enckey)
+        self.wallet_service
+            .staking_addresses(name, enckey, offset, limit, reversed)
     }
 
     #[inline]
-    fn transfer_addresses(&self, name: &str, enckey: &SecKey) -> Result<IndexSet<ExtendedAddr>> {
-        self.wallet_service.transfer_addresses(name, enckey)
+    fn transfer_addresses(
+        &self,
+        name: &str,
+        enckey: &SecKey,
+        offset: u64,
+        limit: u64,
+        reversed: bool,
+    ) -> Result<IndexSet<ExtendedAddr>> {
+        self.wallet_service
+            .transfer_addresses(name, enckey, offset, limit, reversed)
     }
 
     #[inline]
@@ -924,7 +936,7 @@ where
     }
 
     fn get_multisig_addresses(&self, name: &str, enckey: &SecKey) -> Result<Vec<MultiSigAddress>> {
-        let root_hashes = self.wallet_service.root_hashes(name, enckey)?;
+        let root_hashes = self.wallet_service.root_hashes(name, enckey, 0, 0, false)?;
         root_hashes
             .iter()
             .map(|hash| {
@@ -1613,7 +1625,9 @@ mod tests {
         assert_eq!(staking_address_1, staking_address_2);
         let transfer_address_22 = client.new_transfer_address(name2, &enckey2).unwrap();
         assert_ne!(transfer_address_2, transfer_address_22);
-        let transfer_addresses = client.transfer_addresses(name2, &enckey2).unwrap();
+        let transfer_addresses = client
+            .transfer_addresses(name2, &enckey2, 0, 0, false)
+            .unwrap();
         assert_eq!(transfer_addresses.len(), 2);
     }
 

--- a/client-core/src/wallet/syncer.rs
+++ b/client-core/src/wallet/syncer.rs
@@ -909,7 +909,6 @@ fn filter_staking_transactions(
 /// the staking address in the transaction is self_wallet staking address
 fn filter_incomming_staking_transactions(
     block_results: &BlockResultsResponse,
-    //  staking_addresses: impl Iterator<Item = &'a StakedStateAddress>,
     wallet: Box<dyn Fn(StakedStateAddress) -> bool>,
     block: &Block,
 ) -> Result<Vec<Transaction>> {


### PR DESCRIPTION
add paging to client-rpc, and cli
this is breaking change to current protocol

also check_staking_address_for_deposit is refactored ( get rid of staked addresses copying)

with this pr, after 4,000,000 addresses, query address is very fast.
previously it fetches all, it hangs `postman` 