### PR TITLE
Problem: fuzzer fails to compile (fixes #2039)

### DIFF
--- a/ci-scripts/Dockerfile.fuzzer
+++ b/ci-scripts/Dockerfile.fuzzer
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly-stretch
+FROM rustlang/rust:nightly-buster
 LABEL maintainer="Crypto.com"
 
 RUN apt-get update && \


### PR DESCRIPTION
Solution: updated the docker image to be based off buster (instead of stretch),
as a newer LLVM is needed for libfuzzer-sys compilation
