### PR TITLE
Problem: un-necessary WalletState writing to DB (fix #2032)

### DIFF
--- a/client-core/src/service/wallet_state_service.rs
+++ b/client-core/src/service/wallet_state_service.rs
@@ -411,6 +411,18 @@ enum MementoOperation {
 }
 
 impl WalletStateMemento {
+    /// get length of memento
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// is memento empty?
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Adds transaction change to memento
     #[inline]
     pub fn add_transaction_change(&mut self, transaction_change: TransactionChange) {


### PR DESCRIPTION
Solution: pre-check memento before fetch & update
it will do writing when there is change(it's maximum 2 per block), so speed will be OK

in case , a lot of utxo updates in the block, just one group of mementos will be applied at once.