### PR TITLE
Problem: no domain separation of hashed data types (fixes #1715)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "aesm-client",
  "base64 0.12.3",
  "bit-vec",
+ "blake3",
  "byteorder",
  "cc",
  "chain-core",
@@ -1412,6 +1413,7 @@ dependencies = [
 name = "enclave-protocol"
 version = "0.6.0"
 dependencies = [
+ "blake3",
  "chain-core",
  "chain-tx-validation",
  "parity-scale-codec",

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -21,7 +21,7 @@ enclave-protocol = { path = "../enclave-protocol" }
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
 mls = { path = "../chain-tx-enclave-next/mls" }
 ra-client = { path = "../chain-tx-enclave-next/enclave-ra/ra-client" }
-
+blake3 = { version = "0.3.6", default-features = false }
 
 log = "0.4.11"
 env_logger = "0.7.1"

--- a/chain-abci/src/app/query.rs
+++ b/chain-abci/src/app/query.rs
@@ -7,7 +7,7 @@ use chain_core::common::{MerkleTree, Proof as MerkleProof, H256, HASH_SIZE_256};
 use chain_core::state::account::StakedStateAddress;
 use chain_core::state::tendermint::BlockHeight;
 use chain_core::state::ChainState;
-use chain_core::tx::data::{txid_hash, TXID_HASH_ID};
+use chain_core::tx::data::TXID_HASH_ID;
 use chain_storage::jellyfish::get_with_proof;
 use chain_storage::LookupItem;
 use parity_scale_codec::{Decode, Encode};
@@ -17,7 +17,8 @@ fn get_witness_proof_op(witness: &[u8]) -> ProofOp {
     let mut op = ProofOp::new();
     op.set_field_type("witness".into());
     op.set_key(TXID_HASH_ID.to_vec());
-    op.set_data(txid_hash(witness).to_vec());
+    let witness_hash: [u8; 32] = blake3::hash(&witness).into();
+    op.set_data(witness_hash.to_vec());
     op
 }
 

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -32,7 +32,7 @@ use chain_core::tx::{
         attribute::TxAttributes,
         input::{TxoPointer, TxoSize},
         output::TxOut,
-        txid_hash, Tx, TxId,
+        Tx, TxId,
     },
     witness::{TxInWitness, TxWitness},
     PlainTxAux, TransactionId, TxAux, TxEnclaveAux, TxPublicAux,
@@ -1196,7 +1196,8 @@ fn query_should_return_proof_for_committed_tx() {
         }
         _ => unreachable!(),
     }
-    assert_eq!(proof.ops[1].data, txid_hash(&qresp.value));
+    let witness_hash: [u8; 32] = blake3::hash(&qresp.value).into();
+    assert_eq!(proof.ops[1].data, witness_hash.to_vec());
 }
 
 #[test]

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [features]
 default = ["sha2", "serde", "bech32", "hex", "base64", "secp256k1/serde", "secp256k1/std", "mls", "ra-client"]
 edp = ["secp256k1/lowmemory"]
+new-txid = []
 
 [dependencies]
 mls = { path = "../chain-tx-enclave-next/mls", optional = true }

--- a/chain-core/src/mls/mod.rs
+++ b/chain-core/src/mls/mod.rs
@@ -1,6 +1,57 @@
+use crate::tx::data::TxId;
+#[cfg(feature = "new-txid")]
+use crate::tx::TaggedTransaction;
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode};
 use std::prelude::v1::Vec;
+
+/// message to remove members
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct CommitRemoveTx {
+    proposals: Vec<Vec<u8>>, // [MLSPlaintext] -- Remove
+    commit: Vec<u8>,         // MLSPlaintext -- Commit
+}
+
+#[cfg(not(feature = "new-txid"))]
+impl TransactionId for CommitRemoveTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<CommitRemoveTx> for TaggedTransaction {
+    fn from(tx: CommitRemoveTx) -> TaggedTransaction {
+        TaggedTransaction::MLSRemoveCommitProposal(tx)
+    }
+}
+
+/// message to update its own leaf
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct SelfUpdateProposalTx {
+    proposal: Vec<u8>, // MLSPlaintext -- Update
+    commit: Vec<u8>,   // MLSPlaintext -- Commit
+}
+
+#[cfg(not(feature = "new-txid"))]
+impl TransactionId for SelfUpdateProposalTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<SelfUpdateProposalTx> for TaggedTransaction {
+    fn from(tx: SelfUpdateProposalTx) -> TaggedTransaction {
+        TaggedTransaction::MLSSelfUpdateProposal(tx)
+    }
+}
+
+/// FIXME: NackMsg in mls/extras
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct NackMsgTx(Vec<u8>);
+
+#[cfg(not(feature = "new-txid"))]
+impl TransactionId for NackMsgTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<NackMsgTx> for TaggedTransaction {
+    fn from(tx: NackMsgTx) -> TaggedTransaction {
+        TaggedTransaction::MLSMsgNack(tx)
+    }
+}
 
 /// A wrapper type for payloads generated and exchanged
 /// by a part of "Transaction Data Bootstrapping Enclave" (TDBE)
