### PR TITLE
Problem: fuzzer compilation fails (fixes #2052)

### DIFF
--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../../README.md"
 edition = "2018"
 
 [dependencies]
-ring = "0.16.15"
+ring = { version = "0.16.15", features = ["std"] }
 thiserror = "1.0"
 rustls = "0.18"
 x509-parser = "0.8.0-beta4"


### PR DESCRIPTION
Solution: updated the mls dependency specification to include std feature (for error type)

