### PR TITLE
Problem: indirect communication between tx-validation and tx-query (wip #2051)

### DIFF
--- a/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tx-query-next/enclave-app/src/sgx_module.rs
@@ -12,8 +12,10 @@ use parity_scale_codec::{Decode, Encode};
 use rustls::{NoClientAuth, ServerConfig, ServerSession, StreamOwned};
 use thread_pool::ThreadPool;
 
+use enclave_protocol::codec::{StreamRead, StreamWrite};
 use enclave_protocol::{
-    DecryptionRequest, TxQueryInitRequest, TxQueryInitResponse, ENCRYPTION_REQUEST_SIZE,
+    DecryptionRequest, IntraEnclaveRequest, IntraEnclaveResponseOk, IntraEncryptRequest,
+    TxQueryInitRequest, TxQueryInitResponse, ENCRYPTION_REQUEST_SIZE,
 };
 use ra_enclave::DEFAULT_EXPIRATION_SECS;
 use ra_enclave::{EnclaveRaConfig, EnclaveRaContext};
@@ -24,12 +26,39 @@ use self::handler::{
 };
 use chrono::Duration;
 
+#[warn(dead_code)]
+pub fn call_to_txquery(
+    stream_to_txvalidation: Arc<Mutex<TcpStream>>,
+    request: IntraEnclaveRequest,
+) -> std::io::Result<IntraEnclaveResponseOk> {
+    let mut this_stream = &*stream_to_txvalidation.lock().unwrap();
+    request.write_to(this_stream);
+    let response = IntraEnclaveResponseOk::read_from(this_stream);
+    response
+}
+
+#[warn(dead_code)]
+pub fn encrypt_to_txvalidation_stream(
+    stream_to_txvalidation: Arc<Mutex<TcpStream>>,
+    message: Box<IntraEncryptRequest>,
+) {
+    let message_to_txquery = IntraEnclaveRequest::Encrypt(message);
+    let response = call_to_txquery(stream_to_txvalidation.clone(), message_to_txquery);
+    if let Ok(IntraEnclaveResponseOk::Encrypt(s)) = response {
+        log::debug!("received encrypted from tx-validation enclave")
+    }
+}
 pub fn entry(cert_expiration: Option<Duration>) -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
 
     log::info!("Connecting to chain-abci data");
     let chain_data_stream = Arc::new(Mutex::new(TcpStream::connect("chain-abci-data")?));
+
+    let stream_to_txvalidation = Arc::new(Mutex::new(
+        TcpStream::connect("stream_to_txvalidation").unwrap(),
+    ));
+
     // FIXME: connect to tx-validation (mutually attested TLS)
     let num_threads = 4;
 

--- a/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
+++ b/chain-tx-enclave-next/tx-validation-next/src/sgx_module.rs
@@ -9,6 +9,7 @@ use chain_core::tx::TX_AUX_SIZE;
 use chain_tx_filter::BlockFilter;
 use chain_tx_validation::Error;
 use enclave_macro::get_network_id;
+use enclave_protocol::codec::{StreamRead, StreamWrite};
 use enclave_protocol::{IntraEnclaveRequest, IntraEnclaveResponse, IntraEnclaveResponseOk};
 use parity_scale_codec::{Decode, Encode};
 use std::io::{Read, Write};
@@ -16,7 +17,6 @@ use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
-
 /// FIXME: genesis app hash etc.?
 pub const NETWORK_HEX_ID: u8 = get_network_id!();
 
@@ -102,13 +102,37 @@ fn handling_loop<I: Read + Write>(
     }
 }
 
+// stream_to_txquery: actually it's UnixStream
+pub fn handling_txquery(stream_to_txquery: TcpStream) {
+    std::thread::spawn(move || {
+        let mut this_stream = stream_to_txquery;
+        loop {
+            let result = IntraEnclaveRequest::read_from(&this_stream);
+            if result.is_err() {
+                continue;
+            }
+            let request_form_txquery = result.expect("handling_txquery get unix-stream");
+            match request_form_txquery {
+                _ => {
+                    log::debug!("handling_txquery unsupported protocol");
+                    let reply = IntraEnclaveResponseOk::UnknownRequest;
+                    reply.write_to(&this_stream);
+                }
+            }
+        }
+    });
+}
 pub fn entry() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
-
     log::info!("Network ID: {:x}", NETWORK_HEX_ID);
-    log::info!("Connecting to chain-abci");
+
+    log::info!("Connecting to txquery enclave");
+    let stream_to_txquery = TcpStream::connect("stream_to_txquery")?;
+    handling_txquery(stream_to_txquery);
+
     // not really TCP -- stream provided by the runner
+    log::info!("Connecting to chain-abci");
     let chain_abci = TcpStream::connect("chain-abci")?;
     handling_loop(chain_abci, None);
     Ok(())

--- a/enclave-protocol/src/lib.rs
+++ b/enclave-protocol/src/lib.rs
@@ -137,13 +137,19 @@ pub enum IntraEnclaveResponseOk {
     /// if the the network id matched
     InitChainCheck,
     /// returns the actual paid fee + transaction data sealed for the local machine for later lookups
-    TxWithOutputs { paid_fee: Fee, sealed_tx: SealedLog },
+    TxWithOutputs {
+        paid_fee: Fee,
+        sealed_tx: SealedLog,
+    },
     /// deposit stake pays minimal fee, so this returns the sum of input amounts -- staked stake's bonded balance is added `input_coins-min_fee`
-    DepositStakeTx { input_coins: Coin },
+    DepositStakeTx {
+        input_coins: Coin,
+    },
     /// transaction filter
     EndBlock(Option<Box<TxFilter>>),
     /// encryption response
     Encrypt(TxObfuscated),
+    UnknownRequest,
 }
 
 /// variable length response returned from the tx-validation enclave


### PR DESCRIPTION
intermediate pr for #2051
- expose enclave 2 enclave communication
- tx-validation as server
- tx-query as client
- using unix-stream
- calls are using file socket, it's synchronous call
- concurrent calls in tx-query protected by   `Arc<Mutex<TcpStream>>`
