### PR TITLE
Problem: fuzzer fails to build inside the docker image

### DIFF
--- a/ci-scripts/Dockerfile.fuzzer
+++ b/ci-scripts/Dockerfile.fuzzer
@@ -2,5 +2,5 @@ FROM rustlang/rust:nightly-buster
 LABEL maintainer="Crypto.com"
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libzmq3-dev clang protobuf-compiler && \
+    apt-get install -y --no-install-recommends libudev-dev clang protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Solution: updated the fuzzer dockerfile to install libudev dependencies