### PR TITLE
Problem: protoc installation fails on Travis with cached protoc (fixes #2233)

### DIFF
--- a/ci-scripts/install_protoc.sh
+++ b/ci-scripts/install_protoc.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-PROTOBUF_VERSION=3.3.0
-PROTOC_FILENAME=protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
-pushd /home/travis
-wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/${PROTOC_FILENAME}
-unzip ${PROTOC_FILENAME}
-bin/protoc --version
-popd
+pushd "${HOME}"
+if [ ! -f "bin/protoc" ]; then
+    PROTOBUF_VERSION=3.3.0
+    PROTOC_FILENAME=protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
+    wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/${PROTOC_FILENAME}
+    unzip ${PROTOC_FILENAME}
+    bin/protoc --version
+    popd
+fi


### PR DESCRIPTION
Solution: added a check in installation script to verify if protoc doesn't exist before installing it