@@ -9,24 +60,23 @@ use std::prelude::v1::Vec;
 /// but this may switch to SCALE
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 pub enum MLSHandshakeAux {
-    /// the reaction to node joining or leaving (nodejoin tx or events)
-    CommitProposal {
-        /// MLSPlaintext -- any proposals (Add or Remove), the last one is assumed to be Commit
-        messages: Vec<Vec<u8>>,
-        /// Welcome -- if there are any Add proposals, there should be a welcome with encrypted paths/epochs for new joiners
-        welcome: Option<Vec<u8>>,
-    },
+    /// the reaction to node leaving (keypackage expire, unbond tx or events)
+    RemoveCommitProposal(CommitRemoveTx),
     /// when the keypackage is about to expire, the member submits its renewal
-    SelfUpdateProposal {
-        /// MLSPlaintext -- Update
-        proposal: Vec<u8>,
-        /// MLSPlaintext -- Commit
-        commit: Vec<u8>,
-    },
+    SelfUpdateProposal(SelfUpdateProposalTx),
     /// DLEQ proof: https://github.com/crypto-com/chain/pull/1805/files#diff-f5bad205e7530b482b54bda5e678249aR23
     /// + some way to refer to the message part that went wrong
     /// FIXME: spec/data type
-    MsgNack(Vec<u8>),
+    MsgNack(NackMsgTx),
 }
 
-impl TransactionId for MLSHandshakeAux {}
+impl MLSHandshakeAux {
+    /// retrieves a TX ID (currently blake3(<tx type tag> || scale_codec_bytes(tx)))
+    pub fn tx_id(&self) -> TxId {
+        match self {
+            MLSHandshakeAux::RemoveCommitProposal(tx) => tx.id(),
+            MLSHandshakeAux::SelfUpdateProposal(tx) => tx.id(),
+            MLSHandshakeAux::MsgNack(tx) => tx.id(),
+        }
+    }
+}

--- a/chain-core/src/state/account.rs
+++ b/chain-core/src/state/account.rs
@@ -499,12 +499,16 @@ pub struct StakedState {
 }
 
 /// the tree used in StakedState storage db has a hardcoded 32-byte keys,
-/// this computes a key as blake3(StakedState.address) where
+/// this computes a key as blake3(0 || StakedState.address) where
 /// the StakedState address itself is ETH-style address (20 bytes from keccak hash of public key)
 pub fn to_stake_key(address: &StakedStateAddress) -> [u8; HASH_SIZE_256] {
-    // TODO: prefix with zero
     match address {
-        StakedStateAddress::BasicRedeem(a) => blake3::hash(a),
+        StakedStateAddress::BasicRedeem(a) => {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(&[0u8]);
+            hasher.update(a);
+            hasher.finalize()
+        }
     }
     .into()
 }

--- a/chain-core/src/state/account/op/data/deposit.rs
+++ b/chain-core/src/state/account/op/data/deposit.rs
@@ -1,6 +1,9 @@
 use crate::state::account::address::StakedStateAddress;
 use crate::state::account::op::data::attribute::StakedStateOpAttributes;
 use crate::tx::data::input::TxoPointer;
+#[cfg(feature = "new-txid")]
+use crate::tx::TaggedTransaction;
+#[cfg(not(feature = "new-txid"))]
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 use serde::{Deserialize, Serialize};
@@ -59,7 +62,15 @@ impl Encode for DepositBondTx {
     }
 }
 
