### PR TITLE
Problem: (fix #2110)devnet cannot build as tx-query2-app-runner no lo…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,11 +19,9 @@
 !/target/debug/chain-abci
 !/target/debug/client-rpc
 !/target/debug/dev-utils
-!/target/debug/tx-query-app
 !/target/debug/tx_query_enclave.signed.so
 !/target/debug/tx-validation-app
 !/target/debug/tx_validation_enclave.signed.so
-!/target/debug/tx-query2-app-runner
 !/target/debug/tx-query2-enclave-app.sig
 !/target/debug/tx-query2-enclave-app.sgxs
 !/target/debug/tx-validation-next.sig
@@ -33,8 +31,6 @@
 !/target/release/chain-abci
 !/target/release/client-rpc
 !/target/release/dev-utils
-!/target/release/tx-query-app
-!/target/release/tx-query2-app-runner
 !/target/release/tx-query2-enclave-app.sig
 !/target/release/tx-query2-enclave-app.sgxs
 !/target/release/tx-validation-next.sig

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,6 @@ COPY ./target/${BUILD_MODE}/tx-validation-next.sgxs /usr/local/bin
 COPY ./target/${BUILD_MODE}/ra-sp-server /usr/local/bin
 # copy scripts
 COPY ./docker/wait-for-it.sh /usr/local/bin
-COPY ci-scripts/run_tx_query_next.sh /usr/local/bin
 COPY ci-scripts/run_chain_abci.sh /usr/local/bin
 
 # install sgx enclave PSW 2.9


### PR DESCRIPTION
Solution: update Makefile and ci-scripts/run_chain_abci.sh to replace tx-query2-app-runner with chain-abci

Tentatively, set launch_ra_proxy: false in devnet in ci-scripts/run_chain_abci.sh as it has error when running launch_ra_proxy(#2128). fix by run ra-sp-server in separate process.

