### PR TITLE
Problem: rust compilation currently doesn't apply LVI mitigations (fixes #1746)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.16.15"
-source = "git+https://github.com/crypto-com/ring.git?rev=bdbcc7041095f028d49d9fecd7edcf26d6083274#bdbcc7041095f028d49d9fecd7edcf26d6083274"
+source = "git+https://github.com/crypto-com/ring.git?rev=8f2b68d2ac53b1df61ca5cdc1190f86d74e302a3#8f2b68d2ac53b1df61ca5cdc1190f86d74e302a3"
 dependencies = [
  "cc",
  "libc",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.17.2"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=535790e91fac1b3b00c770cb339a06feadc5f48d#535790e91fac1b3b00c770cb339a06feadc5f48d"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=984ccbccb48d62f5cb46f6fc1c75a04f34102987#984ccbccb48d62f5cb46f6fc1c75a04f34102987"
 dependencies = [
  "rand 0.7.3",
  "secp256k1-sys",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.1.3"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=535790e91fac1b3b00c770cb339a06feadc5f48d#535790e91fac1b3b00c770cb339a06feadc5f48d"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=984ccbccb48d62f5cb46f6fc1c75a04f34102987#984ccbccb48d62f5cb46f6fc1c75a04f34102987"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 ]
 
 [patch.crates-io]
-ring = { git = "https://github.com/crypto-com/ring.git", rev = "bdbcc7041095f028d49d9fecd7edcf26d6083274" }
+ring = { git = "https://github.com/crypto-com/ring.git", rev = "8f2b68d2ac53b1df61ca5cdc1190f86d74e302a3" }
 # FIXME: use upstream when merged
 sha2 = { git = "https://github.com/crypto-com/hashes.git", rev = "289d5b76f2163a3808010341ed1df3cb156d97e1" }
 # FIXME: before official spec has a solution

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -35,7 +35,7 @@ hex = "0.4"
 protobuf = "2.7.0"
 integer-encoding = "1.1.5"
 structopt = "0.3"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 thiserror = "1.0"
 

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.9", default-features = false}
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 sha2 = { version = "0.9", default-features = false, optional = true }
 hex = { version = "0.4", optional = true }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake3 = { version = "0.3.6", default-features = false }
 parity-scale-codec = { features = ["derive"], version = "1.3" }

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
@@ -13,7 +13,7 @@ parity-scale-codec = "1.3"
 rand = "0.7"
 rs-libc = "0.2"
 rustls = "0.18"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["lowmemory"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["lowmemory"] }
 thread-pool = "0.1"
 zeroize = "1.1"
 chrono = "0.4"

--- a/chain-tx-enclave-next/tx-validation-next/Cargo.toml
+++ b/chain-tx-enclave-next/tx-validation-next/Cargo.toml
@@ -11,7 +11,7 @@ enclave-macro = { path = "../../chain-tx-enclave/enclave-macro" }
 chain-tx-validation   = {  path = "../../chain-tx-validation" }
 chain-core   = {  path = "../../chain-core" }
 # TODO: "rand" feature may only be dev-dependency / needed for tests
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig", "rand"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig", "rand"] }
 parity-scale-codec = { version = "1.3" }
 enclave-protocol   = { path = "../../enclave-protocol" }
 chain-tx-filter   = { path = "../../chain-tx-filter" }

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -12,7 +12,7 @@ default = ["bit-vec/std", "chain-core/default"]
 [dependencies]
 chain-core = { default-features = false, path = "../chain-core" }
 parity-scale-codec = { version = "1.3" }
