### PR TITLE
Problem: hpke library is not up to date with upstream (fixes #2133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,8 +1898,8 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.1.8"
-source = "git+https://github.com/crypto-com/rust-hpke.git?rev=25686eb87d2862535b1d5107d74e2ac8bd992bae#25686eb87d2862535b1d5107d74e2ac8bd992bae"
+version = "0.2.0"
+source = "git+https://github.com/crypto-com/rust-hpke.git?rev=afdaf6f62fa557a7055d6cc063af65fe5c387aaf#afdaf6f62fa557a7055d6cc063af65fe5c387aaf"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ ring = { git = "https://github.com/crypto-com/ring.git", rev = "8f2b68d2ac53b1df
 # FIXME: use upstream when merged
 sha2 = { git = "https://github.com/crypto-com/hashes.git", rev = "289d5b76f2163a3808010341ed1df3cb156d97e1" }
 # FIXME: before official spec has a solution
-hpke = { git = "https://github.com/crypto-com/rust-hpke.git", rev = "25686eb87d2862535b1d5107d74e2ac8bd992bae" }
+hpke = { git = "https://github.com/crypto-com/rust-hpke.git", rev = "afdaf6f62fa557a7055d6cc063af65fe5c387aaf" }

--- a/chain-abci/fuzz/Cargo.toml
+++ b/chain-abci/fuzz/Cargo.toml
@@ -38,4 +38,4 @@ path = "fuzz_targets/abci_cycle.rs"
 [patch.crates-io]
 ring = { git = "https://github.com/crypto-com/ring.git", rev = "bdbcc7041095f028d49d9fecd7edcf26d6083274" }
 # FIXME: before official spec has a solution
-hpke = { git = "https://github.com/crypto-com/rust-hpke.git", rev = "25686eb87d2862535b1d5107d74e2ac8bd992bae" }
+hpke = { git = "https://github.com/crypto-com/rust-hpke.git", rev = "afdaf6f62fa557a7055d6cc063af65fe5c387aaf" }

--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -15,7 +15,7 @@ nom = "5.1"
 secrecy = "0.7.0"
 sha2 = "0.9"
 hkdf = { version = "0.9", features = ["std"] }
-hpke = { version = "0.1.8", default-features = false, features = ["p256", "std"] }
+hpke = { version = "0.2", default-features = false, features = ["p256", "std"] }
 aead = { version = "0.3", features = ["std"] }
 rand = "0.7"
 chrono="0.4.15"

--- a/chain-tx-enclave-next/mls/src/ciphersuite.rs
+++ b/chain-tx-enclave-next/mls/src/ciphersuite.rs
@@ -152,7 +152,7 @@ pub type DefaultCipherSuite = Dhkemp256Aes128gcmP256;
 pub type Kex<CS> = <<CS as CipherSuite>::Kem as hpke::Kem>::Kex;
 // KEM.Nsk draft-ietf-mls-protocol.md#ratchet-tree-evolution
 pub type SecretSize<CS> =
-    <<Kex<CS> as hpke::KeyExchange>::PrivateKey as hpke::Marshallable>::OutputSize;
+    <<Kex<CS> as hpke::kex::KeyExchange>::PrivateKey as hpke::Serializable>::OutputSize;
 pub type HashImpl<CS> = <<CS as CipherSuite>::Kdf as hpke::kdf::Kdf>::HashImpl;
 // KDF.Nh draft-ietf-mls-protocol.md#key-schedule
 pub type HashSize<CS> = <HashImpl<CS> as FixedOutput>::OutputSize;
@@ -161,9 +161,9 @@ pub type AeadKeySize<CS> =
 pub type AeadNonceSize<CS> =
     <<<CS as CipherSuite>::Aead as hpke::aead::Aead>::AeadImpl as Aead>::NonceSize;
 pub type PrivateKey<CS> =
-    <<<CS as CipherSuite>::Kem as hpke::Kem>::Kex as hpke::KeyExchange>::PrivateKey;
+    <<<CS as CipherSuite>::Kem as hpke::Kem>::Kex as hpke::kex::KeyExchange>::PrivateKey;
 pub type PublicKey<CS> =
-    <<<CS as CipherSuite>::Kem as hpke::Kem>::Kex as hpke::KeyExchange>::PublicKey;
+    <<<CS as CipherSuite>::Kem as hpke::Kem>::Kex as hpke::kex::KeyExchange>::PublicKey;
 pub type Hkdf<CS> = hkdf::Hkdf<HashImpl<CS>>;
 
 /// Statically sized secret value

--- a/chain-tx-enclave-next/mls/src/message.rs
+++ b/chain-tx-enclave-next/mls/src/message.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use generic_array::GenericArray;
-use hpke::Marshallable;
+use hpke::Serializable;
 use secrecy::{ExposeSecret, Secret};
 
 use crate::ciphersuite::{
@@ -499,7 +499,7 @@ pub struct EncryptedGroupSecrets<CS: CipherSuite> {
 #[derive(Debug, Clone)]
 pub struct HPKECiphertext<CS: CipherSuite> {
     /// 0..2^16-1
-    pub kem_output: GenericArray<u8, <PublicKey<CS> as Marshallable>::OutputSize>,
+    pub kem_output: GenericArray<u8, <PublicKey<CS> as Serializable>::OutputSize>,
     /// 0..2^16-1
     pub ciphertext: Vec<u8>,
 }


### PR DESCRIPTION
Solution: update the fork library to 0.2
and migrated the code to the new API (main changes were
renaming marshal/unmarshal traits and not exposing KeyExchange trait
in root)
