### PR TITLE
Problem: client-* isn't configured with enclave measurements to verify against tx-query connection (fixes #2079)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,10 +44,15 @@ jobs:
       - name: temporary mock hack for stable
         run: |
           sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\"\]/" chain-abci/Cargo.toml;
+          sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\", \"sled\", \"websocket-rpc\"\]/" client-common/Cargo.toml;
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: "-- -D warnings"
+        env:
+          NETWORK_ID: "ab"
+          MRSIGNER: "0000000000000000000000000000000000000000000000000000000000000000"
+          TQE_MRENCLAVE: "0000000000000000000000000000000000000000000000000000000000000000"
 
   security_audit:
     runs-on: ubuntu-latest
@@ -75,12 +80,15 @@ jobs:
       - name: temporary mock hack for stable
         run: |
           sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\"\]/" chain-abci/Cargo.toml;
+          sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\", \"sled\", \"websocket-rpc\"\]/" client-common/Cargo.toml;
       - uses: actions-rs/cargo@v1
         with:
           command: build
         env:
           RUSTFLAGS: "-Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3 -D warnings"
           NETWORK_ID: "ab"
+          MRSIGNER: "0000000000000000000000000000000000000000000000000000000000000000"
+          TQE_MRENCLAVE: "0000000000000000000000000000000000000000000000000000000000000000"
       - name: test-stable
         uses: actions-rs/cargo@v1
         with:
@@ -88,6 +96,8 @@ jobs:
         env:
           RUSTFLAGS: "-Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3 -D warnings"
           NETWORK_ID: "ab"
+          MRSIGNER: "0000000000000000000000000000000000000000000000000000000000000000"
+          TQE_MRENCLAVE: "0000000000000000000000000000000000000000000000000000000000000000"
 
   test-nightly-coverage:
     runs-on: ubuntu-latest
@@ -109,6 +119,8 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"
           NETWORK_ID: "ab"
+          MRSIGNER: "0000000000000000000000000000000000000000000000000000000000000000"
+          TQE_MRENCLAVE: "0000000000000000000000000000000000000000000000000000000000000000"
       - uses: actions-rs/grcov@v0.1
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,14 @@ rust: &rust
     - LD_LIBRARY_PATH=$HOME/lib:/opt/sgxsdk/sdk_libs
     - PKG_CONFIG_PATH=$HOME/lib/pkgconfig:/opt/sgxsdk/pkgconfig
     - SGX_SDK=/opt/sgxsdk
-    - SGX_MODE=SW
+    - MRSIGNER=0000000000000000000000000000000000000000000000000000000000000000
+    - TQE_MRENCLAVE=0000000000000000000000000000000000000000000000000000000000000000
     - NETWORK_ID=ab
   before_install: # versions from https://github.com/erickt/rust-zmq/blob/master/.travis.yml
     - |
       if [[ "$TRAVIS_RUST_VERSION" != nightly ]]; then
         sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\"\]/" chain-abci/Cargo.toml;
+        sed -i.bak -E "s/default = \[\".+\"\]/default = \[\"mock-enclave\", \"sled\", \"websocket-rpc\"\]/" client-common/Cargo.toml;
       fi
     - |
       if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "chain-core",
  "chain-tx-filter",
  "chrono",
+ "enclave-macro",
  "enclave-protocol",
  "futures-util",
  "gcd",
@@ -1391,6 +1392,7 @@ dependencies = [
 name = "enclave-macro"
 version = "0.6.0"
 dependencies = [
+ "hex",
  "rand 0.7.3",
 ]
 

--- a/chain-tx-enclave-next/enclave-ra/ra-client/src/config.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-client/src/config.rs
@@ -19,7 +19,7 @@ pub struct EnclaveCertVerifierConfig<'a> {
     pub valid_enclave_quote_statuses: Cow<'a, [Cow<'a, str>]>,
     /// Duration for which an attestation report will be considered as valid (in secs)
     pub report_validity_secs: u32,
