### PR TITLE
Problem: fuzzer still fails to compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,20 +2845,20 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.3.0"
-source = "git+https://github.com/crypto-com/elliptic-curves.git?rev=15df32b45d8395a1e00eeb3873e1266063e1ec53#15df32b45d8395a1e00eeb3873e1266063e1ec53"
-dependencies = [
- "elliptic-curve 0.5.0-pre",
- "zeroize",
-]
-
-[[package]]
-name = "p256"
-version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a425ecb71515663b2735fd1e65bb638fd134c5ad23857eb197c2f157784476cf"
 dependencies = [
  "elliptic-curve 0.4.0",
  "subtle 2.2.3",
+]
+
+[[package]]
+name = "p256"
+version = "0.3.0"
+source = "git+https://github.com/crypto-com/elliptic-curves.git?rev=15df32b45d8395a1e00eeb3873e1266063e1ec53#15df32b45d8395a1e00eeb3873e1266063e1ec53"
+dependencies = [
+ "elliptic-curve 0.5.0-pre",
+ "zeroize",
 ]
 
 [[package]]

--- a/chain-abci/fuzz/Cargo.toml
+++ b/chain-abci/fuzz/Cargo.toml
@@ -34,3 +34,8 @@ members = ["."]
 [[bin]]
 name = "abci-cycle"
 path = "fuzz_targets/abci_cycle.rs"
+
+[patch.crates-io]
+ring = { git = "https://github.com/crypto-com/ring.git", rev = "bdbcc7041095f028d49d9fecd7edcf26d6083274" }
+# FIXME: before official spec has a solution
+hpke = { git = "https://github.com/crypto-com/rust-hpke.git", rev = "25686eb87d2862535b1d5107d74e2ac8bd992bae" }


### PR DESCRIPTION
Solution: patch crates.io in fuzzer manifest

