### PR TITLE
Problem: light client witness nodes can't be configured in client-* (…

### DIFF
--- a/client-cli/src/command.rs
+++ b/client-cli/src/command.rs
@@ -214,6 +214,16 @@ pub enum Command {
             help = "Disable light client, which is not secure when connecting to outside nodes"
         )]
         disable_light_client: bool,
+
+        #[structopt(
+            name = "light client peer",
+            short = "l",
+            long = "light-client-peers",
+            default_value = "",
+            help = "Light client peers"
+        )]
+        light_client_peers: String,
+
         #[structopt(
             name = "disable-address-recovery",
             long,
@@ -391,6 +401,7 @@ impl Command {
                 disable_light_client,
                 disable_address_recovery,
                 block_height_ensure,
+                light_client_peers,
             } => {
                 let enckey = ask_seckey(None)?;
                 let rpc_url = tendermint_url();
@@ -401,8 +412,8 @@ impl Command {
                 let storage = SledStorage::new(&db_path)?;
                 let handle = spawn_light_client_supervisor(
                     db_path.as_ref(),
-                    &rpc_url,
                     tendermint_client.genesis()?.trusting_period(),
+                    light_client_peers.into(),
                 )?;
                 let config = ObfuscationSyncerConfig::new(
                     storage.clone(),
@@ -414,6 +425,7 @@ impl Command {
                         enable_address_recovery: !*disable_address_recovery,
                         batch_size: *batch_size,
                         block_height_ensure: *block_height_ensure,
+                        light_client_peers: light_client_peers.clone(),
                     },
                     handle.clone(),
                 );

--- a/client-rpc/server/src/program.rs
+++ b/client-rpc/server/src/program.rs
@@ -11,6 +11,7 @@ ENVIRONMENT VARIABLES:
     CRYPTO_GENESIS_FINGERPRINT             Set the genesis fingerprint(Optional)
     "#
 )]
+
 pub struct Options {
     #[structopt(
         name = "host",
@@ -62,6 +63,16 @@ pub struct Options {
         help = "Disable light client, which is not secure when connecting to outside nodes"
     )]
     pub disable_light_client: bool,
+
+    #[structopt(
+        name = "light client peer",
+        short = "l",
+        long = "light-client-peers",
+        default_value = "",
+        help = "Light client peers"
+    )]
+    pub light_client_peers: String,
+
     #[structopt(
         name = "disable-address-recovery",
         long,

--- a/client-rpc/server/src/server.rs
+++ b/client-rpc/server/src/server.rs
@@ -36,6 +36,7 @@ impl Server {
                 enable_address_recovery: !options.disable_address_recovery,
                 batch_size: options.batch_size,
                 block_height_ensure: options.block_height_ensure,
+                light_client_peers: options.light_client_peers,
             },
         })
     }

--- a/client-rpc/src/handler.rs
+++ b/client-rpc/src/handler.rs
@@ -67,8 +67,8 @@ impl RpcHandler {
         )?;
         let handle = spawn_light_client_supervisor(
             storage_dir.as_ref(),
-            websocket_url,
             tendermint_client.genesis()?.trusting_period(),
+            sync_options.light_client_peers.clone(),
         )?;
         let syncer_config = AppSyncerConfig::new(
             storage.clone(),

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -220,6 +220,8 @@ unsafe fn create_rpc(
         enable_address_recovery: true,
         batch_size: 50,
         block_height_ensure: 50,
+        light_client_peers: "0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657"
+        .into(),
     };
     let handler = RpcHandler::new(
         &storage_dir,

--- a/integration-tests/bot/chainbot.py
+++ b/integration-tests/bot/chainbot.py
@@ -266,6 +266,7 @@ def programs(node, app_hash, root_path, cfg):
         ('client-rpc', f"client-rpc --port={client_rpc_port} --chain-id={cfg['chain_id']} "
          f"--storage-dir={node_path / Path('wallet')} "
          f"--websocket-url=ws://127.0.0.1:{tendermint_rpc_port}/websocket "
+         f"--light-client-peers=\"0000000000000000000000000000000000000000@127.0.0.1:{tendermint_rpc_port},1000000000000000000000000000000000000000@127.0.0.1:{tendermint_rpc_port}\" "
          ,
          dict(def_env, CRYPTO_GENESIS_FINGERPRINT=cfg['genesis_fingerprint'])),
     ]

--- a/integration-tests/bot/client_cli.py
+++ b/integration-tests/bot/client_cli.py
@@ -279,8 +279,10 @@ class Wallet():
             enable_fast_forward=True,
             batch_size=20,
             block_height_ensure=50,
+            light_client_peers="0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657"
     ):
-        cmd = ["client-cli", "sync", "-n", self.name, "--batch-size", str(batch_size), "--block-height-ensure", str(block_height_ensure)]
+        cmd = ["client-cli", "sync", "-n", self.name, "--batch-size", str(batch_size), "--block-height-ensure", str(block_height_ensure),
+        "--light-client-peers", light_client_peers]
         if force:
             cmd.append("--force")
         if disable_address_recovery:


### PR DESCRIPTION
Soution: add witness, peer configuration
option example) 
--light-client-peers "429......02665@10.11.12.13:26657,96663a3....21c693@10.11.12.14:26657"
first will be primary, others witnesses

