### PR TITLE
Problem: Enclave certificate verifier does not allow configuration of parameters to verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4465,6 +4465,7 @@ dependencies = [
 name = "test_cert_expiration"
 version = "0.1.0"
 dependencies = [
+ "enclave-macro",
  "ra-client",
  "rustls",
  "webpki",

--- a/chain-tx-enclave-next/enclave-ra/ra-client/src/config.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-client/src/config.rs
@@ -54,7 +54,16 @@ pub struct EnclaveInfo {
     /// 256-bit hash of enclave author's public key
     pub mr_signer: [u8; 32],
     /// 256-bit hash that identifies the code and initial data in enclave
-    pub mr_enclave: [u8; 32],
+    ///
+    /// # Note
+    ///
+    /// - This value will be `Some` for `ServerCertVerifier` in any type of attested connection.
+    /// - This value will be `None` for `ClientCertVerifier` in two-way mutually attested TLS
+    ///   stream between different enclaves.
+    /// - This value will be `Some()` for `ClientCertVerifier` in two-way mutually attested TLS
+    ///   stream between same enclaves.
+    /// - `EnclaveInfo` will be `None` for `ClientCertVerifier` in one-way attested TLS stream.
+    pub mr_enclave: Option<[u8; 32]>,
     /// `mr_enclave` corresponding to previous `isv_svn`, i.e., `isv_svn - 1`
     pub previous_mr_enclave: Option<[u8; 32]>,
     /// CPU security version number
@@ -78,7 +87,7 @@ impl EnclaveInfo {
 
         Self {
             mr_signer: report.mrsigner,
-            mr_enclave: report.mrenclave,
+            mr_enclave: Some(report.mrenclave),
             previous_mr_enclave,
             cpu_svn: report.cpusvn,
             isv_svn: report.isvsvn,

--- a/chain-tx-enclave-next/tdbe/enclave-app/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tdbe/enclave-app/src/sgx_module.rs
@@ -223,7 +223,9 @@ fn create_tls_client_stream(
         .get_certificate()
         .expect("Unable to generate remote attestation certificate");
 
-    let mut client_config = verifier.into_client_config();
+    let mut client_config = verifier
+        .into_client_config()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     certificate
         .configure_client_config(&mut client_config)
         .expect("Unable to configure TLS client config with certificate");
@@ -254,7 +256,9 @@ fn create_tls_server_stream(
     let certificate = context
         .get_certificate()
         .expect("Unable to create remote attestation certificate");
-    let mut tls_server_config = verifier.into_client_verifying_server_config();
+    let mut tls_server_config = verifier
+        .into_client_verifying_server_config(true)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     certificate
         .configure_server_config(&mut tls_server_config)

--- a/integration-tests/rust_tests/test_cert_expiration/Cargo.toml
+++ b/integration-tests/rust_tests/test_cert_expiration/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 rustls =  { version = "0.18", features = ["dangerous_configuration"]  }
 webpki = "0.21"
 ra-client = { path = "../../../chain-tx-enclave-next/enclave-ra/ra-client" }
+enclave-macro = { path = "../../../chain-tx-enclave/enclave-macro" }


### PR DESCRIPTION
Solution: Modified the code to allow the configuration of parameters

There are three modes of connections:
- One-way attested TLS connection (client verifies all the details and server does not verify anything)
- Mutually attested TLS connection between different enclaves (client verifies all the details and server everything except MRENCLAVE)
- Mutually attested TLS connection between same enclaves (both client and server verifies all the details)