### PR TITLE
Problem: secp256k1 not up to date with upstream (fixes #2091)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,6 @@ dependencies = [
  "indexmap",
  "itertools 0.9.0",
  "jsonrpc-core",
- "lazy_static",
  "log",
  "mock-utils",
  "once_cell",
@@ -3838,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.17.2"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=984ccbccb48d62f5cb46f6fc1c75a04f34102987#984ccbccb48d62f5cb46f6fc1c75a04f34102987"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a#1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a"
 dependencies = [
  "rand 0.7.3",
  "secp256k1-sys",
@@ -3849,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.1.3"
-source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=984ccbccb48d62f5cb46f6fc1c75a04f34102987#984ccbccb48d62f5cb46f6fc1c75a04f34102987"
+source = "git+https://github.com/crypto-com/rust-secp256k1-zkp.git?rev=1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a#1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a"
 dependencies = [
  "cc",
 ]

--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -36,7 +36,7 @@ hex = "0.4"
 protobuf = "2.7.0"
 integer-encoding = "1.1.5"
 structopt = "0.3"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "global-context"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 thiserror = "1.0"
 

--- a/chain-abci/src/staking/mod.rs
+++ b/chain-abci/src/staking/mod.rs
@@ -5,10 +5,7 @@ pub use table::{RewardsDistribution, StakingTable};
 
 #[cfg(test)]
 mod tests {
-    use secp256k1::{
-        key::{PublicKey, SecretKey},
-        Secp256k1,
-    };
+    use secp256k1::key::{PublicKey, SecretKey};
     use std::str::FromStr;
 
     use chain_core::init::address::RedeemAddress;
@@ -46,7 +43,7 @@ mod tests {
     type StakingMemStore = MemStore<StakedStateAddress, StakedState>;
 
     fn staking_address(seed: &[u8; 32]) -> StakedStateAddress {
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let secret_key = SecretKey::from_slice(seed).expect("32 bytes, within curve order");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -451,7 +451,7 @@ fn check_tx_should_reject_invalid_tx() {
 }
 
 fn prepare_app_valid_tx() -> (ChainNodeApp<MockClient>, TxAux, WithdrawUnbondedTx) {
-    let secp = Secp256k1::new();
+    let secp = secp256k1::SECP256K1;
     let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
     let addr = RedeemAddress::from(&public_key);
@@ -901,7 +901,7 @@ fn get_tx_meta(txid: &TxId, app: &ChainNodeApp<MockClient>) -> BitVec {
 #[test]
 #[allow(clippy::cognitive_complexity)]
 fn all_valid_tx_types_should_commit() {
-    let secp = Secp256k1::new();
+    let secp = secp256k1::SECP256K1;
     let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
     let x_public_key = XOnlyPublicKey::from_secret_key(&secp, &secret_key);
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
@@ -1066,7 +1066,7 @@ fn all_valid_tx_types_should_commit() {
         StakedStateOpAttributes::new(0),
         mock_council_node_join(TendermintValidatorPubKey::Ed25519([2u8; 32])),
     );
-    let secp = Secp256k1::new();
+    let secp = secp256k1::SECP256K1;
     let witness = StakedStateOpWitness::new(get_ecdsa_witness(&secp, &tx.id(), &secret_key));
     let nodejointx = TxAux::PublicTx(TxPublicAux::NodeJoinTx(tx, witness));
     {

--- a/chain-core/Cargo.toml
+++ b/chain-core/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.9", default-features = false}
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 sha2 = { version = "0.9", default-features = false, optional = true }
 hex = { version = "0.4", optional = true }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "schnorrsig", "global-context"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake3 = { version = "0.3.6", default-features = false }
 parity-scale-codec = { features = ["derive"], version = "1.3" }

--- a/chain-core/src/tx/mod.rs
+++ b/chain-core/src/tx/mod.rs
@@ -672,9 +672,7 @@ pub mod tests {
     use crate::tx::witness::tree::RawXOnlyPubkey;
     use crate::tx::witness::TxInWitness;
     use parity_scale_codec::{Decode, Encode};
-    use secp256k1::{
-        key::XOnlyPublicKey, schnorrsig::schnorr_sign, Message, PublicKey, Secp256k1, SecretKey,
-    };
+    use secp256k1::{key::XOnlyPublicKey, schnorrsig::schnorr_sign, Message, PublicKey, SecretKey};
 
     // TODO: rewrite as quickcheck prop
     #[test]
@@ -683,7 +681,7 @@ pub mod tests {
         let mut tx = Tx::new();
         tx.add_input(TxoPointer::new([0x01; 32], 1));
         tx.add_output(TxOut::new(ExtendedAddr::OrTree([0xbb; 32]), Coin::unit()));
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let sk1 = SecretKey::from_slice(&[0xcc; 32][..]).expect("secret key");
         let pk1 = PublicKey::from_secret_key(&secp, &sk1);
         let raw_pk1 = RawXOnlyPubkey::from(XOnlyPublicKey::from_pubkey(&pk1).0.serialize());

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/Cargo.toml
@@ -13,7 +13,7 @@ parity-scale-codec = "1.3"
 rand = "0.7"
 rs-libc = "0.2"
 rustls = "0.18"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["lowmemory"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["lowmemory", "global-context"] }
 thread-pool = "0.1"
 zeroize = "1.1"
 chrono = "0.4"

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module/handler/decryption_request.rs
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module/handler/decryption_request.rs
@@ -25,9 +25,7 @@ pub fn get_random_challenge() -> H256 {
 }
 
 pub fn verify_decryption_request(decryption_request: &DecryptionRequest, challenge: H256) -> bool {
-    // FIXME: provide secp as ref
-    let mut buf_vfy = vec![0u8; Secp256k1::preallocate_verification_size()];
-    let secp = Secp256k1::preallocated_verification_only(&mut buf_vfy).expect("allocation");
+    let secp = secp256k1::SECP256K1;
     decryption_request.verify(&secp, challenge).is_ok()
 }
 

--- a/chain-tx-enclave-next/tx-validation-next/Cargo.toml
+++ b/chain-tx-enclave-next/tx-validation-next/Cargo.toml
@@ -11,7 +11,7 @@ enclave-macro = { path = "../../chain-tx-enclave/enclave-macro" }
 chain-tx-validation   = {  path = "../../chain-tx-validation" }
 chain-core   = {  path = "../../chain-core" }
 # TODO: "rand" feature may only be dev-dependency / needed for tests
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig", "rand"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "lowmemory", "schnorrsig", "rand", "global-context"] }
 parity-scale-codec = { version = "1.3" }
 enclave-protocol   = { path = "../../enclave-protocol" }
 chain-tx-filter   = { path = "../../chain-tx-filter" }

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
@@ -276,7 +276,7 @@ mod tests {
             }
         };
 
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);
         let x_public_key = XOnlyPublicKey::from_secret_key(&secp, &secret_key);

--- a/chain-tx-filter/Cargo.toml
+++ b/chain-tx-filter/Cargo.toml
@@ -12,7 +12,7 @@ default = ["bit-vec/std", "chain-core/default"]
 [dependencies]
 chain-core = { default-features = false, path = "../chain-core" }
 parity-scale-codec = { version = "1.3" }
-secp256k1 = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["endomorphism"] }
+secp256k1 = { default-features = false, git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["endomorphism", "global-context"] }
 bit-vec = { default-features = false, version = "0.6" }
 
 [dev-dependencies]

--- a/chain-tx-validation/Cargo.toml
+++ b/chain-tx-validation/Cargo.toml
@@ -11,7 +11,7 @@ default = ["chain-core/default", "thiserror"]
 
 [dependencies]
 chain-core = { path = "../chain-core", default-features = false }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "schnorrsig", "global-context"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 thiserror = { version = "1.0", default-features = false, optional = true }
 

--- a/chain-tx-validation/src/witness.rs
+++ b/chain-tx-validation/src/witness.rs
@@ -3,7 +3,7 @@ use chain_core::state::account::{StakedStateAddress, StakedStateOpWitness};
 use chain_core::tx::data::address::ExtendedAddr;
 use chain_core::tx::data::TxId;
 use chain_core::tx::witness::TxInWitness;
-use secp256k1::{key::XOnlyPublicKey, schnorrsig::schnorr_verify, Message, Secp256k1};
+use secp256k1::{key::XOnlyPublicKey, schnorrsig::schnorr_verify, Message};
 
 /// verify a given extended address is associated to the witness
 /// and the signature against the given transaction `Tx`
@@ -14,9 +14,7 @@ pub fn verify_tx_address(
     txid: &TxId,
     address: &ExtendedAddr,
 ) -> Result<(), secp256k1::Error> {
-    // FIXME: provide secp as ref
-    let mut buf_vfy = vec![0u8; Secp256k1::preallocate_verification_size()];
-    let secp = Secp256k1::preallocated_verification_only(&mut buf_vfy)?;
+    let secp = secp256k1::SECP256K1;
     let message = Message::from_slice(&txid[..])?;
 
     match (witness, address) {
@@ -44,9 +42,7 @@ pub fn verify_tx_recover_address(
 ) -> Result<StakedStateAddress, secp256k1::Error> {
     match witness {
         StakedStateOpWitness::BasicRedeem(sig) => {
-            // FIXME: provide secp as ref
-            let mut buf_vfy = vec![0u8; Secp256k1::preallocate_verification_size()];
-            let secp = Secp256k1::preallocated_verification_only(&mut buf_vfy)?;
+            let secp = secp256k1::SECP256K1;
             let message = Message::from_slice(txid)?;
             let pk = secp.recover(&message, &sig)?;
             secp.verify(&message, &sig.to_standard(), &pk)?;
@@ -71,7 +67,7 @@ pub mod tests {
     fn check_1_of_1_verify() {
         let transation = Tx::new();
 
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
 
         let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
         let public_key = XOnlyPublicKey::from_secret_key(&secp, &secret_key);
@@ -98,7 +94,7 @@ pub mod tests {
     fn check_1_of_2_verify() {
         let transation = Tx::new();
 
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
 
         let secret_keys = [
             SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key"),
@@ -134,7 +130,7 @@ pub mod tests {
     fn check_1_of_2_incorrect_proof() {
         let transation = Tx::new();
 
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
 
         let secret_keys = [
             SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key"),
@@ -170,7 +166,7 @@ pub mod tests {
     fn check_staked_verify() {
         let transation = Tx::new();
 
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
 
         let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.7"
 rust-argon2 = "0.8"
 rustls =  { version = "0.18", features = ["dangerous_configuration"] }
 # secp256k1experimental = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "cccfdb77c068b9cefa07b6884849f8473683d6d4", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "schnorrsig", "global-context"] }
 secstr = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/client-common/src/cipher/default.rs
+++ b/client-common/src/cipher/default.rs
@@ -8,7 +8,7 @@ use parity_scale_codec::{Decode, Encode};
 
 use crate::{
     tendermint::{types::AbciQueryExt, Client},
-    Error, ErrorKind, PrivateKey, Result, ResultExt, SignedTransaction, Transaction, SECP,
+    Error, ErrorKind, PrivateKey, Result, ResultExt, SignedTransaction, Transaction,
 };
 use chain_core::tx::{data::TxId, TxAux, TxWithOutputs};
 use enclave_protocol::{
@@ -138,14 +138,13 @@ impl TransactionObfuscation for DefaultTransactionObfuscation {
                     ))
                 }
             };
-            let request = SECP.with(|secp| {
-                DecryptionRequest::create(
-                    &secp,
-                    transaction_ids.to_owned(),
-                    ch,
-                    &private_key.into(),
-                )
-            });
+
+            let request = DecryptionRequest::create(
+                secp256k1::SECP256K1,
+                transaction_ids.to_owned(),
+                ch,
+                &private_key.into(),
+            );
             tls.write_all(&request.encode()).chain(|| {
                 (
                     ErrorKind::IoError,

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -24,10 +24,3 @@ pub use seckey::SecKey;
 pub use storage::{SecureStorage, Storage};
 #[doc(inline)]
 pub use transaction::{temporary_mls_init, SignedTransaction, Transaction, TransactionInfo};
-
-use secp256k1::{All, Secp256k1};
-
-thread_local! {
-    /// Thread local static Secp object
-    pub static SECP: Secp256k1<All> = Secp256k1::new();
-}

--- a/client-common/src/multi_sig_address.rs
+++ b/client-common/src/multi_sig_address.rs
@@ -19,7 +19,7 @@ pub fn combine_to_raw_pubkey(public_keys: &[PublicKey]) -> Result<RawXOnlyPubkey
 #[cfg(feature = "experimental")]
 /// Combines multiple public keys into one and also return a musig pre-session
 pub fn combine(public_keys: &[Self]) -> Result<(XOnlyPublicKey, MuSigPreSession)> {
-    let secp = Secp256k1::new();
+    let secp = secp256k1::SECP256K1;
     let (public_key, pre_session) = {
         pubkey_combine(
             &secp,
@@ -391,17 +391,15 @@ mod multi_sig_tests {
                 .unwrap()
                 .0;
 
-            let manual_combination = SECP.with(|secp| {
-                pubkey_combine(
-                    secp,
-                    &[
-                        XOnlyPublicKey::from_pubkey(&public_key_1.into()).0,
-                        XOnlyPublicKey::from_pubkey(&public_key_2.into()).0,
-                    ],
-                )
-                .unwrap()
-                .0
-            });
+            let manual_combination = pubkey_combine(
+                secp256k1::SECP256K1,
+                &[
+                    XOnlyPublicKey::from_pubkey(&public_key_1.into()).0,
+                    XOnlyPublicKey::from_pubkey(&public_key_2.into()).0,
+                ],
+            )
+            .unwrap()
+            .0;
 
             assert_eq!(manual_combination, combination);
         }

--- a/client-core/Cargo.toml
+++ b/client-core/Cargo.toml
@@ -16,7 +16,7 @@ chain-storage = { path = "../chain-storage", default-features = false }
 once_cell = "1.4"
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
 # secp256k1experimental = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "cccfdb77c068b9cefa07b6884849f8473683d6d4", features = ["serde", "zeroize", "rand", "recovery", "endomorphism", "musig"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["serde", "rand", "recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["serde", "rand", "recovery", "endomorphism", "schnorrsig", "global-context"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.7"
@@ -34,7 +34,6 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.1.22", default-features = false, features = ["rt-full"] }
 tiny-bip39 = { version = "0.7", default-features = false }
 unicase = "2.6.0"
-lazy_static = "1.4.0"
 ring = "0.16.15"
 tendermint = "0.15"
 tendermint-light-client = "0.15"

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -44,6 +44,3 @@ pub use crate::wallet::WalletClient;
 #[cfg(feature = "experimental")]
 #[doc(inline)]
 pub use crate::wallet::MultiSigWalletClient;
-
-#[macro_use]
-extern crate lazy_static;

--- a/client-core/src/multi_sig/builder.rs
+++ b/client-core/src/multi_sig/builder.rs
@@ -285,9 +285,12 @@ mod multi_sig_builder_tests {
         let combined_public_key = PublicKey::combine(&public_keys).unwrap().0;
         let message = Message::from_slice(&message).unwrap();
 
-        SECP.with(|secp| {
-            schnorr_verify(&secp, &message, &signature_1, &combined_public_key.into())
-                .expect("Invalid signature");
-        })
+        schnorr_verify(
+            secp256k1::SECP256K1,
+            &message,
+            &signature_1,
+            &combined_public_key.into(),
+        )
+        .expect("Invalid signature");
     }
 }

--- a/client-core/src/multi_sig/session.rs
+++ b/client-core/src/multi_sig/session.rs
@@ -14,7 +14,7 @@ use secp256k1experimental::{All, Secp256k1};
 
 thread_local! {
     /// Thread local static Secp object
-    static SECP: Secp256k1<All> = Secp256k1::new();
+    static SECP: Secp256k1<All> = secp256k1::SECP256K1;
 }
 
 use chain_core::common::H256;

--- a/client-core/src/service/multi_sig_session_service.rs
+++ b/client-core/src/service/multi_sig_session_service.rs
@@ -309,9 +309,12 @@ mod multi_sig_session_service_tests {
         let combined_public_key = PublicKey::combine(&public_keys).unwrap().0;
         let message = Message::from_slice(&message).unwrap();
 
-        SECP.with(|secp| {
-            schnorr_verify(&secp, &message, &signature_1, &combined_public_key.into())
-                .expect("Invalid signature");
-        })
+        schnorr_verify(
+            secp256k1::SECP256K1,
+            &message,
+            &signature_1,
+            &combined_public_key.into(),
+        )
+        .expect("Invalid signature");
     }
 }

--- a/client-network/Cargo.toml
+++ b/client-network/Cargo.toml
@@ -17,9 +17,9 @@ base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 hex = "0.4.2"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "global-context"] }
 tendermint = "0.15"
 
 [dev-dependencies]
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["serde", "rand", "recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["serde", "rand", "recovery", "endomorphism", "global-context"] }
 test-common = { path = "../test-common" }

--- a/cro-clib/Cargo.toml
+++ b/cro-clib/Cargo.toml
@@ -22,7 +22,7 @@ client-core = { path = "../client-core" }
 client-network = { path = "../client-network" }
 client-rpc-core = { path = "../client-rpc" }
 secstr = { version = "0.4.0", features = ["serde"] }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "global-context"] }
 jsonrpc-core = "14.2"
 libc = "0.2.74"
 env_logger = "0.7"

--- a/dev-utils/Cargo.toml
+++ b/dev-utils/Cargo.toml
@@ -22,7 +22,7 @@ dirs = "3.0.1"
 quest = "0.3"
 secstr = "0.4.0"
 parity-scale-codec = { version = "1.3" }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "schnorrsig", "global-context"] }
 base64 = "0.12"
 mls = { path = "../chain-tx-enclave-next/mls" }
 ra-client = { path = "../chain-tx-enclave-next/enclave-ra/ra-client" }

--- a/dev-utils/src/commands/test_vector_command.rs
+++ b/dev-utils/src/commands/test_vector_command.rs
@@ -25,7 +25,6 @@ use client_common::key::PrivateKeyAction;
 use client_common::{MultiSigAddress, PrivateKey, PublicKey, Result, Transaction};
 use client_core::service::{HDAccountType, HdKey};
 use client_core::HDSeed;
-use secp256k1::Secp256k1;
 use secp256k1::{key::XOnlyPublicKey, SecretKey};
 use test_common::chain_env::mock_confidential_init;
 
@@ -406,7 +405,7 @@ impl VectorFactory {
                 address.to_cro(Network::Testnet).unwrap()
             );
             let xonly =
-                XOnlyPublicKey::from_secret_key(&Secp256k1::new(), &SecretKey::from(secret));
+                XOnlyPublicKey::from_secret_key(&secp256k1::SECP256K1, &SecretKey::from(secret));
             println!("secret: {}", hex::encode(secret.serialize()));
             println!("public key: {}", hex::encode(public.serialize()));
             println!("X only public key: {}", hex::encode(&xonly.serialize()));

--- a/enclave-protocol/Cargo.toml
+++ b/enclave-protocol/Cargo.toml
@@ -16,4 +16,4 @@ chain-core = { path = "../chain-core", default-features = false }
 chain-tx-validation = { path = "../chain-tx-validation", default-features = false }
 parity-scale-codec = { version = "1.3", features = ["derive"] }
 blake3 = { version = "0.3.6", default-features = false }
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987" }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a" }

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -368,7 +368,7 @@ pub mod tests {
 
     #[test]
     fn check_basic_dec_verify() {
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
         let req =
             DecryptionRequest::create(&secp, vec![[0u8; 32], [1u8; 32]], [2u8; 32], &secret_key);
@@ -380,7 +380,7 @@ pub mod tests {
 
     #[test]
     fn check_wrong_challenge_not_verify() {
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("Unable to create secret key");
         let req =
             DecryptionRequest::create(&secp, vec![[0u8; 32], [1u8; 32]], [2u8; 32], &secret_key);

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -17,7 +17,7 @@ signature = "1.1"
 abci = "0.7"
 kvdb-memorydb = "0.7"
 protobuf = "2.7.0"
-secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "984ccbccb48d62f5cb46f6fc1c75a04f34102987", features = ["recovery", "endomorphism", "schnorrsig"] }
+secp256k1 = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", rev = "1aae6edc5f1de0bbdcdb26f1f1d8b00ca28e012a", features = ["recovery", "endomorphism", "schnorrsig", "global-context"] }
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 base64 = "0.12"
 hex = "0.4"

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -221,7 +221,7 @@ impl Account {
         validator_pub_key: TendermintValidatorPubKey,
         name: String,
     ) -> Account {
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let secret_key = SecretKey::from_slice(seed).expect("32 bytes, within curve order");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);
         let address = RedeemAddress::from(&public_key);
@@ -351,7 +351,7 @@ impl ChainEnv {
             StakedStateOpAttributes::new(0),
             NodeMetadata::CouncilNode(node_meta),
         );
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let witness = StakedStateOpWitness::new(get_ecdsa_witness(
             &secp,
             &tx.id(),
@@ -367,7 +367,7 @@ impl ChainEnv {
             coin,
             StakedStateOpAttributes::new(0),
         );
-        let secp = Secp256k1::new();
+        let secp = secp256k1::SECP256K1;
         let witness = StakedStateOpWitness::new(get_ecdsa_witness(
             &secp,
             &tx.id(),


### PR DESCRIPTION
Solution: updated the dependency with both rust upstream and secp256k1 schnorrsig PR changes
- as the rust upstream now contains optional global context feature, the code was adapted to make use of it
(instead of creating custom global contexts or re-creating the contexts)