### PR TITLE
Problem: unnecessary handling of tx validation usercalls (fixes #2104)

### DIFF
--- a/chain-abci/Cargo.toml
+++ b/chain-abci/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "1.0"
 aesm-client = {version = "0.5", features = ["sgxs"], optional = true }
 enclave-runner = {version = "0.4", optional = true}
 sgxs-loaders = {version = "0.2", optional = true}
-tokio = { version = "0.2", optional = true }
+tokio = { version = "0.2", features = ["uds"], optional = true }
 enclave-utils = { path = "../chain-tx-enclave-next/enclave-utils", features = ["zmq-helper"] }
 zmq = "0.9"
 rand = "0.7"

--- a/chain-abci/src/enclave_bridge/edp/mod.rs
+++ b/chain-abci/src/enclave_bridge/edp/mod.rs
@@ -2,6 +2,7 @@ mod server;
 
 use crate::enclave_bridge::EnclaveProxy;
 use aesm_client::AesmClient;
+use chain_core::tx::TX_AUX_SIZE;
 use chain_storage::ReadOnlyStorage;
 use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponse};
 use enclave_runner::{
@@ -10,124 +11,41 @@ use enclave_runner::{
 };
 use parity_scale_codec::{Decode, Encode};
 use sgxs_loaders::isgx::Device;
-use std::io::{Cursor, Read};
-use std::sync::{mpsc::channel, mpsc::Receiver, mpsc::Sender, Arc, Mutex};
+use std::io::{Read, Write};
+use std::sync::{mpsc::channel, Arc, Mutex};
 use std::thread::{self};
-use std::{
-    future::Future,
-    io,
-    pin::Pin,
-    task::{Context, Poll},
-};
-use tokio::io::{AsyncRead, AsyncWrite};
+use std::{future::Future, io, pin::Pin};
 
 use ra_sp_server::{config::SpRaConfig, server::SpRaServer};
 use tokio::net::{TcpListener, TcpStream};
 
 use enclave_utils::zmq_helper::ZmqHelper;
+use std::os::unix::net::UnixStream;
 
-/// Internal type for communicating with EDP-based tx-validation enclave
+/// pair of unix domain sockets
+/// enclave_stream is only needed / passed in `connect_stream`
+/// `runner_stream` is shared in chain-abci app
 #[derive(Debug)]
-pub struct TxValidationStream {
-    /// contains the serialize request
-    reader: Cursor<Vec<u8>>,
-    /// for replying back with the response
-    request_processed: Sender<IntraEnclaveResponse>,
-}
-
-impl TxValidationStream {
-    /// start with a channel to send back responses
-    pub fn new(request_processed: Sender<IntraEnclaveResponse>) -> Self {
-        Self {
-            reader: Default::default(),
-            request_processed,
-        }
-    }
-
-    /// only 1 at a time can push the request (locked outside)
-    pub fn push_request(&mut self, request: IntraEnclaveRequest) {
-        let avail = self.reader.get_ref().len();
-        if self.reader.position() == avail as u64 {
-            self.reader = Default::default();
-        }
-        self.reader.get_mut().extend(&request.encode());
-    }
-}
-
-/// multi-thread wrapper around `TxValidationStream`.
-/// Currently, at least 3 threads are accessing it:
-/// 1) chain-abci main thread (pushing requests when check/delivertx)
-/// 2) zmq server -- temporarily -- pushes requests received from tx-query
-/// 3) enclave runner -- passes requests/responses via async streams
-/// from/to tx-validation enclave
-#[derive(Debug, Clone)]
-pub struct TxValidationAsyncStream {
-    stream: Arc<Mutex<TxValidationStream>>,
-}
-
-impl TxValidationAsyncStream {
-    pub fn new(request_processed: Sender<IntraEnclaveResponse>) -> Self {
-        Self {
-            stream: Arc::new(Mutex::new(TxValidationStream::new(request_processed))),
-        }
-    }
-}
-
-impl AsyncRead for TxValidationAsyncStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        _cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        // the locking should not block for too long -- this either succeeds and goes through
-        // or wait for `TxValidationApp` to push the request (it releases the lock
-        // once it pushes it)
-        let mut stream = self.stream.lock().expect("lock for stream -- async read");
-        let r = stream.reader.read(buf);
-        Poll::Ready(r)
-    }
-}
-
-impl AsyncWrite for TxValidationAsyncStream {
-    /// "&mut buf.as_ref()" is marked as useless by clippy, but it's needed for the compilation
-    #[allow(clippy::useless_asref)]
-    fn poll_write(self: Pin<&mut Self>, _cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
-        // the locking should not block --
-        // at the moment, tx-validation enclave shouldn't
-        // be executed on several threads and `TxValidationApp` won't hold the lock
-        // as it releases it and waits for `send` here
-        let stream = self.stream.lock().expect("lock for stream -- async write");
-        let resp = IntraEnclaveResponse::decode(&mut buf.as_ref())
-            .expect("enclave writes valid responses");
-        if let Err(e) = stream.request_processed.send(resp) {
-            log::warn!("receiver dropped: {:?}", e);
-            Poll::Ready(Err(std::io::ErrorKind::Other.into()))
-        } else {
-            Poll::Ready(Ok(buf.len()))
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct TxValidationApp {
-    inner: TxValidationAsyncStream,
-    rx: Arc<Mutex<Receiver<IntraEnclaveResponse>>>,
+    enclave_stream: Option<UnixStream>,
+    runner_stream: Arc<Mutex<UnixStream>>,
+}
+
+impl Clone for TxValidationApp {
+    fn clone(&self) -> Self {
+        Self {
+            enclave_stream: None,
+            runner_stream: self.runner_stream.clone(),
+        }
+    }
 }
 
 impl Default for TxValidationApp {
     fn default() -> Self {
-        let (tx, rx) = channel();
-        TxValidationApp {
-            inner: TxValidationAsyncStream::new(tx),
-            rx: Arc::new(Mutex::new(rx)),
+        let (sender, receiver) = UnixStream::pair().expect("init tx validation socket");
+        Self {
+            enclave_stream: Some(receiver),
+            runner_stream: Arc::new(Mutex::new(sender)),
         }
     }
 }
@@ -161,17 +79,21 @@ impl UsercallExtension for TxValidationApp {
         _local_addr: Option<&'future mut String>,
         _peer_addr: Option<&'future mut String>,
     ) -> Pin<Box<dyn Future<Output = UserCallStream> + 'future>> {
-        async fn connect_stream_inner(
-            stream: TxValidationAsyncStream,
-            addr: &str,
-        ) -> UserCallStream {
+        async fn connect_stream_inner(this: &TxValidationApp, addr: &str) -> UserCallStream {
             match addr {
-                "chain-abci" => Ok(Some(Box::new(stream))),
+                "chain-abci" => {
+                    if let Some(enclave_stream) = this.enclave_stream.as_ref() {
+                        let stream = tokio::net::UnixStream::from_std(enclave_stream.try_clone()?)?;
+                        Ok(Some(Box::new(stream)))
+                    } else {
+                        Ok(None)
+                    }
+                }
                 _ => Ok(None),
             }
         }
 
-        Box::pin(connect_stream_inner(self.inner.clone(), addr))
+        Box::pin(connect_stream_inner(self, addr))
     }
 }
 
@@ -183,21 +105,24 @@ impl EnclaveProxy for TxValidationApp {
     }
 
     fn process_request(&mut self, request: IntraEnclaveRequest) -> IntraEnclaveResponse {
-        // this lock prevents zmq server + chain-abci to submit requests at the same time
-        // as the zmq is temporary, this can later be removed
-        // (and perhaps use some channel that implements both Sync + Send, unlike mpsc)
-        let rx = self.rx.lock().expect("lock for reply");
-        {
-            let mut stream = self.inner.stream.lock().expect("lock for stream -- proxy");
-            stream.push_request(request);
-            // release the lock for `UsercallExtension` processing in async streams
-            // the explicit drop should not be necessary, but here just for sanity
-            drop(stream);
-        }
-        match rx.recv() {
-            Ok(response) => response,
+        let mut stream = self
+            .runner_stream
+            .lock()
+            .expect("lock for tx-validation request-reply");
+        stream
+            .write_all(&request.encode())
+            .expect("write enclave request");
+        let mut request_buf = vec![0u8; 2 * TX_AUX_SIZE];
+        match stream.read(&mut request_buf) {
+            Ok(c) => match IntraEnclaveResponse::decode(&mut request_buf[..c].as_ref()) {
+                Ok(response) => response,
+                Err(e) => {
+                    log::error!("enclave response decode error {:?}", e);
+                    Err(chain_tx_validation::Error::EnclaveRejected)
+                }
+            },
             Err(e) => {
-                log::warn!("the sender dropped {:?}", e);
+                log::error!("enclave response decode error {:?}", e);
                 Err(chain_tx_validation::Error::EnclaveRejected)
             }
         }

--- a/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module/handler/decryption_request.rs
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module/handler/decryption_request.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use parity_scale_codec::{Decode, Encode};
-use secp256k1::{key::PublicKey, Secp256k1};
+use secp256k1::key::PublicKey;
 use zeroize::Zeroize;
 
 use chain_core::{


### PR DESCRIPTION
Solution: replaced the code with a unix domain socket pair
(one socket is used inside chain-abci, the other is passed in
/ wrapped in tokio usercall extesion)
- should reduce the busy-waiting