-secp256k1 = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["endomorphism"] }
+secp256k1 = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["endomorphism"] }
 bit-vec = { default-features = false, version = "0.6" }
 
 [dev-dependencies]

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -11,7 +11,7 @@ default = ["chain-core/default", "thiserror"]
 
 [dependencies]
 chain-core = { path = "../chain-core", default-features = false }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 thiserror = { version = "1.0", default-features = false, optional = true }
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.7"
 rust-argon2 = "0.8"
 rustls =  { version = "0.18", features = ["dangerous_configuration"] }
 # secp256k1experimental = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "cccfdb77c068b9cefa07b6884849f8473683d6d4", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "schnorrsig"] }
 secstr = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -16,7 +16,7 @@ chain-storage = { path = "../chain-storage", default-features = false }
 once_cell = "1.4"
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
 # secp256k1experimental = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "cccfdb77c068b9cefa07b6884849f8473683d6d4", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["serde", "rand", "recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["serde", "rand", "recovery", "endomorphism", "schnorrsig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.7"

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -17,9 +17,9 @@ base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 hex = "0.4.2"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery"] }
 tendermint = "0.15"
 
 [dev-dependencies]
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["serde", "rand", "recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["serde", "rand", "recovery", "endomorphism"] }
 test-common = { path = "../test-common" }

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -22,7 +22,7 @@ client-core = { path = "../client-core" }
 client-network = { path = "../client-network" }
 client-rpc-core = { path = "../client-rpc" }
 secstr = { version = "0.4.0", features = ["serde"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism"] }
 jsonrpc-core = "14.2"
 libc = "0.2.74"
 env_logger = "0.7"

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -22,7 +22,7 @@ dirs = "3.0.1"
 quest = "0.3"
 secstr = "0.4.0"
 parity-scale-codec = { version = "1.3" }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
 base64 = "0.12"
 mls = { path = "../chain-tx-enclave-next/mls" }
 ra-client = { path = "../chain-tx-enclave-next/enclave-ra/ra-client" }

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -24,20 +24,10 @@ fi
 cd ..
 echo "Build $BUILD_MODE $BUILD_PROFILE"
 if [ $BUILD_MODE == "sgx" ]; then
-    # fix the rust-lld error: contains a compressed section, but zlib is not available
-    export CFLAGS="-gz=none"
 
     cargo build $CARGO_ARGS
     cargo build $CARGO_ARGS --features mock-hardware-wallet --manifest-path client-cli/Cargo.toml
     cargo build $CARGO_ARGS --manifest-path integration-tests/rust_tests/test_cert_expiration/Cargo.toml
-
-    # Add fortanix target and tools
-    rustup target add x86_64-fortanix-unknown-sgx
-    cargo install fortanix-sgx-tools sgxs-tools
-
-    # FIXME: test enclave packages
-    # LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service --no-daemon &
-    # NETWORK_ID="ab" cargo test --target=x86_64-fortanix-unknown-sgx -p tx-validation-next -p enclave-utils
 
     # mls enclave -- FIXME: TDBE, mls should only be a library
     cargo build --target=x86_64-fortanix-unknown-sgx -p mls

--- a/docker/sgx_test.sh
+++ b/docker/sgx_test.sh
@@ -16,11 +16,7 @@ else
     EDP_ARGS=
 fi
 
-# fix the rust-lld error: contains a compressed section, but zlib is not available
-export CFLAGS="-gz=none"
-# Add fortanix target and tools
-rustup target add x86_64-fortanix-unknown-sgx
-cargo install fortanix-sgx-tools sgxs-tools
+# Add a test runner
 mkdir .cargo
 echo "[target.x86_64-fortanix-unknown-sgx]
 runner = \"ftxsgx-runner-cargo\"" >> .cargo/config

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -1,3 +1,4 @@
+
 [package]
 name = "enclave-protocol"
 version = "0.6.0"
@@ -14,5 +15,5 @@ edp = ["chain-core/edp", "parity-scale-codec/std", "secp256k1/lowmemory"]
 chain-core = { path = "../chain-core", default-features = false }
 chain-tx-validation = { path = "../chain-tx-validation", default-features = false }
 parity-scale-codec = { version = "1.3", features = ["derive"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "535790e91fac1b3b00c770cb339a06feadc5f48d" }
 blake3 = { version = "0.3.6", default-features = false }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987" }

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -17,7 +17,7 @@ signature = "1.1"
 abci = "0.7"
 kvdb-memorydb = "0.7"
 protobuf = "2.7.0"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "535790e91fac1b3b00c770cb339a06feadc5f48d", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 base64 = "0.12"
 hex = "0.4"


### PR DESCRIPTION
Solution: updated the C dependencies to insert
"-mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
flags (supported by latest LLVM 11)
+ updated docker image building to use later EDP nightly