-    /// Information about the enclave that'll be verifier if present
+    /// Information about the enclave that'll be verifier if present -- TODO: make non-optional?
     pub enclave_info: Option<EnclaveInfo>,
 }
 

--- a/chain-tx-enclave-next/enclave-ra/ra-client/src/verifier.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-client/src/verifier.rs
@@ -53,6 +53,7 @@ pub struct EnclaveCertVerifier {
     root_cert_store: RootCertStore,
     valid_enclave_quote_statuses: HashSet<EnclaveQuoteStatus>,
     report_validity_duration: Duration,
+    // TODO: make non-optional?
     enclave_info: Option<EnclaveInfo>,
 }
 

--- a/chain-tx-enclave/enclave-macro/Cargo.toml
+++ b/chain-tx-enclave/enclave-macro/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 
 [dependencies]
 rand = "0.7.2"
+hex = "0.4"

--- a/chain-tx-enclave/enclave-macro/src/lib.rs
+++ b/chain-tx-enclave/enclave-macro/src/lib.rs
@@ -11,3 +11,21 @@ pub fn mock_key(_input: TokenStream) -> TokenStream {
     let random_bytes: [u8; 16] = rand::random();
     format!("{:?}", random_bytes).parse().unwrap()
 }
+
+#[proc_macro]
+pub fn get_mrsigner(_input: TokenStream) -> TokenStream {
+    let mrsigner: Vec<u8> = hex::decode(env! {"MRSIGNER"}).unwrap();
+    if mrsigner.len() != 32 {
+        panic!("mrsigner incorrect length");
+    }
+    format!("{:?}", mrsigner).parse().unwrap()
+}
+
+#[proc_macro]
+pub fn get_tqe_mrenclave(_input: TokenStream) -> TokenStream {
+    let mrenclave: Vec<u8> = hex::decode(env! {"TQE_MRENCLAVE"}).unwrap();
+    if mrenclave.len() != 32 {
+        panic!("mrenclave incorrect length");
+    }
+    format!("{:?}", mrenclave).parse().unwrap()
+}

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -9,6 +9,7 @@ chain-core = { path = "../chain-core" }
 chain-tx-filter = { path = "../chain-tx-filter" }
 enclave-protocol = { path = "../enclave-protocol" }
 mock-utils = { path = "../chain-tx-enclave/mock-utils" }
+enclave-macro = { path = "../chain-tx-enclave/enclave-macro" }
 ra-client = { path = "../chain-tx-enclave-next/enclave-ra/ra-client" }
 mls = { path = "../chain-tx-enclave-next/mls" }
 

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -1,4 +1,9 @@
-#![deny(missing_docs, unsafe_code, unstable_features)]
+// `proc_macro_hygiene` -- strange that this works OK / isn't required on stable Rust (1.45.2)
+#![cfg_attr(
+    all(target_os = "linux", not(feature = "mock-enclave")),
+    feature(proc_macro_hygiene)
+)]
+#![deny(missing_docs, unsafe_code)]
 //! This crate contains all the common types and utilities used by other `client-*` crates.
 mod transaction;
 

--- a/docker/sgx_test.sh
+++ b/docker/sgx_test.sh
@@ -16,6 +16,10 @@ else
     EDP_ARGS=
 fi
 
+# for unit tests; it may not appply, as it'll be signed by runner's dummy key
+export MRSIGNER="0000000000000000000000000000000000000000000000000000000000000000"
+export TQE_MRENCLAVE="0000000000000000000000000000000000000000000000000000000000000000"
+
 # Add a test runner
 mkdir .cargo
 echo "[target.x86_64-fortanix-unknown-sgx]


### PR DESCRIPTION
Solution:
- added proc macros to extract hex-encoded MRSIGNER and MRENCLAVE values
- extended client-common attested TLS config for veryfiyng enclave measurements
- reordered integration test building + parsing of sigstruct to extract TQE MRSIGNER and MRENCLAVE values + dummy values in non-sgx tests
