### PR TITLE
Problem: genesis parameters are not up to date (fixes #1997)

### DIFF
--- a/chain-abci/fuzz/fuzz_targets/abci_cycle.rs
+++ b/chain-abci/fuzz/fuzz_targets/abci_cycle.rs
@@ -50,13 +50,15 @@ const TEST_GENESIS: &str = "{
         \"coefficient\": 1001
       },
       \"required_council_node_stake\": \"1\",
+      \"required_community_node_stake\": \"1\",
       \"jailing_config\": {
         \"block_signing_window\": 100,
         \"missed_block_threshold\": 50
       },
       \"slashing_config\": {
         \"liveness_slash_percent\": \"0.100\",
-        \"byzantine_slash_percent\": \"0.200\"
+        \"byzantine_slash_percent\": \"0.200\",
+        \"invalid_commit_slash_percent\": \"0.300\"
       },
       \"rewards_config\": {
         \"monetary_expansion_cap\": \"0\",

--- a/chain-abci/tests/abci_app.rs
+++ b/chain-abci/tests/abci_app.rs
@@ -184,6 +184,7 @@ fn get_dummy_network_params() -> NetworkParameters {
             Milli::try_new(1, 1).unwrap(),
         ),
         required_council_node_stake: Coin::unit(),
+        required_community_node_stake: Coin::unit(),
         jailing_config: JailingParameters {
             block_signing_window: 100,
             missed_block_threshold: 50,
@@ -191,6 +192,7 @@ fn get_dummy_network_params() -> NetworkParameters {
         slashing_config: SlashingParameters {
             liveness_slash_percent: SlashRatio::from_str("0.1").unwrap(),
             byzantine_slash_percent: SlashRatio::from_str("0.2").unwrap(),
+            invalid_commit_slash_percent: SlashRatio::from_str("0.3").unwrap(),
         },
         rewards_config: RewardsParameters {
             monetary_expansion_cap: Coin::zero(),
@@ -365,6 +367,7 @@ fn init_chain_panics_with_different_app_hash() {
             Milli::try_new(1, 1).unwrap(),
         ),
         required_council_node_stake: Coin::unit(),
+        required_community_node_stake: Coin::unit(),
         jailing_config: JailingParameters {
             block_signing_window: 100,
             missed_block_threshold: 50,
@@ -372,6 +375,7 @@ fn init_chain_panics_with_different_app_hash() {
         slashing_config: SlashingParameters {
             liveness_slash_percent: SlashRatio::from_str("0.1").unwrap(),
             byzantine_slash_percent: SlashRatio::from_str("0.2").unwrap(),
+            invalid_commit_slash_percent: SlashRatio::from_str("0.3").unwrap(),
         },
         rewards_config: RewardsParameters {
             monetary_expansion_cap: expansion_cap,

--- a/chain-core/src/init/config.rs
+++ b/chain-core/src/init/config.rs
@@ -59,7 +59,6 @@ pub enum DistributionError {
 }
 
 /// Initial configuration ("app_state" in genesis.json of Tendermint config)
-/// TODO: reward/treasury config, extra validator config...
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct InitConfig {
     /// Redeem mapping of ERC20 snapshot: Eth address => (StakedStateDestination,CRO tokens)

--- a/chain-core/src/init/mod.rs
+++ b/chain-core/src/init/mod.rs
@@ -14,6 +14,9 @@ pub mod network;
 /// Network parameters
 pub mod params;
 
+/// Network parameters -- compile-time
+pub mod params_compile;
+
 /// maximum total supply with a fixed decimal point
 /// ref: https://etherscan.io/token/0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b
 /// 100 billion + 8 decimals

--- a/chain-core/src/init/params.rs
+++ b/chain-core/src/init/params.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 
 const MAX_SLASH_RATIO: Milli = Milli::new(1, 0); // 1.0
 
-/// network parameters specified at genesis
+/// network parameters specified at genesis (in genesis.json)
 /// ref: https://crypto-com.github.io/getting-started/network-parameters.html
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Serialize, Deserialize)]
 pub struct InitNetworkParameters {
@@ -21,6 +21,8 @@ pub struct InitNetworkParameters {
     pub initial_fee_policy: LinearFee,
     /// minimal? council node stake
     pub required_council_node_stake: Coin,
+    /// minimal required stake for joining the network
+    pub required_community_node_stake: Coin,
     /// Jailing configuration
     pub jailing_config: JailingParameters,
     /// Slashing configuration
@@ -160,6 +162,9 @@ pub struct SlashingParameters {
     pub liveness_slash_percent: SlashRatio,
     /// Percentage of funds (bonded + unbonded) slashed when validator makes a byzantine fault
     pub byzantine_slash_percent: SlashRatio,
+    /// Percentage of funds (bonded + unbonded) slashed when it is detected (from NACK)
+    /// that a node submitted invalid MLS commit message (with update or remove)
+    pub invalid_commit_slash_percent: SlashRatio,
 }
 
 /// reward parameters

--- a/chain-core/src/init/params_compile.rs
+++ b/chain-core/src/init/params_compile.rs
@@ -1,0 +1,13 @@
+use ra_client::DEFAULT_EXPIRATION_SECS;
+
+/// Timeout (in seconds) for MLS handshake commit
+pub const MLS_COMMIT_TIMEOUT_SECS: u64 = 60;
+
+/// Timeout (in seconds) for MLS handshake message NACK
+pub const MLS_MESSAGE_NACK_TIMEOUT_SECS: u64 = MLS_COMMIT_TIMEOUT_SECS;
+
+/// Time (in seconds) after which, the keypackage for a node will be considered as expired
+pub const KEYPACKAGE_EXPIRATION_SECS: u64 = DEFAULT_EXPIRATION_SECS as u64;
+
+/// Time (in seconds) after which, the keypackage for a node is allowed to update, keypackage_update_secs < keypackage_expiration_secs
+pub const KEYPACKAGE_UPDATE_SECS: u64 = KEYPACKAGE_EXPIRATION_SECS / 3;

--- a/chain-core/tests/verify_config.rs
+++ b/chain-core/tests/verify_config.rs
@@ -63,6 +63,7 @@ fn test_verify_test_example_snapshot() {
     let mut params = InitNetworkParameters {
         initial_fee_policy: fee_policy,
         required_council_node_stake: Coin::new(5000_0000_0000_0000).unwrap(),
+        required_community_node_stake: Coin::unit(),
         jailing_config: JailingParameters {
             block_signing_window: 100,
             missed_block_threshold: 50,
@@ -70,6 +71,7 @@ fn test_verify_test_example_snapshot() {
         slashing_config: SlashingParameters {
             liveness_slash_percent: SlashRatio::from_str("0.1").unwrap(),
             byzantine_slash_percent: SlashRatio::from_str("0.2").unwrap(),
+            invalid_commit_slash_percent: SlashRatio::from_str("0.3").unwrap(),
         },
         rewards_config: RewardsParameters {
             monetary_expansion_cap: expansion_cap,

--- a/chain-tx-enclave-next/enclave-ra/ra-client/src/lib.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-client/src/lib.rs
@@ -28,3 +28,4 @@ pub use self::{
         ENCLAVE_CERT_VERIFIER,
     },
 };
+pub use ra_common::DEFAULT_EXPIRATION_SECS;

--- a/chain-tx-enclave-next/enclave-ra/ra-common/src/lib.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-common/src/lib.rs
@@ -10,3 +10,6 @@ pub use self::{
         EnclaveQuoteStatusParsingError, QuoteParsingError, OID_EXTENSION_ATTESTATION_REPORT,
     },
 };
+
+/// 90 days
+pub const DEFAULT_EXPIRATION_SECS: i64 = 7776000;

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/src/context.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/src/context.rs
@@ -18,9 +18,7 @@ use crate::{
     cmac::{Cmac, CmacError},
     config::EnclaveRaConfig,
 };
-
-/// 90 days
-pub const DEFAULT_EXPIRATION_SECS: i64 = 7776000;
+use ra_common::DEFAULT_EXPIRATION_SECS;
 
 /// Wraps all the in-enclave operations required for remote attestation
 pub struct EnclaveRaContext {

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/src/lib.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/src/lib.rs
@@ -30,4 +30,5 @@ mod context;
 
 pub use self::{certificate::Certificate, config::EnclaveRaConfig};
 #[cfg(target_env = "sgx")]
-pub use context::{EnclaveRaContext, EnclaveRaContextError, DEFAULT_EXPIRATION_SECS};
+pub use context::{EnclaveRaContext, EnclaveRaContextError};
+pub use ra_common::DEFAULT_EXPIRATION_SECS;

--- a/client-common/src/tendermint/mock.rs
+++ b/client-common/src/tendermint/mock.rs
@@ -56,6 +56,7 @@ const DEFAULT_GENESIS_JSON: &str = r#"{
                 "coefficient": 0
             },
             "required_council_node_stake": "1250000000000000000",
+            "required_community_node_stake": "100000000000",
             "unbonding_period": 86400,
             "jailing_config": {
                 "block_signing_window": 100,
@@ -63,7 +64,8 @@ const DEFAULT_GENESIS_JSON: &str = r#"{
             },
             "slashing_config": {
                 "liveness_slash_percent": "0.100",
-                "byzantine_slash_percent": "0.200"
+                "byzantine_slash_percent": "0.200",
+                "invalid_commit_slash_percent": "0.300"
             },
             "rewards_config": {
                 "monetary_expansion_cap": "6250000000000000000",

--- a/cro-clib/chain-core.h
+++ b/cro-clib/chain-core.h
@@ -31,6 +31,16 @@
 #define KECCAK256_BYTES 32
 
 /**
+ * Time (in seconds) after which, the keypackage for a node will be considered as expired
+ */
+#define KEYPACKAGE_EXPIRATION_SECS (uint64_t)DEFAULT_EXPIRATION_SECS
+
+/**
+ * Time (in seconds) after which, the keypackage for a node is allowed to update, keypackage_update_secs < keypackage_expiration_secs
+ */
+#define KEYPACKAGE_UPDATE_SECS (KEYPACKAGE_EXPIRATION_SECS / 3)
+
+/**
  * maximum total supply with a fixed decimal point
  * ref: https://etherscan.io/token/0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b
  * 100 billion + 8 decimals
@@ -46,6 +56,16 @@
  * 100 billion
  */
 #define MAX_COIN_UNITS 100000000000
+
+/**
+ * Timeout (in seconds) for MLS handshake commit
+ */
+#define MLS_COMMIT_TIMEOUT_SECS 60
+
+/**
+ * Timeout (in seconds) for MLS handshake message NACK
+ */
+#define MLS_MESSAGE_NACK_TIMEOUT_SECS MLS_COMMIT_TIMEOUT_SECS
 
 /**
  * ed25519 public key size

--- a/dev-utils/example-dev-conf.json
+++ b/dev-utils/example-dev-conf.json
@@ -5,13 +5,15 @@
     },
     "unbonding_period": 86400,
     "required_council_node_stake": "1250000000000000000",
+    "required_community_node_stake": "1000000000000",
     "jailing_config": {
         "block_signing_window": 100,
         "missed_block_threshold": 50
     },
     "slashing_config": {
         "liveness_slash_percent": "0.1",
-        "byzantine_slash_percent": "0.2"
+        "byzantine_slash_percent": "0.2",
+        "invalid_commit_slash_percent": "0.3"
     },
     "rewards_config": {
         "monetary_expansion_cap": "6250000000000000000",

--- a/dev-utils/src/commands/genesis_command.rs
+++ b/dev-utils/src/commands/genesis_command.rs
@@ -338,6 +338,7 @@ pub fn generate_genesis(
     let network_params = InitNetworkParameters {
         initial_fee_policy: fee_policy,
         required_council_node_stake: genesis_dev_config.required_council_node_stake,
+        required_community_node_stake: genesis_dev_config.required_community_node_stake,
         jailing_config: genesis_dev_config.jailing_config,
         slashing_config: genesis_dev_config.slashing_config,
         rewards_config: genesis_dev_config.rewards_config,

--- a/dev-utils/src/commands/genesis_dev_config.rs
+++ b/dev-utils/src/commands/genesis_dev_config.rs
@@ -14,6 +14,7 @@ use chain_core::state::tendermint::TendermintValidatorPubKey;
 pub struct GenesisDevConfig {
     pub distribution: BTreeMap<RedeemAddress, Coin>,
     pub required_council_node_stake: Coin,
+    pub required_community_node_stake: Coin,
     pub jailing_config: JailingParameters,
     pub slashing_config: SlashingParameters,
     pub rewards_config: RewardsParameters,
@@ -35,6 +36,7 @@ impl GenesisDevConfig {
         GenesisDevConfig {
             distribution: BTreeMap::new(),
             required_council_node_stake: Coin::new(1_250_000_000_000_000_000).unwrap(),
+            required_community_node_stake: Coin::new(100_000_000_000).unwrap(),
             jailing_config: JailingParameters {
                 block_signing_window: 100,
                 missed_block_threshold: 50,
@@ -42,6 +44,7 @@ impl GenesisDevConfig {
             slashing_config: SlashingParameters {
                 liveness_slash_percent: SlashRatio::from_str("0.1").unwrap(),
                 byzantine_slash_percent: SlashRatio::from_str("0.2").unwrap(),
+                invalid_commit_slash_percent: SlashRatio::from_str("0.3").unwrap(),
             },
             rewards_config: RewardsParameters {
                 monetary_expansion_cap: expansion_cap,

--- a/docker/config/devnet/dev-conf.json
+++ b/docker/config/devnet/dev-conf.json
@@ -7,13 +7,15 @@
     },
     "unbonding_period": 86400,
     "required_council_node_stake": "1",
+    "required_community_node_stake": "1",
     "jailing_config": {
         "block_signing_window": 100,
         "missed_block_threshold": 50
     },
     "slashing_config": {
         "liveness_slash_percent": "0.1",
-        "byzantine_slash_percent": "0.2"
+        "byzantine_slash_percent": "0.2",
+        "invalid_commit_slash_percent": "0.3"
     },
     "rewards_config": {
         "monetary_expansion_cap": "1000000000000000000",

--- a/docker/config/devnet/tendermint/genesis.json
+++ b/docker/config/devnet/tendermint/genesis.json
@@ -1,5 +1,5 @@
 {
-    "app_hash": "D3218ECBF9D1F90656C624246ECDFB30CE01386F5BD5C6AC423766FEFC0DEB62",
+    "app_hash": "CF34A4E4CF4C0060AE32EDF840C8FDEE3E95BFB893DE1CC9E0D3236B8AC02A1D",
     "app_state": {
         "council_nodes": {
             "0x45c1851c2f0dc6138935857b9e23b173185fea15": [
@@ -43,6 +43,7 @@
             },
             "max_validators": 50,
             "required_council_node_stake": "1",
+            "required_community_node_stake": "1",
             "rewards_config": {
                 "monetary_expansion_cap": "1000000000000000000",
                 "monetary_expansion_decay": 999860,
@@ -52,7 +53,8 @@
             },
             "slashing_config": {
                 "byzantine_slash_percent": "0.200",
-                "liveness_slash_percent": "0.100"
+                "liveness_slash_percent": "0.100",
+                "invalid_commit_slash_percent": "0.3"
             }
         }
     },

--- a/integration-tests/bot/chainbot.py
+++ b/integration-tests/bot/chainbot.py
@@ -197,6 +197,7 @@ async def app_state_cfg(cfg):
     return {
         "distribution": gen_distribution(cfg),
         "required_council_node_stake": "100000000",  # 10 coins
+        "required_community_node_stake": "10000000",  # 1 coin
         "jailing_config": {
             "block_signing_window": 20,
             "missed_block_threshold": 5
@@ -204,6 +205,7 @@ async def app_state_cfg(cfg):
         "slashing_config": {
             "liveness_slash_percent": "0.1",
             "byzantine_slash_percent": "0.2",
+            "invalid_commit_slash_percent": "0.3"
         },
         "rewards_config": {
             "monetary_expansion_cap": str(cfg['expansion_cap']),

--- a/test-common/src/block_generator.rs
+++ b/test-common/src/block_generator.rs
@@ -631,6 +631,7 @@ fn gen_network_params(
             coefficient: per_byte_fee,
         },
         required_council_node_stake: Coin::unit(),
+        required_community_node_stake: Coin::unit(),
         jailing_config: params::JailingParameters {
             block_signing_window: 100,
             missed_block_threshold: 50,
@@ -638,6 +639,7 @@ fn gen_network_params(
         slashing_config: params::SlashingParameters {
             liveness_slash_percent: params::SlashRatio::from_str("0.1").unwrap(),
             byzantine_slash_percent: params::SlashRatio::from_str("0.2").unwrap(),
+            invalid_commit_slash_percent: params::SlashRatio::from_str("0.3").unwrap(),
         },
         rewards_config: params::RewardsParameters {
             monetary_expansion_cap: expansion_cap,

--- a/test-common/src/chain_env.rs
+++ b/test-common/src/chain_env.rs
@@ -103,6 +103,7 @@ pub fn get_init_network_params(expansion_cap: Coin) -> InitNetworkParameters {
             Milli::try_new(0, 0).unwrap(),
         ),
         required_council_node_stake: Coin::unit(),
+        required_community_node_stake: Coin::unit(),
         jailing_config: JailingParameters {
             block_signing_window: 5,
             missed_block_threshold: 1,
@@ -110,6 +111,7 @@ pub fn get_init_network_params(expansion_cap: Coin) -> InitNetworkParameters {
         slashing_config: SlashingParameters {
             liveness_slash_percent: SlashRatio::from_str("0.1").unwrap(),
             byzantine_slash_percent: SlashRatio::from_str("0.2").unwrap(),
+            invalid_commit_slash_percent: SlashRatio::from_str("0.3").unwrap(),
         },
         rewards_config: RewardsParameters {
             monetary_expansion_cap: expansion_cap,


### PR DESCRIPTION
Solution:
- extended the genesis config with TDBE-related parameters that will only be used by chain-abci
- the other timing parameters I've put as compile-time parameters,
because future TDBE code will be based its logic on them (e.g. when it'll generate self-update)
+ for expiration, there is a lot of places, where it uses the default expiration,
so it'd need more work (it's to be revisited when these things are implemented
-- e.g. if it'll make sense to include them in the app hash,
as they are unlikely/hard to change, like e.g. evidence age)
- fixed tests