+#[cfg(not(feature = "new-txid"))]
 impl TransactionId for DepositBondTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<DepositBondTx> for TaggedTransaction {
+    fn from(tx: DepositBondTx) -> TaggedTransaction {
+        TaggedTransaction::Deposit(tx)
+    }
+}
 
 impl DepositBondTx {
     /// create a new tx

--- a/chain-core/src/state/account/op/data/unbond.rs
+++ b/chain-core/src/state/account/op/data/unbond.rs
@@ -2,6 +2,9 @@ use crate::init::coin::Coin;
 use crate::state::account::address::StakedStateAddress;
 use crate::state::account::op::data::attribute::StakedStateOpAttributes;
 use crate::state::account::Nonce;
+#[cfg(feature = "new-txid")]
+use crate::tx::TaggedTransaction;
+#[cfg(not(feature = "new-txid"))]
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
@@ -55,7 +58,15 @@ impl Encode for UnbondTx {
     }
 }
 
+#[cfg(not(feature = "new-txid"))]
 impl TransactionId for UnbondTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<UnbondTx> for TaggedTransaction {
+    fn from(tx: UnbondTx) -> TaggedTransaction {
+        TaggedTransaction::UnbondStakeTx(tx)
+    }
+}
 
 impl UnbondTx {
     /// creates a new tx to unbond certain amount

--- a/chain-core/src/state/account/op/data/withdraw.rs
+++ b/chain-core/src/state/account/op/data/withdraw.rs
@@ -2,6 +2,9 @@ use crate::init::coin::{sum_coins, Coin, CoinError};
 use crate::state::account::Nonce;
 use crate::tx::data::attribute::TxAttributes;
 use crate::tx::data::output::TxOut;
+#[cfg(feature = "new-txid")]
+use crate::tx::TaggedTransaction;
+#[cfg(not(feature = "new-txid"))]
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
@@ -48,7 +51,15 @@ impl Encode for WithdrawUnbondedTx {
     }
 }
 
+#[cfg(not(feature = "new-txid"))]
 impl TransactionId for WithdrawUnbondedTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<WithdrawUnbondedTx> for TaggedTransaction {
+    fn from(tx: WithdrawUnbondedTx) -> TaggedTransaction {
+        TaggedTransaction::Withdraw(tx)
+    }
+}
 
 impl WithdrawUnbondedTx {
     /// creates a new tx to withdraw unbonded stake

--- a/chain-core/src/state/validator/nodejoin.rs
+++ b/chain-core/src/state/validator/nodejoin.rs
@@ -1,4 +1,7 @@
 use crate::state::account::{NodeMetadata, Nonce, StakedStateAddress, StakedStateOpAttributes};
+#[cfg(feature = "new-txid")]
+use crate::tx::TaggedTransaction;
+#[cfg(not(feature = "new-txid"))]
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
@@ -60,7 +63,15 @@ impl Encode for NodeJoinRequestTx {
     }
 }
 
+#[cfg(not(feature = "new-txid"))]
 impl TransactionId for NodeJoinRequestTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<NodeJoinRequestTx> for TaggedTransaction {
+    fn from(tx: NodeJoinRequestTx) -> TaggedTransaction {
+        TaggedTransaction::NodeJoinTx(tx)
+    }
+}
 
 impl NodeJoinRequestTx {
     /// constructs a new node join request transaction from the provided components

--- a/chain-core/src/state/validator/unjail.rs
+++ b/chain-core/src/state/validator/unjail.rs
@@ -1,4 +1,7 @@
 use crate::state::account::{Nonce, StakedStateAddress, StakedStateOpAttributes};
+#[cfg(feature = "new-txid")]
+use crate::tx::TaggedTransaction;
+#[cfg(not(feature = "new-txid"))]
 use crate::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
@@ -43,7 +46,15 @@ impl Encode for UnjailTx {
     }
 }
 
+#[cfg(not(feature = "new-txid"))]
 impl TransactionId for UnjailTx {}
