### PR TITLE
Problem: incorrect NACK unit test assertions (fixes #2151)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,11 +1384,14 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits?rev=3e7b861581185d7350db3315cd1a99b4c6d382e4#3e7b861581185d7350db3315cd1a99b4c6d382e4"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
 dependencies = [
  "generic-array 0.14.4",
+ "rand_core 0.5.1",
  "subtle 2.2.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -1923,7 +1926,7 @@ dependencies = [
  "chacha20poly1305",
  "digest 0.9.0",
  "hkdf",
- "p256 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "p256 0.3.0",
  "rand 0.7.3",
  "sha2 0.9.1",
  "subtle 2.2.3",
@@ -2668,12 +2671,13 @@ dependencies = [
  "assert_matches",
  "chain-util",
  "chrono",
+ "elliptic-curve 0.5.0",
  "generic-array 0.14.4",
  "hkdf",
  "hpke",
  "nom",
  "once_cell",
- "p256 0.3.0 (git+https://github.com/crypto-com/elliptic-curves.git?rev=15df32b45d8395a1e00eeb3873e1266063e1ec53)",
+ "p256 0.4.1",
  "parity-scale-codec",
  "ra-client",
  "ra-enclave",
@@ -2918,20 +2922,20 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.3.0"
-source = "git+https://github.com/crypto-com/elliptic-curves.git?rev=15df32b45d8395a1e00eeb3873e1266063e1ec53#15df32b45d8395a1e00eeb3873e1266063e1ec53"
-dependencies = [
- "elliptic-curve 0.5.0-pre",
- "zeroize",
-]
-
-[[package]]
-name = "p256"
-version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a425ecb71515663b2735fd1e65bb638fd134c5ad23857eb197c2f157784476cf"
 dependencies = [
  "elliptic-curve 0.4.0",
  "subtle 2.2.3",
+]
+
+[[package]]
+name = "p256"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f8aff5e98a6a83e374418a0a510ae4d9d45d714b5b0767c2e23ea007d0ba54"
+dependencies = [
+ "elliptic-curve 0.5.0",
 ]
 
 [[package]]

--- a/chain-tx-enclave-next/mls/Cargo.toml
+++ b/chain-tx-enclave-next/mls/Cargo.toml
@@ -22,8 +22,8 @@ chrono="0.4.15"
 ra-client = { path = "../enclave-ra/ra-client" }
 subtle = "2.2.3"
 chain-util = { path = "../../chain-util" }
-# FIXME: use upstream when released
-p256 = { version = "0.3.0", features = ["arithmetic", "zeroize"], git = "https://github.com/crypto-com/elliptic-curves.git", rev = "15df32b45d8395a1e00eeb3873e1266063e1ec53" }
+elliptic-curve = "0.5.0"
+p256 = { version = "0.4.1", features = ["arithmetic", "zeroize"] }
 zeroize = "1.1"
 parity-scale-codec = { features = ["derive"], version = "1.3" }
 once_cell = "1.4"


### PR DESCRIPTION
Solution:
- updated p256 to upstream
- split up confirmation computation
- extended the testing commit "corruption" code, so that commit can be processed in tests
- fixed the incorrect assertions in NACK unit tests
