### PR TITLE
Problem: light client trusted block can't be set in client-* (fix #2005)

### DIFF
--- a/client-rpc/server/src/program.rs
+++ b/client-rpc/server/src/program.rs
@@ -68,10 +68,33 @@ pub struct Options {
         name = "light client peer",
         short = "l",
         long = "light-client-peers",
-        default_value = "",
         help = "Light client peers"
     )]
-    pub light_client_peers: String,
+    pub light_client_peers: Option<String>,
+
+    #[structopt(
+        name = "light client trusting period in seconds",
+        long = "light-client-trusting-period",
+        default_value = "36000000",
+        help = "light client trusting period in seconds"
+    )]
+    pub light_client_trusting_period_seconds: u64,
+
+    #[structopt(
+        name = "light client trusting height",
+        long = "light-client-trusting-height",
+        default_value = "1",
+        help = "light client trusting height"
+    )]
+    pub light_client_trusting_height: u64,
+
+    #[structopt(
+        name = "light client trusting blockhash",
+        long = "light-client-trusting-blockhash",
+        default_value = "",
+        help = "light client trusting blockhash"
+    )]
+    pub light_client_trusting_blockhash: String,
 
     #[structopt(
         name = "disable-address-recovery",

--- a/client-rpc/server/src/server.rs
+++ b/client-rpc/server/src/server.rs
@@ -5,9 +5,9 @@ use std::net::SocketAddr;
 
 use chain_core::init::network::{get_network, get_network_id, init_chain_id};
 use client_common::Result;
+use client_common::{Error, ErrorKind};
 use client_core::wallet::syncer::SyncerOptions;
 use client_rpc_core::RpcHandler;
-
 pub(crate) struct Server {
     host: String,
     port: u16,
@@ -24,6 +24,19 @@ impl Server {
         let network_id = get_network_id();
 
         println!("Network type {:?} id {:02X}", get_network(), network_id);
+        let mut light_client_peers: String = "".to_string();
+
+        if !options.disable_light_client {
+            if let Some(value) = options.light_client_peers {
+                light_client_peers = value;
+            } else {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "Invalid light-client-peers",
+                ));
+            }
+        }
+
         Ok(Server {
             host: options.host,
             port: options.port,
@@ -36,7 +49,10 @@ impl Server {
                 enable_address_recovery: !options.disable_address_recovery,
                 batch_size: options.batch_size,
                 block_height_ensure: options.block_height_ensure,
-                light_client_peers: options.light_client_peers,
+                light_client_peers,
+                light_client_trusting_period_seconds: options.light_client_trusting_period_seconds,
+                light_client_trusting_height: options.light_client_trusting_height,
+                light_client_trusting_blockhash: options.light_client_trusting_blockhash,
             },
         })
     }

--- a/client-rpc/src/handler.rs
+++ b/client-rpc/src/handler.rs
@@ -65,11 +65,19 @@ impl RpcHandler {
             fee_policy.clone(),
             tendermint_client.clone(),
         )?;
-        let handle = spawn_light_client_supervisor(
-            storage_dir.as_ref(),
-            tendermint_client.genesis()?.trusting_period(),
-            sync_options.light_client_peers.clone(),
-        )?;
+        let handle = if sync_options.disable_light_client {
+            None
+        } else {
+            Some(spawn_light_client_supervisor(
+                storage_dir.as_ref(),
+                tendermint_client.genesis()?.trusting_period(),
+                sync_options.light_client_peers.clone(),
+                sync_options.light_client_trusting_period_seconds,
+                sync_options.light_client_trusting_height,
+                sync_options.light_client_trusting_blockhash.clone(),
+                None,
+            )?)
+        };
         let syncer_config = AppSyncerConfig::new(
             storage.clone(),
             tendermint_client.clone(),

--- a/client-rpc/src/rpc/sync_rpc.rs
+++ b/client-rpc/src/rpc/sync_rpc.rs
@@ -88,7 +88,7 @@ where
     progress_callback: Option<CBindingCore>,
     worker: WorkerShared,
     recover_address: T,
-    light_client_handle: L,
+    light_client_handle: Option<L>,
 }
 
 impl<S, C, O, T, L> SyncRpcImpl<S, C, O, T, L>
@@ -104,7 +104,7 @@ where
         progress_callback: Option<CBindingCore>,
 
         recover_address: T,
-        light_client_handle: L,
+        light_client_handle: Option<L>,
     ) -> Self {
         SyncRpcImpl {
             config,
@@ -338,8 +338,12 @@ where
     L: Handle + Send + Sync + Clone,
 {
     fn drop(&mut self) {
-        self.light_client_handle
-            .terminate()
-            .expect("terminate light client supervisor in drop");
+        if self.light_client_handle.is_some() {
+            self.light_client_handle
+                .as_ref()
+                .expect("get light-client handle")
+                .terminate()
+                .expect("terminate light client supervisor in drop");
+        }
     }
 }

--- a/cro-clib/src/jsonrpc.rs
+++ b/cro-clib/src/jsonrpc.rs
@@ -222,6 +222,9 @@ unsafe fn create_rpc(
         block_height_ensure: 50,
         light_client_peers: "0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657"
         .into(),
+        light_client_trusting_period_seconds:3600000000000,
+        light_client_trusting_height: 1,
+        light_client_trusting_blockhash: "".into(),
     };
     let handler = RpcHandler::new(
         &storage_dir,

--- a/integration-tests/bot/client_cli.py
+++ b/integration-tests/bot/client_cli.py
@@ -279,10 +279,17 @@ class Wallet():
             enable_fast_forward=True,
             batch_size=20,
             block_height_ensure=50,
-            light_client_peers="0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657"
+            light_client_peers="0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657",
+            light_client_trusting_period_seconds="36000000",
+            light_client_trusting_height="1",
+            light_client_trusting_blockhash=""
     ):
         cmd = ["client-cli", "sync", "-n", self.name, "--batch-size", str(batch_size), "--block-height-ensure", str(block_height_ensure),
-        "--light-client-peers", light_client_peers]
+        "--light-client-peers", light_client_peers,
+        "--light-client-trusting-period", light_client_trusting_period_seconds,
+        "--light-client-trusting-height", light_client_trusting_height,
+        "--light-client-trusting-blockhash", light_client_trusting_blockhash
+        ]
         if force:
             cmd.append("--force")
         if disable_address_recovery:


### PR DESCRIPTION
Solution: add trust block setting, and removed un-necessary spawning light-client
fix integration test

## simple disabling light client
`--disable-light-client` will not create `light client handle`

## user confirm
if you don't specify light-client info, it will ask (for client-cli)
you can give options (for client-rpc, not interactive)

## client-cli
if you give full light-client options, it will not ask.
if not, it will ask questions, and fetch the block, you can confirm it
```
./client-cli sync --name a    <- it will ask  trusting period, height, blockhash
./client-cli sync --name a --light-client-peers 0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657 --light-client-trusting-period 1000000000 --light-client-trusting-height 111 --light-client-trusting-blockhash ""
./client-cli sync --name a --disable-light-client
```
## client-rpc
```
./client-rpc --chain-id $CRYPTO_CHAIN_ID --port 9981 --storage-dir $PWD/.storage --websocket-url ws://127.0.0.1:26657/websocket   --light-client-peers 0000000000000000000000000000000000000000@127.0.0.1:26657,1000000000000000000000000000000000000000@127.0.0.1:26657
./client-rpc --chain-id $CRYPTO_CHAIN_ID --port 9981 --storage-dir $PWD/.storage --websocket-url ws://127.0.0.1:26657/websocket  --disable-light-client 
```