+
+#[cfg(feature = "new-txid")]
+impl From<UnjailTx> for TaggedTransaction {
+    fn from(tx: UnjailTx) -> TaggedTransaction {
+        TaggedTransaction::UnjailTx(tx)
+    }
+}
 
 impl UnjailTx {
     /// constructs a new unjail transaction from the provided components

--- a/client-common/src/cipher/mock.rs
+++ b/client-common/src/cipher/mock.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use crate::tendermint::Client;
 use crate::{PrivateKey, Result, SignedTransaction, Transaction};
 use chain_core::tx::data::TxId;
-use chain_core::tx::{TransactionId, TxAux, TxEnclaveAux, TxWithOutputs};
+use chain_core::tx::{TxAux, TxEnclaveAux, TxWithOutputs};
 use mock_utils::{encrypt, unseal};
 
 use crate::TransactionObfuscation;
@@ -60,7 +60,7 @@ where
     }
 
     fn encrypt(&self, transaction: SignedTransaction) -> Result<TxAux> {
-        let payload = encrypt(&transaction.clone().into(), transaction.id());
+        let payload = encrypt(&transaction.clone().into(), transaction.tx_id());
         let enclave_tx = match transaction {
             SignedTransaction::TransferTransaction(tx, _) => TxEnclaveAux::TransferTx {
                 inputs: tx.inputs.clone(),

--- a/client-common/src/key/private_key.rs
+++ b/client-common/src/key/private_key.rs
@@ -1,5 +1,4 @@
 use crate::Transaction;
-use chain_core::tx::TransactionId;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 use rand::rngs::OsRng;
 use secp256k1::schnorrsig::{schnorr_sign, schnorr_sign_aux, AuxRandNonce, SchnorrSignature};

--- a/client-common/src/transaction.rs
+++ b/client-common/src/transaction.rs
@@ -103,8 +103,9 @@ impl Transaction {
     }
 }
 
-impl TransactionId for Transaction {
-    fn id(&self) -> TxId {
+impl Transaction {
+    /// transaction id of the encapsulated transaction type
+    pub fn id(&self) -> TxId {
         match self {
             Transaction::TransferTransaction(ref transaction) => transaction.id(),
             Transaction::DepositStakeTransaction(ref transaction) => transaction.id(),
@@ -136,8 +137,9 @@ pub enum SignedTransaction {
     WithdrawUnbondedStakeTransaction(WithdrawUnbondedTx, StakedStateOpWitness),
 }
 
-impl TransactionId for SignedTransaction {
-    fn id(&self) -> TxId {
+impl SignedTransaction {
+    /// transaction ID of the inner types
+    pub fn tx_id(&self) -> TxId {
         match self {
             SignedTransaction::TransferTransaction(ref transaction, _) => transaction.id(),
             SignedTransaction::DepositStakeTransaction(ref transaction, _) => transaction.id(),

--- a/client-core/src/signer/wallet_signer.rs
+++ b/client-core/src/signer/wallet_signer.rs
@@ -201,7 +201,6 @@ mod wallet_signer_tests {
     use secstr::SecUtf8;
 
     use chain_core::tx::data::Tx;
-    use chain_core::tx::TransactionId;
     use chain_tx_validation::witness::verify_tx_address;
     use client_common::storage::MemoryStorage;
 

--- a/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
+++ b/client-core/src/transaction_builder/default_wallet_transaction_builder.rs
@@ -13,7 +13,7 @@ use client_common::{
 use crate::signer::WalletSignerManager;
 use crate::transaction_builder::RawTransferTransactionBuilder;
 use crate::{SelectedUnspentTransactions, UnspentTransactions, WalletTransactionBuilder};
-use chain_core::tx::{data::TxId, TransactionId};
+use chain_core::tx::data::TxId;
 
 /// Default implementation of `TransactionBuilder`
 ///

--- a/client-core/src/types/transaction_change.rs
+++ b/client-core/src/types/transaction_change.rs
@@ -267,12 +267,12 @@ impl From<&Transaction> for TransactionType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chain_core::{init::coin::Coin, tx::data::txid_hash};
+    use chain_core::init::coin::Coin;
 
     #[test]
     fn check_transaction_change_encode_decode() {
         let transaction_change = TransactionChange {
-            transaction_id: txid_hash(&[0, 1, 2]),
+            transaction_id: blake3::hash(&[0, 1, 2]).into(),
             inputs: Vec::new(),
             outputs: Vec::new(),
             balance_change: BalanceChange::Incoming {

--- a/client-core/src/wallet/default_wallet_client.rs
+++ b/client-core/src/wallet/default_wallet_client.rs
@@ -29,7 +29,7 @@ use chain_core::tx::fee::Fee;
 use chain_core::tx::witness::tree::RawXOnlyPubkey;
 #[cfg(feature = "experimental")]
 use chain_core::tx::witness::{TxInWitness, TxWitness};
-use chain_core::tx::{TransactionId, TxAux, TxEnclaveAux, TxObfuscated};
+use chain_core::tx::{TxAux, TxEnclaveAux, TxObfuscated};
 use client_common::tendermint::types::Time;
 use client_common::tendermint::types::{AbciQueryExt, BlockResults, BroadcastTxResponse};
 use client_common::tendermint::{Client, UnauthorizedClient};

--- a/client-core/src/wallet/syncer.rs
+++ b/client-core/src/wallet/syncer.rs
@@ -35,7 +35,6 @@ use chain_core::state::ChainState;
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::TxId;
 use chain_core::tx::fee::Fee;
-use chain_core::tx::TransactionId;
 use chain_storage::jellyfish::compute_staking_root;
 use chain_tx_filter::BlockFilter;
 use chain_util::NonEmpty;
@@ -702,6 +701,7 @@ const CRYPTO_GENESIS_FINGERPRINT: &str =
 /// compute the hash of genesis
 pub fn compute_genesis_fingerprint(genesis: &Genesis) -> Result<String> {
     let mut hasher = blake3::Hasher::new();
+    hasher.update(b"genesis_fingerprint");
     hasher.update(genesis.app_hash.as_ref());
     for validator in genesis
         .validators

--- a/client-core/src/wallet/syncer_logic.rs
+++ b/client-core/src/wallet/syncer_logic.rs
@@ -9,7 +9,6 @@ use chain_core::tx::{
         TxId,
     },
     fee::Fee,
-    TransactionId,
 };
 use chain_util::NonEmpty;
 use client_common::tendermint::types::Time;
@@ -257,7 +256,6 @@ mod tests {
     };
     use chain_core::tx::data::{address::ExtendedAddr, attribute::TxAttributes, output::TxOut, Tx};
     use chain_core::tx::fee::Fee;
-    use chain_core::tx::TransactionId;
     use chain_tx_filter::BlockFilter;
     use client_common::{storage::MemoryStorage, PublicKey, Result, Transaction};
 

--- a/cro-clib/chain-core.h
+++ b/cro-clib/chain-core.h
@@ -12,10 +12,13 @@
  *
  * version 0 -- 0.4.0 release
  * version 1 -- 0.5.0 release (wire format didn't change, but unbond tx semantics changed: https://github.com/crypto-com/chain/pull/1516)
- * version 2 -- 0.6.0 (not yet released --> transaction data bootstrapping, new TX types, genesis changes..);
- * FIXME: bump to 2 with https://github.com/crypto-com/chain/issues/1715#issuecomment-650845116
  */
 #define APP_VERSION 1
+
+/**
+ * version 2 -- 0.6.0 (not yet released --> transaction data bootstrapping, new TX types, genesis changes, TXID calculation change, app hash calculation change);
+ */
+#define APP_VERSION 2
 
 /**
  * Size in bytes of a 256-bit hash

--- a/docker/config/devnet/tendermint/genesis.json
+++ b/docker/config/devnet/tendermint/genesis.json
@@ -1,5 +1,5 @@
 {
-    "app_hash": "068255d2dc765dcd4d3f6141f0b215e9af985264746c8d972fc07dca9c296e5e",
+    "app_hash": "9B3263E4412E90902E7ED634399062A8DEDF45E89C87919E1474FD23EF77BB2F",
     "app_state": {
         "council_nodes": {
             "0x45c1851c2f0dc6138935857b9e23b173185fea15": [

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -15,3 +15,4 @@ chain-core = { path = "../chain-core", default-features = false }
 chain-tx-validation = { path = "../chain-tx-validation", default-features = false }
 parity-scale-codec = { version = "1.3", features = ["derive"] }
 secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d" }
+blake3 = { version = "0.3.6", default-features = false }


### PR DESCRIPTION
Solution: currently the data types are distinct, but it could happen
in the future that two TX types have the same/similar schema,
so the txid would be the same and one may potentially "swap"
tx type (e.g. one may sign unjailtx, but malicious party
would broadcast it as unbondtx -- currently not possible,
bu just an example of what this aims to prevent).
- a trait "TransactionType" was added and implemented for all tx payloads
- txid is now calculated as blake3(\<type tag\>||scale_payload(tx))
- note this "breaks" 0.5 signing code
(as even though the payload is the same, wallets will be
using a different message digest) -- for that reason,
    it's feature-guarded under "new-txid"