### PR TITLE
Problem: fuzzer fails to compile due to missing environment variables

### DIFF
--- a/ci-scripts/fuzzit.sh
+++ b/ci-scripts/fuzzit.sh
@@ -3,6 +3,10 @@ set -xe
 cd chain-abci
 ## build fuzzer
 cargo install cargo-fuzz
+# dummy values
+export NETWORK_ID="ab"
+export MRSIGNER="0000000000000000000000000000000000000000000000000000000000000000"
+export TQE_MRENCLAVE="0000000000000000000000000000000000000000000000000000000000000000"
 cargo fuzz run abci-cycle -- -runs=0
 wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.77/fuzzit_Linux_x86_64
 chmod a+x fuzzit


### PR DESCRIPTION
Solution: added dummy environment variables to the fuzzer compilation script